### PR TITLE
fix(#12): strip markdown fences from alignment response before JSON parse

### DIFF
--- a/backend/src/services/__tests__/alignment-service.test.ts
+++ b/backend/src/services/__tests__/alignment-service.test.ts
@@ -94,6 +94,29 @@ describe('generateAlignmentSummary', () => {
     expect(result.raw).toBe(validSummaryJson);
   });
 
+  it('strips ```json fences when model wraps response in markdown', async () => {
+    const fenced = `\`\`\`json\n${validSummaryJson}\n\`\`\``;
+    mockCreate.mockResolvedValue({
+      content: [{ type: 'text', text: fenced }],
+    });
+
+    const result = await generateAlignmentSummary(brief);
+
+    expect(result.blogGoal).toBe('Help professionals sleep better.');
+    expect(result.raw).toBe(validSummaryJson);
+  });
+
+  it('strips plain ``` fences when model wraps response without language tag', async () => {
+    const fenced = `\`\`\`\n${validSummaryJson}\n\`\`\``;
+    mockCreate.mockResolvedValue({
+      content: [{ type: 'text', text: fenced }],
+    });
+
+    const result = await generateAlignmentSummary(brief);
+
+    expect(result.blogGoal).toBe('Help professionals sleep better.');
+  });
+
   it('passes feedback to the prompt when provided', async () => {
     mockCreate.mockResolvedValue({
       content: [{ type: 'text', text: validSummaryJson }],

--- a/backend/src/services/alignment-service.ts
+++ b/backend/src/services/alignment-service.ts
@@ -57,13 +57,16 @@ Respond with ONLY valid JSON matching this exact shape — no markdown fences, n
     messages: [{ role: 'user', content: prompt }],
   });
 
-  const text = message.content[0]?.type === 'text' ? message.content[0].text.trim() : '';
+  const raw = message.content[0]?.type === 'text' ? message.content[0].text.trim() : '';
+
+  /** Strip optional markdown code fences: ```json ... ``` or ``` ... ``` */
+  const text = raw.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim();
 
   let parsed: Omit<AlignmentSummary, 'raw'>;
   try {
     parsed = JSON.parse(text) as Omit<AlignmentSummary, 'raw'>;
   } catch {
-    console.error('[alignment-service] Claude returned non-JSON:', text);
+    console.error('[alignment-service] Claude returned non-JSON:', raw);
     throw new Error('AI returned an unexpected response format. Please try again.');
   }
 


### PR DESCRIPTION
## What

Closes #12

The alignment service prompt instructs the model to return raw JSON with no markdown fences. Smaller models (e.g. claude-haiku-4-5-20251001) sometimes wrap the response in backtick fences anyway. The raw JSON.parse() then throws and the user gets a 500 error even though the model produced a perfectly valid response.

## Root cause

The JSON itself was valid — only the backtick fences caused the parse to fail.

## Fix

Added a one-line fence-strip before JSON.parse(). The original raw response is still passed to the error logger so debugging context is preserved.

## Tests

Two new regression tests in alignment-service.test.ts:
- Response wrapped in backtick json fences parses correctly
- Response wrapped in plain backtick fences (no language tag) parses correctly

30/30 tests pass.

## Glossary

| Term | Meaning |
|------|---------|
| Markdown fences | Backtick delimiters models sometimes add around code blocks |
| raw | The untouched response string from the model, used for error logging |
| text | The fence-stripped string passed to JSON.parse() |

Made with [Cursor](https://cursor.com)