### PR TITLE
feat(#15): show reference URL understanding in alignment summary

### DIFF
--- a/backend/src/services/__tests__/alignment-service.test.ts
+++ b/backend/src/services/__tests__/alignment-service.test.ts
@@ -43,6 +43,15 @@ const validSummaryJson = JSON.stringify({
   scope: 'Covers 10 actionable tips. Excludes medical advice.',
 });
 
+const validSummaryWithReferenceJson = JSON.stringify({
+  blogGoal: 'Help professionals sleep better.',
+  targetAudience: 'Busy professionals 30–45 seeking wellness tips.',
+  seoIntent: 'Rank for "sleep hygiene" with practical advice.',
+  tone: 'Friendly and expert.',
+  scope: 'Covers 10 actionable tips. Excludes medical advice.',
+  referenceUnderstanding: 'The reference article covered evidence-based sleep routines and will inform the structure of the tips.',
+});
+
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -123,7 +132,7 @@ describe('generateAlignmentSummary', () => {
 
   it('includes scraped content in the prompt when available', async () => {
     mockCreate.mockResolvedValue({
-      content: [{ type: 'text', text: validSummaryJson }],
+      content: [{ type: 'text', text: validSummaryWithReferenceJson }],
     });
 
     const briefWithContent: BlogBrief = {
@@ -135,5 +144,50 @@ describe('generateAlignmentSummary', () => {
 
     const promptArg = mockCreate.mock.calls[0]?.[0] as { messages: { content: string }[] };
     expect(promptArg.messages[0]?.content).toContain('Reference content scraped');
+    expect(promptArg.messages[0]?.content).toContain('referenceUnderstanding');
+  });
+
+  it('returns referenceUnderstanding when scraped content is present', async () => {
+    mockCreate.mockResolvedValue({
+      content: [{ type: 'text', text: validSummaryWithReferenceJson }],
+    });
+
+    const briefWithContent: BlogBrief = {
+      ...brief,
+      scrapedContent: 'Reference article about sleep hygiene…',
+    };
+
+    const result = await generateAlignmentSummary(briefWithContent);
+
+    expect(result.referenceUnderstanding).toBe(
+      'The reference article covered evidence-based sleep routines and will inform the structure of the tips.',
+    );
+  });
+
+  it('does not include referenceUnderstanding when no scraped content', async () => {
+    mockCreate.mockResolvedValue({
+      content: [{ type: 'text', text: validSummaryJson }],
+    });
+
+    const result = await generateAlignmentSummary(brief);
+
+    expect(result.referenceUnderstanding).toBeUndefined();
+    const promptArg = mockCreate.mock.calls[0]?.[0] as { messages: { content: string }[] };
+    expect(promptArg.messages[0]?.content).not.toContain('referenceUnderstanding');
+  });
+
+  it('throws when referenceUnderstanding is missing despite scraped content', async () => {
+    mockCreate.mockResolvedValue({
+      content: [{ type: 'text', text: validSummaryJson }],
+    });
+
+    const briefWithContent: BlogBrief = {
+      ...brief,
+      scrapedContent: 'Reference article about sleep hygiene…',
+    };
+
+    await expect(generateAlignmentSummary(briefWithContent)).rejects.toThrow(
+      'AI returned an unexpected response format. Please try again.',
+    );
   });
 });

--- a/backend/src/services/alignment-service.ts
+++ b/backend/src/services/alignment-service.ts
@@ -17,6 +17,8 @@ export interface AlignmentSummary {
   seoIntent: string;
   tone: string;
   scope: string;
+  /** Present only when the brief had a scraped reference URL. Describes what the AI understood from the reference content. */
+  referenceUnderstanding?: string;
   raw: string;
 }
 
@@ -24,8 +26,9 @@ export async function generateAlignmentSummary(
   brief: BlogBrief,
   feedback?: string,
 ): Promise<AlignmentSummary> {
-  const scrapedNote = brief.scrapedContent
-    ? `\nReference content scraped (${brief.scrapedContent.length} chars): ${brief.scrapedContent.slice(0, 800)}…`
+  const hasReference = !!brief.scrapedContent;
+  const scrapedNote = hasReference
+    ? `\nReference content scraped (${brief.scrapedContent!.length} chars): ${brief.scrapedContent!.slice(0, 800)}…`
     : '';
 
   const feedbackNote = feedback
@@ -42,13 +45,17 @@ export async function generateAlignmentSummary(
 - Word count: ${brief.wordCountMin}–${brief.wordCountMax} words
 - Brief: ${brief.blogBrief}${scrapedNote}${feedbackNote}
 
-Respond with ONLY valid JSON matching this exact shape — no markdown fences, no extra keys:
+Respond with ONLY valid JSON — no markdown fences, no extra keys.${hasReference ? `
+The response MUST include a sixth field "referenceUnderstanding" because a reference URL was provided.` : ''}
+
+Required JSON shape:
 {
   "blogGoal": "one sentence describing the core goal of this post",
   "targetAudience": "one sentence describing who will read this and why",
   "seoIntent": "one sentence on the SEO angle and keyword strategy",
   "tone": "one sentence describing the writing style and voice",
-  "scope": "two to three sentences covering what will and will not be covered"
+  "scope": "two to three sentences covering what will and will not be covered"${hasReference ? `,
+  "referenceUnderstanding": "two to three sentences describing what key ideas, structure, and angle were taken from the reference content, and how they will inform this post"` : ''}
 }`;
 
   const message = await client.messages.create({
@@ -73,6 +80,11 @@ Respond with ONLY valid JSON matching this exact shape — no markdown fences, n
       console.error('[alignment-service] Missing or invalid field in response:', field, text);
       throw new Error('AI returned an unexpected response format. Please try again.');
     }
+  }
+
+  if (hasReference && (!parsed['referenceUnderstanding'] || typeof parsed['referenceUnderstanding'] !== 'string')) {
+    console.error('[alignment-service] Missing referenceUnderstanding field despite scraped content:', text);
+    throw new Error('AI returned an unexpected response format. Please try again.');
   }
 
   return { ...parsed, raw: text };

--- a/docs/agdr/AgDR-0007-reference-understanding-alignment-field.md
+++ b/docs/agdr/AgDR-0007-reference-understanding-alignment-field.md
@@ -1,0 +1,39 @@
+# AgDR-0007 — Reference Understanding Field in Alignment Summary
+
+> In the context of showing users what the AI understood from their reference URL, facing the choice of where to surface that understanding and how to extend the existing alignment JSON contract, I decided to add an optional `referenceUnderstanding` field to the `AlignmentSummary` type and prompt — present only when scraped content exists — accepting the trade-off of a variable-shape response over a fixed-shape one.
+
+## Context
+
+EP-03 / US-13 requires the alignment summary to surface the AI's interpretation of the scraped reference URL so users can verify alignment before content generation. The alignment summary already stores a 5-field JSON blob in `blog_briefs.alignment_summary`. The `BlogBrief` domain object carries `scrapedContent` and `scrapeStatus` — the data is available at generation time.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Add optional `referenceUnderstanding` to AlignmentSummary (chosen)** | Single source of truth; persisted with alignment; no new DB column; backward compatible | Response shape varies (6 fields with reference, 5 without); requires conditional rendering |
+| Separate API field returned alongside `summary` | Clean separation | Not persisted in alignment blob; lost on re-read; requires new DB column or response-only field |
+| Always include field, empty string when no reference | Uniform shape | Misleading empty card shown to users without a reference; prompt must handle gracefully |
+| New `blog_reference_insights` table | Clean normalisation | New migration, new repository, over-engineered for a single text field |
+
+## Decision
+
+- **`referenceUnderstanding?: string`** added to `AlignmentSummary` as an optional field
+- Present in the prompt only when `brief.scrapedContent` is non-null — the prompt instructs the model to produce a sixth JSON field `"referenceUnderstanding"` describing what it understood from the scraped material
+- Absent entirely when no scraped content — the existing 5-field contract is preserved for those briefs
+- The frontend renders a "Reference Understanding" card conditionally on the field's presence
+- No DB migration required — `alignment_summary` TEXT column stores the richer JSON transparently
+
+## Consequences
+
+- `AlignmentSummary` type gains `referenceUnderstanding?: string`
+- Prompt extended with a conditional sixth field instruction when scrapedContent is present
+- Frontend `AlignmentSummary` component adds one conditional card
+- All existing tests for the 5-field case continue to pass unchanged
+- Future steps (outline, draft) can read `referenceUnderstanding` from the stored JSON
+
+## Artifacts
+
+- Epic: https://github.com/mohamednaseramein/blog-generator/issues/14
+- `backend/src/services/alignment-service.ts`
+- `frontend/src/api/blog-api.ts`
+- `frontend/src/components/AlignmentSummary.tsx`

--- a/frontend/src/api/blog-api.ts
+++ b/frontend/src/api/blog-api.ts
@@ -68,6 +68,8 @@ export interface AlignmentSummary {
   seoIntent: string;
   tone: string;
   scope: string;
+  /** Present only when the brief had a scraped reference URL. */
+  referenceUnderstanding?: string;
 }
 
 export interface AlignmentResponse {

--- a/frontend/src/components/AlignmentSummary.tsx
+++ b/frontend/src/components/AlignmentSummary.tsx
@@ -11,12 +11,13 @@ interface Props {
   onConfirmed: () => void;
 }
 
-const SECTIONS: { key: keyof AlignmentSummaryType; label: string; icon: string }[] = [
+const SECTIONS: { key: keyof AlignmentSummaryType; label: string; icon: string; optional?: boolean }[] = [
   { key: 'blogGoal', label: 'Blog Goal', icon: '🎯' },
   { key: 'targetAudience', label: 'Target Audience', icon: '👥' },
   { key: 'seoIntent', label: 'SEO Intent', icon: '🔍' },
   { key: 'tone', label: 'Tone & Voice', icon: '✍️' },
   { key: 'scope', label: 'Scope', icon: '📋' },
+  { key: 'referenceUnderstanding', label: 'Reference Understanding', icon: '🔗', optional: true },
 ];
 
 export function AlignmentSummary({ blogId, onEdit, onConfirmed }: Props) {
@@ -77,14 +78,21 @@ export function AlignmentSummary({ blogId, onEdit, onConfirmed }: Props) {
       {/* Summary cards */}
       {summary && !generating && (
         <div className="flex flex-col gap-3">
-          {SECTIONS.map(({ key, label, icon }) => (
-            <div key={key} className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3">
-              <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-slate-400">
-                {icon} {label}
-              </p>
-              <p className="text-sm text-slate-700">{summary[key]}</p>
-            </div>
-          ))}
+          {SECTIONS.map(({ key, label, icon, optional }) => {
+            const value = summary[key];
+            if (optional && !value) return null;
+            return (
+              <div
+                key={key}
+                className={`rounded-xl border px-4 py-3 ${key === 'referenceUnderstanding' ? 'border-indigo-200 bg-indigo-50' : 'border-slate-200 bg-slate-50'}`}
+              >
+                <p className={`mb-1 text-xs font-semibold uppercase tracking-wide ${key === 'referenceUnderstanding' ? 'text-indigo-400' : 'text-slate-400'}`}>
+                  {icon} {label}
+                </p>
+                <p className="text-sm text-slate-700">{value}</p>
+              </div>
+            );
+          })}
 
           {iterations > 0 && (
             <p className="text-right text-xs text-slate-400">
@@ -93,6 +101,7 @@ export function AlignmentSummary({ blogId, onEdit, onConfirmed }: Props) {
           )}
         </div>
       )}
+
 
       {error && <Toast variant="error">{error}</Toast>}
 


### PR DESCRIPTION
## What

Closes #15 — part of epic #14 (EP-03).

When a user provides a reference URL and it is successfully scraped, the alignment summary now includes a **Reference Understanding** card showing what the AI understood from that reference. This lets the user verify the AI correctly interpreted their source material before committing to content generation.

## Why

Users had no visibility into how the AI used their reference URL. A misinterpreted reference would silently propagate through all downstream generation steps. Surfacing it at alignment lets users catch and correct it immediately via the feedback loop.

## Changes

### Backend — `alignment-service.ts`
- `AlignmentSummary` type gains optional `referenceUnderstanding?: string`
- Prompt conditionally requests the sixth field only when `brief.scrapedContent` is present
- Validation enforces the field when scraped content exists; throws if missing
- `hasReference` flag computed once and reused in both prompt and validation

### Frontend — `blog-api.ts`
- `AlignmentSummary` interface gains optional `referenceUnderstanding?: string`

### Frontend — `AlignmentSummary.tsx`
- `SECTIONS` array gains the `referenceUnderstanding` entry with `optional: true`
- Rendering skips `null` for optional absent fields
- Reference Understanding card uses an indigo colour scheme to visually distinguish it from the other five summary cards

### Docs — `AgDR-0007-reference-understanding-alignment-field.md`
- Documents the decision, options considered, and consequences

## Tests

4 new tests in `alignment-service.test.ts`:
- `referenceUnderstanding` returned when scraped content is present
- `referenceUnderstanding` absent (and prompt excludes field instruction) when no scraped content
- Prompt includes `referenceUnderstanding` instruction when scraped content present
- Throws when field is missing despite scraped content being available

**31/31 backend tests pass. Frontend TypeScript clean.**

## How to test manually

1. Submit a brief **with** a reference URL — wait for scrape to complete — generate alignment → confirm a "Reference Understanding" card appears in indigo
2. Submit a brief **without** a reference URL → confirm no "Reference Understanding" card
3. Use the feedback box and regenerate → card updates with new understanding

## Glossary

| Term | Meaning |
|------|---------|
| `referenceUnderstanding` | Optional sixth alignment field: AI's interpretation of the scraped reference URL content |
| `hasReference` | Local boolean: `brief.scrapedContent` is non-null |
| `optional: true` | Marker on SECTIONS entry to skip rendering when field is absent |

Made with [Cursor](https://cursor.com)