### PR TITLE
feat(GH-18): add AI blog outline generation (Step 3)

### DIFF
--- a/backend/src/db/migrations/migrate-002-blog-outlines.sql
+++ b/backend/src/db/migrations/migrate-002-blog-outlines.sql
@@ -1,0 +1,16 @@
+-- Migration 002: Create blog_outlines table for Step 3 outline persistence
+-- Ticket:  https://github.com/mohamednaseramein/blog-generator/issues/19
+-- AgDR:    docs/agdr/AgDR-0008-migration-blog-outlines-table.md
+-- Rollback: DROP TABLE IF EXISTS blog_outlines;
+
+CREATE TABLE IF NOT EXISTS blog_outlines (
+  id                  UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  blog_id             UUID         NOT NULL UNIQUE REFERENCES blogs(id) ON DELETE CASCADE,
+  outline_json        TEXT         NOT NULL,
+  outline_confirmed   BOOLEAN      NOT NULL DEFAULT FALSE,
+  outline_iterations  SMALLINT     NOT NULL DEFAULT 0,
+  created_at          TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  updated_at          TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_blog_outlines_blog_id ON blog_outlines(blog_id);

--- a/backend/src/domain/types.ts
+++ b/backend/src/domain/types.ts
@@ -30,6 +30,23 @@ export interface BlogBrief {
   updatedAt: Date;
 }
 
+export interface BlogOutlineSection {
+  title: string;
+  description: string;
+  subsections: string[];
+  estimatedWords: number;
+}
+
+export interface BlogOutline {
+  id: string;
+  blogId: string;
+  outlineJson: string;
+  outlineConfirmed: boolean;
+  outlineIterations: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
 export interface SubmitBriefInput {
   title: string;
   primaryKeyword: string;

--- a/backend/src/handlers/__tests__/blog-outline-handler.test.ts
+++ b/backend/src/handlers/__tests__/blog-outline-handler.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const {
+  mockGetBlogByIdAndUser,
+  mockGetBriefByBlogId,
+  mockGetOutlineByBlogId,
+  mockUpsertOutline,
+  mockConfirmOutline,
+  mockGenerateBlogOutline,
+  mockGetUserId,
+} = vi.hoisted(() => ({
+  mockGetBlogByIdAndUser: vi.fn(),
+  mockGetBriefByBlogId: vi.fn(),
+  mockGetOutlineByBlogId: vi.fn(),
+  mockUpsertOutline: vi.fn(),
+  mockConfirmOutline: vi.fn(),
+  mockGenerateBlogOutline: vi.fn(),
+  mockGetUserId: vi.fn(() => 'user-1'),
+}));
+
+vi.mock('../../repositories/blog-repository.js', () => ({
+  getBlogByIdAndUser: mockGetBlogByIdAndUser,
+}));
+
+vi.mock('../../repositories/blog-brief-repository.js', () => ({
+  getBriefByBlogId: mockGetBriefByBlogId,
+}));
+
+vi.mock('../../repositories/blog-outline-repository.js', () => ({
+  getOutlineByBlogId: mockGetOutlineByBlogId,
+  upsertOutline: mockUpsertOutline,
+  confirmOutline: mockConfirmOutline,
+}));
+
+vi.mock('../../services/outline-service.js', () => ({
+  generateBlogOutline: mockGenerateBlogOutline,
+}));
+
+vi.mock('../../middleware/auth.js', () => ({
+  getUserId: mockGetUserId,
+}));
+
+import { handleGenerateOutline, handleConfirmOutline } from '../blog-outline-handler.js';
+import type { Request, Response, NextFunction } from 'express';
+
+const blog = { id: 'blog-1', userId: 'user-1' };
+
+const brief = {
+  id: 'brief-1',
+  blogId: 'blog-1',
+  title: '10 Tips for Better Sleep',
+  primaryKeyword: 'sleep hygiene',
+  audiencePersona: 'Busy professionals',
+  toneOfVoice: 'Friendly',
+  wordCountMin: 800,
+  wordCountMax: 1500,
+  blogBrief: 'Practical tips.',
+  referenceUrl: null,
+  scrapedContent: null,
+  scrapeStatus: 'skipped',
+  alignmentConfirmed: true,
+  alignmentSummary: JSON.stringify({
+    blogGoal: 'Help people sleep.',
+    targetAudience: 'Professionals',
+    seoIntent: 'Rank for sleep hygiene.',
+    tone: 'Friendly.',
+    scope: 'Actionable tips only.',
+  }),
+  alignmentIterations: 1,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const fakeOutline = {
+  sections: [
+    { title: 'S1', description: 'D1', subsections: ['A', 'B'], estimatedWords: 200 },
+    { title: 'S2', description: 'D2', subsections: ['A', 'B'], estimatedWords: 200 },
+    { title: 'S3', description: 'D3', subsections: ['A', 'B'], estimatedWords: 200 },
+    { title: 'S4', description: 'D4', subsections: ['A', 'B'], estimatedWords: 200 },
+  ],
+  totalEstimatedWords: 800,
+  raw: '{}',
+};
+
+function makeReqRes(blogId: string, body: Record<string, unknown> = {}) {
+  const req = { params: { id: blogId }, body } as unknown as Request;
+  const json = vi.fn();
+  const res = { json, status: vi.fn().mockReturnThis() } as unknown as Response;
+  const next = vi.fn() as unknown as NextFunction;
+  return { req, res, json, next };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetUserId.mockReturnValue('user-1');
+});
+
+describe('handleGenerateOutline', () => {
+  it('returns outline when all preconditions are met', async () => {
+    mockGetBlogByIdAndUser.mockResolvedValue(blog);
+    mockGetBriefByBlogId.mockResolvedValue(brief);
+    mockGetOutlineByBlogId.mockResolvedValue(null);
+    mockGenerateBlogOutline.mockResolvedValue(fakeOutline);
+    mockUpsertOutline.mockResolvedValue({});
+
+    const { req, res, json, next } = makeReqRes('blog-1');
+    await handleGenerateOutline(req, res, next);
+
+    expect(json).toHaveBeenCalledWith({ outline: fakeOutline });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('calls next with 404 when blog not found', async () => {
+    mockGetBlogByIdAndUser.mockResolvedValue(null);
+
+    const { req, res, next } = makeReqRes('blog-1');
+    await handleGenerateOutline(req, res, next);
+
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 404 }));
+  });
+
+  it('calls next with 404 when brief not found', async () => {
+    mockGetBlogByIdAndUser.mockResolvedValue(blog);
+    mockGetBriefByBlogId.mockResolvedValue(null);
+
+    const { req, res, next } = makeReqRes('blog-1');
+    await handleGenerateOutline(req, res, next);
+
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 404 }));
+  });
+
+  it('calls next with 400 when alignment not confirmed', async () => {
+    mockGetBlogByIdAndUser.mockResolvedValue(blog);
+    mockGetBriefByBlogId.mockResolvedValue({ ...brief, alignmentConfirmed: false });
+
+    const { req, res, next } = makeReqRes('blog-1');
+    await handleGenerateOutline(req, res, next);
+
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 400 }));
+  });
+
+  it('passes feedback to generateBlogOutline when provided', async () => {
+    mockGetBlogByIdAndUser.mockResolvedValue(blog);
+    mockGetBriefByBlogId.mockResolvedValue(brief);
+    mockGetOutlineByBlogId.mockResolvedValue(null);
+    mockGenerateBlogOutline.mockResolvedValue(fakeOutline);
+    mockUpsertOutline.mockResolvedValue({});
+
+    const { req, res, next } = makeReqRes('blog-1', { feedback: 'Add pricing section' });
+    await handleGenerateOutline(req, res, next);
+
+    expect(mockGenerateBlogOutline).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      'Add pricing section',
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleConfirmOutline', () => {
+  it('confirms outline and returns confirmed=true', async () => {
+    mockGetBlogByIdAndUser.mockResolvedValue(blog);
+    mockGetOutlineByBlogId.mockResolvedValue({ id: 'outline-1', blogId: 'blog-1' });
+    mockConfirmOutline.mockResolvedValue(undefined);
+
+    const { req, res, json, next } = makeReqRes('blog-1');
+    await handleConfirmOutline(req, res, next);
+
+    expect(json).toHaveBeenCalledWith({ confirmed: true, blogId: 'blog-1' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('calls next with 400 when no outline exists yet', async () => {
+    mockGetBlogByIdAndUser.mockResolvedValue(blog);
+    mockGetOutlineByBlogId.mockResolvedValue(null);
+
+    const { req, res, next } = makeReqRes('blog-1');
+    await handleConfirmOutline(req, res, next);
+
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 400 }));
+  });
+
+  it('calls next with 404 when blog not found', async () => {
+    mockGetBlogByIdAndUser.mockResolvedValue(null);
+
+    const { req, res, next } = makeReqRes('blog-1');
+    await handleConfirmOutline(req, res, next);
+
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 404 }));
+  });
+});

--- a/backend/src/handlers/blog-outline-handler.ts
+++ b/backend/src/handlers/blog-outline-handler.ts
@@ -1,0 +1,95 @@
+import type { Request, Response, NextFunction } from 'express';
+import { getBlogByIdAndUser } from '../repositories/blog-repository.js';
+import { getBriefByBlogId } from '../repositories/blog-brief-repository.js';
+import {
+  getOutlineByBlogId,
+  upsertOutline,
+  confirmOutline,
+} from '../repositories/blog-outline-repository.js';
+import { generateBlogOutline } from '../services/outline-service.js';
+import type { AlignmentSummary } from '../services/alignment-service.js';
+import { AppError } from '../middleware/error-handler.js';
+import { getUserId } from '../middleware/auth.js';
+
+export async function handleGenerateOutline(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const userId = getUserId(req);
+    const blogId = req.params['id'] as string;
+    const feedback = (req.body as Record<string, unknown>)['feedback'];
+    const feedbackText = typeof feedback === 'string' && feedback.trim() ? feedback.trim() : undefined;
+
+    const blog = await getBlogByIdAndUser(blogId, userId);
+    if (!blog) throw new AppError(404, 'NOT_FOUND', 'Blog not found');
+
+    const brief = await getBriefByBlogId(blogId);
+    if (!brief) throw new AppError(404, 'NOT_FOUND', 'Brief not found — submit the brief first');
+    if (!brief.alignmentConfirmed || !brief.alignmentSummary) {
+      throw new AppError(400, 'BAD_REQUEST', 'Confirm alignment before generating an outline');
+    }
+
+    let alignment: AlignmentSummary;
+    try {
+      alignment = JSON.parse(brief.alignmentSummary) as AlignmentSummary;
+    } catch {
+      throw new AppError(500, 'INTERNAL', 'Stored alignment summary is malformed');
+    }
+
+    const existingOutline = await getOutlineByBlogId(blogId);
+    const currentIterations = existingOutline?.outlineIterations ?? 0;
+
+    const outline = await generateBlogOutline(brief, alignment, feedbackText);
+    await upsertOutline(blogId, outline.raw, currentIterations);
+
+    res.json({ outline });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function handleConfirmOutline(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const userId = getUserId(req);
+    const blogId = req.params['id'] as string;
+
+    const blog = await getBlogByIdAndUser(blogId, userId);
+    if (!blog) throw new AppError(404, 'NOT_FOUND', 'Blog not found');
+
+    const outline = await getOutlineByBlogId(blogId);
+    if (!outline) throw new AppError(400, 'BAD_REQUEST', 'Generate an outline first');
+
+    await confirmOutline(blogId);
+
+    res.json({ confirmed: true, blogId });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function handleGetOutline(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const userId = getUserId(req);
+    const blogId = req.params['id'] as string;
+
+    const blog = await getBlogByIdAndUser(blogId, userId);
+    if (!blog) throw new AppError(404, 'NOT_FOUND', 'Blog not found');
+
+    const outline = await getOutlineByBlogId(blogId);
+    if (!outline) throw new AppError(404, 'NOT_FOUND', 'Outline not found');
+
+    res.json({ outline });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/backend/src/repositories/blog-outline-repository.ts
+++ b/backend/src/repositories/blog-outline-repository.ts
@@ -1,0 +1,70 @@
+import { getSupabase } from '../db/supabase.js';
+import type { BlogOutline } from '../domain/types.js';
+
+interface BlogOutlineRow {
+  id: string;
+  blog_id: string;
+  outline_json: string;
+  outline_confirmed: boolean;
+  outline_iterations: number;
+  created_at: string;
+  updated_at: string;
+}
+
+function toModel(row: BlogOutlineRow): BlogOutline {
+  return {
+    id: row.id,
+    blogId: row.blog_id,
+    outlineJson: row.outline_json,
+    outlineConfirmed: row.outline_confirmed,
+    outlineIterations: row.outline_iterations,
+    createdAt: new Date(row.created_at),
+    updatedAt: new Date(row.updated_at),
+  };
+}
+
+export async function getOutlineByBlogId(blogId: string): Promise<BlogOutline | null> {
+  const { data, error } = await getSupabase()
+    .from('blog_outlines')
+    .select()
+    .eq('blog_id', blogId)
+    .single<BlogOutlineRow>();
+
+  if (error?.code === 'PGRST116') return null;
+  if (error) throw new Error(error.message);
+  return toModel(data);
+}
+
+export async function upsertOutline(
+  blogId: string,
+  outlineJson: string,
+  currentIterations: number,
+): Promise<BlogOutline> {
+  const { data, error } = await getSupabase()
+    .from('blog_outlines')
+    .upsert(
+      {
+        blog_id: blogId,
+        outline_json: outlineJson,
+        outline_iterations: currentIterations + 1,
+        outline_confirmed: false,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'blog_id' },
+    )
+    .select()
+    .single<BlogOutlineRow>();
+
+  if (error) throw new Error(error.message);
+  console.log(`[outline-repository] saved outline for blogId=${blogId}`);
+  return toModel(data);
+}
+
+export async function confirmOutline(blogId: string): Promise<void> {
+  const { error } = await getSupabase()
+    .from('blog_outlines')
+    .update({ outline_confirmed: true, updated_at: new Date().toISOString() })
+    .eq('blog_id', blogId);
+
+  if (error) throw new Error(error.message);
+}

--- a/backend/src/routes/blog-routes.ts
+++ b/backend/src/routes/blog-routes.ts
@@ -10,6 +10,11 @@ import {
   handleGenerateAlignment,
   handleConfirmAlignment,
 } from '../handlers/blog-alignment-handler.js';
+import {
+  handleGenerateOutline,
+  handleConfirmOutline,
+  handleGetOutline,
+} from '../handlers/blog-outline-handler.js';
 
 const router = Router();
 
@@ -19,5 +24,8 @@ router.get('/:id/brief', requireAuth, handleGetBrief);
 router.get('/:id/brief/scrape-status', requireAuth, handleGetScrapeStatus);
 router.post('/:id/alignment', requireAuth, handleGenerateAlignment);
 router.post('/:id/alignment/confirm', requireAuth, handleConfirmAlignment);
+router.post('/:id/outline', requireAuth, handleGenerateOutline);
+router.post('/:id/outline/confirm', requireAuth, handleConfirmOutline);
+router.get('/:id/outline', requireAuth, handleGetOutline);
 
 export default router;

--- a/backend/src/services/__tests__/outline-service.test.ts
+++ b/backend/src/services/__tests__/outline-service.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockCreate } = vi.hoisted(() => ({ mockCreate: vi.fn() }));
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: vi.fn().mockImplementation(() => ({
+    messages: { create: mockCreate },
+  })),
+}));
+
+import { generateBlogOutline } from '../outline-service.js';
+import type { BlogBrief } from '../../domain/types.js';
+import type { AlignmentSummary } from '../alignment-service.js';
+
+const brief: BlogBrief = {
+  id: 'brief-1',
+  blogId: 'blog-1',
+  title: '10 Tips for Better Sleep',
+  primaryKeyword: 'sleep hygiene',
+  audiencePersona: 'Busy professionals aged 30–45',
+  toneOfVoice: 'Friendly, expert',
+  wordCountMin: 800,
+  wordCountMax: 1500,
+  blogBrief: 'Practical science-backed tips for improving sleep quality.',
+  referenceUrl: null,
+  scrapedContent: null,
+  scrapeStatus: 'skipped',
+  alignmentSummary: null,
+  alignmentConfirmed: true,
+  alignmentIterations: 1,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const alignment: AlignmentSummary = {
+  blogGoal: 'Help professionals sleep better.',
+  targetAudience: 'Busy professionals 30–45 seeking wellness tips.',
+  seoIntent: 'Rank for "sleep hygiene" with practical advice.',
+  tone: 'Friendly and expert.',
+  scope: 'Covers 10 actionable tips. Excludes medical advice.',
+  raw: '{}',
+};
+
+function validOutlineJson(sections = 5): string {
+  return JSON.stringify({
+    sections: Array.from({ length: sections }, (_, i) => ({
+      title: `Section ${i + 1}`,
+      description: `Description for section ${i + 1}.`,
+      subsections: ['Sub A', 'Sub B'],
+      estimatedWords: 200,
+    })),
+    totalEstimatedWords: sections * 200,
+  });
+}
+
+function mockResponse(text: string) {
+  mockCreate.mockResolvedValue({
+    content: [{ type: 'text', text }],
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  delete process.env['ANTHROPIC_MODEL'];
+});
+
+describe('generateBlogOutline', () => {
+  it('returns parsed outline when Claude responds with valid JSON', async () => {
+    mockResponse(validOutlineJson(5));
+
+    const result = await generateBlogOutline(brief, alignment);
+
+    expect(result.sections).toHaveLength(5);
+    expect(result.totalEstimatedWords).toBe(1000);
+    expect(typeof result.raw).toBe('string');
+  });
+
+  it('strips markdown fences before parsing', async () => {
+    mockResponse('```json\n' + validOutlineJson(4) + '\n```');
+
+    const result = await generateBlogOutline(brief, alignment);
+
+    expect(result.sections).toHaveLength(4);
+  });
+
+  it('throws when Claude returns non-JSON', async () => {
+    mockResponse('Sorry, I cannot help with that.');
+
+    await expect(generateBlogOutline(brief, alignment)).rejects.toThrow(
+      'AI returned an unexpected response format',
+    );
+  });
+
+  it('throws when outline has fewer than 4 sections', async () => {
+    mockResponse(validOutlineJson(3));
+
+    await expect(generateBlogOutline(brief, alignment)).rejects.toThrow(
+      'AI returned an unexpected response format',
+    );
+  });
+
+  it('throws when a section is missing a required field', async () => {
+    const outline = {
+      sections: [
+        { title: 'S1', description: 'D1', subsections: ['A'], estimatedWords: 200 },
+        { title: 'S2', description: 'D2', subsections: ['A'], estimatedWords: 200 },
+        { title: 'S3', description: 'D3', subsections: ['A'], estimatedWords: 200 },
+        { title: 'S4', subsections: ['A'], estimatedWords: 200 }, // missing description
+      ],
+      totalEstimatedWords: 800,
+    };
+    mockResponse(JSON.stringify(outline));
+
+    await expect(generateBlogOutline(brief, alignment)).rejects.toThrow(
+      'AI returned an unexpected response format',
+    );
+  });
+
+  it('includes feedback in the prompt when provided', async () => {
+    mockResponse(validOutlineJson(4));
+
+    await generateBlogOutline(brief, alignment, 'Add a pricing section');
+
+    const promptSent = (mockCreate.mock.calls[0] as [{ messages: Array<{ content: string }> }])[0]
+      .messages[0].content;
+    expect(promptSent).toContain('Add a pricing section');
+  });
+
+  it('includes referenceUnderstanding when present in alignment', async () => {
+    mockResponse(validOutlineJson(4));
+    const alignmentWithRef: AlignmentSummary = {
+      ...alignment,
+      referenceUnderstanding: 'The reference covers modern sleep research.',
+    };
+
+    await generateBlogOutline(brief, alignmentWithRef);
+
+    const promptSent = (mockCreate.mock.calls[0] as [{ messages: Array<{ content: string }> }])[0]
+      .messages[0].content;
+    expect(promptSent).toContain('modern sleep research');
+  });
+});

--- a/backend/src/services/outline-service.ts
+++ b/backend/src/services/outline-service.ts
@@ -1,0 +1,112 @@
+import Anthropic from '@anthropic-ai/sdk';
+import type { BlogBrief } from '../domain/types.js';
+import type { AlignmentSummary } from './alignment-service.js';
+
+const client = new Anthropic({ apiKey: process.env['ANTHROPIC_API_KEY'] });
+
+/** Reuse the same model resolver so a single env-var controls all AI calls. */
+function resolveModel(): string {
+  return process.env['ANTHROPIC_MODEL']?.trim() || 'claude-sonnet-4-6';
+}
+
+export interface OutlineSection {
+  title: string;
+  description: string;
+  subsections: string[];
+  estimatedWords: number;
+}
+
+export interface BlogOutline {
+  sections: OutlineSection[];
+  totalEstimatedWords: number;
+  raw: string;
+}
+
+export async function generateBlogOutline(
+  brief: BlogBrief,
+  alignment: AlignmentSummary,
+  feedback?: string,
+): Promise<BlogOutline> {
+  const wordTarget = Math.round((brief.wordCountMin + brief.wordCountMax) / 2);
+
+  const feedbackNote = feedback
+    ? `\n\nThe user has provided the following feedback on the previous outline. Incorporate it fully:\n"${feedback}"`
+    : '';
+
+  const referenceNote = alignment.referenceUnderstanding
+    ? `\n- Reference understanding: ${alignment.referenceUnderstanding}`
+    : '';
+
+  const prompt = `You are an expert content strategist. Using the confirmed alignment summary and blog brief below, generate a detailed, hierarchical blog outline.
+
+## Confirmed Alignment
+- Blog goal: ${alignment.blogGoal}
+- Target audience: ${alignment.targetAudience}
+- SEO intent: ${alignment.seoIntent}
+- Tone: ${alignment.tone}
+- Scope: ${alignment.scope}${referenceNote}
+
+## Blog Brief
+- Title: ${brief.title}
+- Primary keyword: ${brief.primaryKeyword}
+- Tone: ${brief.toneOfVoice}
+- Word count target: ~${wordTarget} words (range: ${brief.wordCountMin}–${brief.wordCountMax})${feedbackNote}
+
+Generate a structured outline. Respond with ONLY valid JSON — no markdown fences, no extra keys.
+
+Rules:
+- Include 4–7 H2 sections (never fewer than 4, never more than 7)
+- Each section must have a clear, keyword-relevant title and 2–4 H3 subsections
+- Distribute estimatedWords across sections so they sum to approximately ${wordTarget}
+- The description for each section is 1–2 sentences explaining what it will cover
+
+Required JSON shape:
+{
+  "sections": [
+    {
+      "title": "H2 section title",
+      "description": "1–2 sentences covering what this section addresses",
+      "subsections": ["H3 subsection 1", "H3 subsection 2", "H3 subsection 3"],
+      "estimatedWords": 250
+    }
+  ],
+  "totalEstimatedWords": ${wordTarget}
+}`;
+
+  const message = await client.messages.create({
+    model: resolveModel(),
+    max_tokens: 1024,
+    messages: [{ role: 'user', content: prompt }],
+  });
+
+  const raw = message.content[0]?.type === 'text' ? message.content[0].text.trim() : '';
+
+  const text = raw.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim();
+
+  let parsed: { sections: OutlineSection[]; totalEstimatedWords: number };
+  try {
+    parsed = JSON.parse(text) as { sections: OutlineSection[]; totalEstimatedWords: number };
+  } catch {
+    console.error('[outline-service] Claude returned non-JSON:', raw);
+    throw new Error('AI returned an unexpected response format. Please try again.');
+  }
+
+  if (!Array.isArray(parsed.sections) || parsed.sections.length < 4) {
+    console.error('[outline-service] Invalid outline structure:', text);
+    throw new Error('AI returned an unexpected response format. Please try again.');
+  }
+
+  for (const section of parsed.sections) {
+    if (
+      typeof section.title !== 'string' ||
+      typeof section.description !== 'string' ||
+      !Array.isArray(section.subsections) ||
+      typeof section.estimatedWords !== 'number'
+    ) {
+      console.error('[outline-service] Invalid section shape:', section);
+      throw new Error('AI returned an unexpected response format. Please try again.');
+    }
+  }
+
+  return { sections: parsed.sections, totalEstimatedWords: parsed.totalEstimatedWords, raw: text };
+}

--- a/docs/agdr/AgDR-0008-migration-blog-outlines-table.md
+++ b/docs/agdr/AgDR-0008-migration-blog-outlines-table.md
@@ -1,0 +1,100 @@
+---
+id: AgDR-0008
+timestamp: 2026-04-21T00:00:00Z
+agent: Claude (Sonnet 4.6)
+trigger: user-prompt
+status: accepted
+ticket: mohamednaseramein/blog-generator#19
+---
+
+# AgDR-0008 — Migration: Create blog_outlines Table
+
+## Context
+
+US-08 (EP-04) adds an AI-generated blog outline step (Step 3 of the wizard). The outline is a JSON
+document containing ordered H2 sections, each with H3 sub-points and a word allocation. It must be
+persisted so downstream steps (draft) can retrieve it without regeneration.
+
+The alignment data lives in `blog_briefs` (a single extra JSONB column). The outline is heavier —
+it has iteration tracking, a confirmed flag, and JSON structure — so a dedicated table was chosen
+over adding more columns to `blog_briefs`.
+
+## Options Considered
+
+### Option A — New `blog_outlines` table (chosen)
+- One row per blog, keyed by `blog_id` (UNIQUE FK on `blogs`).
+- Stores `outline_json TEXT`, `outline_confirmed BOOLEAN`, `outline_iterations SMALLINT`.
+- Mirrors the `blog_briefs` alignment columns pattern for consistency.
+- **Rollback**: `DROP TABLE IF EXISTS blog_outlines;`
+
+### Option B — Add outline columns to `blog_briefs`
+- Avoids a new migration.
+- `blog_briefs` is already 14 columns; mixing brief, scrape, alignment, and outline data in one
+  table violates single-responsibility and makes future per-step queries harder.
+- Rejected.
+
+### Option C — Supabase Storage (JSON file)
+- No schema migration needed.
+- Loses ACID guarantees, transactional reads, and JOIN capability.
+- Rejected.
+
+## Decision
+
+Option A — new `blog_outlines` table.
+
+## Rollback Plan
+
+```sql
+DROP TABLE IF EXISTS blog_outlines;
+```
+
+Run via the Supabase SQL editor or the project's `npm run migrate` script with the inverse
+migration file. No data is at risk because `blog_outlines` is additive — no existing table or
+column is altered.
+
+**Tested against**: unit fixture (Supabase test project — same SQL engine, empty dataset).
+
+## Affected Tables / Entities
+
+- `blog_outlines` (new)
+
+## Cross-Service Consumers
+
+None at time of writing. The frontend calls the backend API which is the sole writer/reader of this
+table.
+
+**Deploy-order constraint**: Backend must deploy (and migrate) before frontend ships the Outline
+step UI, so the endpoint exists. Both ship in the same PR so ordering is automatic.
+
+## Estimated Downtime
+
+None — additive DDL only. `CREATE TABLE IF NOT EXISTS` acquires an `AccessShareLock` on the
+catalog, not on existing tables.
+
+## Data Volume
+
+0 rows at migration time. Expected to grow ~1 row per blog created.
+
+## Testing Plan
+
+- Dev smoke: `npm run migrate` in the backend container; verify `blog_outlines` appears in
+  `\dt` via `psql`.
+- Staging verify: Create a blog, confirm alignment, hit `POST /api/blogs/:id/outline`, confirm
+  row inserted with `SELECT * FROM blog_outlines WHERE blog_id = '<id>'`.
+- Canary / phased rollout: n/a — table is empty, no traffic concern.
+
+## Observability
+
+- Supabase Table Editor: row count on `blog_outlines`.
+- Backend logs: `[outline-repository] saved outline for blogId=<id>`.
+
+## Consequences
+
+- `blog_outlines` table is permanent. Future draft step reads `outline_json` from it.
+- `outline_iterations` tracks regeneration depth (useful for analytics).
+- `outline_confirmed` gates the Step 4 draft handler.
+
+## Artifacts
+
+- Migration file: `backend/src/db/migrations/migrate-002-blog-outlines.sql`
+- Ticket: https://github.com/mohamednaseramein/blog-generator/issues/19

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { BlogBriefForm } from './components/BlogBriefForm.js';
 import { AlignmentSummary } from './components/AlignmentSummary.js';
+import { OutlineStep } from './components/OutlineStep.js';
 import { WizardProgress } from './components/WizardProgress.js';
 import { Button } from './components/ui/button.js';
 import { Toast } from './components/ui/toast.js';
@@ -11,6 +12,7 @@ type AppState =
   | { step: 'creating' }
   | { step: 'brief'; blogId: string }
   | { step: 'alignment'; blogId: string }
+  | { step: 'outline'; blogId: string }
   | { step: 'done'; blogId: string };
 
 export function App() {
@@ -32,7 +34,8 @@ export function App() {
   const wizardStep = state.step === 'idle' || state.step === 'creating' ? 1
     : state.step === 'brief' ? 1
     : state.step === 'alignment' ? 2
-    : 3;
+    : state.step === 'outline' ? 3
+    : 4;
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-indigo-50">
@@ -50,7 +53,7 @@ export function App() {
         </div>
 
         {/* Wizard progress */}
-        {(state.step === 'brief' || state.step === 'alignment' || state.step === 'done') && (
+        {(state.step === 'brief' || state.step === 'alignment' || state.step === 'outline' || state.step === 'done') && (
           <div className="mb-8">
             <WizardProgress current={wizardStep} />
           </div>
@@ -100,6 +103,14 @@ export function App() {
             <AlignmentSummary
               blogId={state.blogId}
               onEdit={() => setState({ step: 'brief', blogId: state.blogId })}
+              onConfirmed={() => setState({ step: 'outline', blogId: state.blogId })}
+            />
+          )}
+
+          {state.step === 'outline' && (
+            <OutlineStep
+              blogId={state.blogId}
+              onBack={() => setState({ step: 'alignment', blogId: state.blogId })}
               onConfirmed={() => setState({ step: 'done', blogId: state.blogId })}
             />
           )}
@@ -110,9 +121,9 @@ export function App() {
                 ✓
               </div>
               <div>
-                <h2 className="text-lg font-semibold text-slate-800">Alignment confirmed!</h2>
+                <h2 className="text-lg font-semibold text-slate-800">Outline confirmed!</h2>
                 <p className="mt-1 text-sm text-slate-500">
-                  Next up: Research & Outline — Step 3.
+                  Next up: Draft — Step 4.
                 </p>
               </div>
               <Button variant="ghost" size="sm" onClick={() => void startNewBlog()}>

--- a/frontend/src/api/blog-api.ts
+++ b/frontend/src/api/blog-api.ts
@@ -91,3 +91,35 @@ export async function confirmAlignment(blogId: string): Promise<{ confirmed: boo
     method: 'POST',
   });
 }
+
+export interface OutlineSection {
+  title: string;
+  description: string;
+  subsections: string[];
+  estimatedWords: number;
+}
+
+export interface BlogOutline {
+  sections: OutlineSection[];
+  totalEstimatedWords: number;
+}
+
+export interface OutlineResponse {
+  outline: BlogOutline & { raw: string };
+}
+
+export async function generateOutline(
+  blogId: string,
+  feedback?: string,
+): Promise<OutlineResponse> {
+  return request<OutlineResponse>(`${BASE}/${blogId}/outline`, {
+    method: 'POST',
+    body: JSON.stringify({ feedback }),
+  });
+}
+
+export async function confirmOutline(blogId: string): Promise<{ confirmed: boolean }> {
+  return request<{ confirmed: boolean }>(`${BASE}/${blogId}/outline/confirm`, {
+    method: 'POST',
+  });
+}

--- a/frontend/src/components/OutlineStep.tsx
+++ b/frontend/src/components/OutlineStep.tsx
@@ -1,0 +1,159 @@
+import { useState, useEffect } from 'react';
+import { generateOutline, confirmOutline, type BlogOutline } from '../api/blog-api.js';
+import { Button } from './ui/button.js';
+import { Textarea } from './ui/textarea.js';
+import { Toast } from './ui/toast.js';
+import { Field } from './ui/field.js';
+
+interface Props {
+  blogId: string;
+  onBack: () => void;
+  onConfirmed: () => void;
+}
+
+export function OutlineStep({ blogId, onBack, onConfirmed }: Props) {
+  const [outline, setOutline] = useState<BlogOutline | null>(null);
+  const [feedback, setFeedback] = useState('');
+  const [generating, setGenerating] = useState(false);
+  const [confirming, setConfirming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [iterations, setIterations] = useState(0);
+
+  async function generate(feedbackText?: string) {
+    setError(null);
+    setGenerating(true);
+    try {
+      const res = await generateOutline(blogId, feedbackText);
+      setOutline(res.outline);
+      setFeedback('');
+      setIterations((i) => i + 1);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setGenerating(false);
+    }
+  }
+
+  async function confirm() {
+    setError(null);
+    setConfirming(true);
+    try {
+      await confirmOutline(blogId);
+      onConfirmed();
+    } catch (e) {
+      setError((e as Error).message);
+      setConfirming(false);
+    }
+  }
+
+  useEffect(() => { void generate(); }, []);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div>
+        <h2 className="text-lg font-semibold text-slate-800">Step 3 — Blog Outline</h2>
+        <p className="mt-1 text-sm text-slate-500">
+          Review the AI-generated structure. Provide feedback or confirm to proceed to drafting.
+        </p>
+      </div>
+
+      {generating && (
+        <div className="flex flex-col items-center gap-3 py-10 text-slate-500">
+          <span className="inline-block h-6 w-6 animate-spin rounded-full border-2 border-slate-200 border-t-indigo-500" />
+          <p className="text-sm">
+            {iterations === 0 ? 'Generating outline…' : 'Regenerating with your feedback…'}
+          </p>
+        </div>
+      )}
+
+      {outline && !generating && (
+        <div className="flex flex-col gap-4">
+          <div className="flex items-center justify-between">
+            <p className="text-xs text-slate-400 font-medium uppercase tracking-wide">
+              {outline.sections.length} sections · ~{outline.totalEstimatedWords.toLocaleString()} words
+            </p>
+            {iterations > 0 && (
+              <p className="text-xs text-slate-400">Iteration {iterations}</p>
+            )}
+          </div>
+
+          {outline.sections.map((section, idx) => (
+            <div
+              key={idx}
+              className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3"
+            >
+              <div className="flex items-start justify-between gap-2">
+                <p className="text-sm font-semibold text-slate-800">
+                  H2 · {section.title}
+                </p>
+                <span className="shrink-0 rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-medium text-indigo-600">
+                  ~{section.estimatedWords.toLocaleString()} words
+                </span>
+              </div>
+              <p className="mt-1 text-xs text-slate-500">{section.description}</p>
+              {section.subsections.length > 0 && (
+                <ul className="mt-2 space-y-1">
+                  {section.subsections.map((sub, sIdx) => (
+                    <li key={sIdx} className="flex items-start gap-1.5 text-xs text-slate-600">
+                      <span className="mt-0.5 shrink-0 text-indigo-300">›</span>
+                      <span>{sub}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {error && <Toast variant="error">{error}</Toast>}
+
+      {outline && !generating && (
+        <Field
+          label="Something off? Tell the AI what to change:"
+          hint="Leave blank if the outline looks good."
+        >
+          <Textarea
+            rows={3}
+            placeholder="e.g. Add a section on pricing comparisons, and make the intro shorter…"
+            value={feedback}
+            onChange={(e) => setFeedback(e.target.value)}
+          />
+        </Field>
+      )}
+
+      <div className="flex flex-wrap items-center justify-between gap-3 pt-1">
+        <Button variant="ghost" size="sm" onClick={onBack} disabled={generating || confirming}>
+          ← Back to Alignment
+        </Button>
+
+        <div className="flex gap-2">
+          {outline && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => void generate(feedback || undefined)}
+              disabled={generating || confirming}
+            >
+              {feedback ? 'Regenerate with feedback' : 'Regenerate'}
+            </Button>
+          )}
+          <Button
+            onClick={() => void confirm()}
+            disabled={!outline || generating || confirming}
+            aria-busy={confirming}
+          >
+            {confirming ? (
+              <span className="flex items-center gap-2">
+                <span className="inline-block h-3.5 w-3.5 animate-spin rounded-full border-2 border-white/40 border-t-white" />
+                Confirming…
+              </span>
+            ) : (
+              'Confirm Outline →'
+            )}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Implements EP-04 / US-08 — Step 3 of the blog wizard: AI-generated blog outline
- After alignment confirmation the wizard advances to `OutlineStep`, which generates a hierarchical outline (4–7 H2 sections, each with H3 sub-points and an estimated word count)
- User can provide feedback and regenerate before confirming
- Confirmed outline is persisted in the new `blog_outlines` table

## Changes

### Backend
- **migrate-002-blog-outlines.sql** — new `blog_outlines` table (`outline_json`, `outline_confirmed`, `outline_iterations`)
- **AgDR-0008** — migration decision record (rollback, downtime analysis, cross-service consumers)
- **outline-service.ts** — Claude prompt, JSON parse, validation (4+ sections, required fields)
- **blog-outline-repository.ts** — `upsertOutline`, `getOutlineByBlogId`, `confirmOutline`
- **blog-outline-handler.ts** — `POST /:id/outline`, `POST /:id/outline/confirm`, `GET /:id/outline`
- **blog-routes.ts** — three new routes wired up

### Frontend
- **blog-api.ts** — `generateOutline`, `confirmOutline`, `OutlineSection`, `BlogOutline` types
- **OutlineStep.tsx** — Step 3 component: loading state, section cards with word allocation, feedback textarea, Back to Alignment and Confirm buttons
- **App.tsx** — `outline` step added to wizard state machine; alignment `onConfirmed` advances to outline; progress bar step 3 active

## Tests

48 tests passing (6 test files):
- `outline-service.test.ts` — 7 tests (JSON parse, fence stripping, validation, feedback/reference in prompt)
- `blog-outline-handler.test.ts` — 8 tests (generate + confirm, all guard clauses)
- existing 33 tests unchanged

## Migration note

Run `npm run db:migrate --workspace=backend` after deploying to create `blog_outlines`.

## Glossary

- **Outline** — the hierarchical H2/H3 structure generated by Claude that the user reviews and confirms before the draft step
- **blog_outlines** — new Postgres table that persists the confirmed outline JSON per blog post
- **OutlineStep** — the new Step 3 React component

Closes https://github.com/mohamednaseramein/blog-generator/issues/18
Closes https://github.com/mohamednaseramein/blog-generator/issues/19
Part of https://github.com/mohamednaseramein/blog-generator/issues/17

Made with [Cursor](https://cursor.com)