### PR TITLE
chore(GH-21): auto-run DB migrations on backend container startup

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -28,6 +28,11 @@ RUN npm ci --workspace=backend --omit=dev
 
 COPY --from=builder /app/backend/dist ./backend/dist
 
+# SQL migration files are not compiled by tsc; copy them next to the compiled
+# migrate.js so the runner can find them at backend/dist/db/migrations/*.sql
+COPY backend/src/db/migrations ./backend/dist/db/migrations
+
 EXPOSE 3000
 
-CMD ["node", "backend/dist/index.js"]
+# Run pending migrations (idempotent) then start the API server.
+CMD ["sh", "-c", "node backend/dist/db/migrate.js && node backend/dist/index.js"]


### PR DESCRIPTION
## Summary

- Wires the existing `db:migrate` script into the Docker container startup sequence so migrations run automatically on every `docker compose up --build`
- Eliminates the need to manually run migrations after each deploy

## Changes

**`backend/Dockerfile`** (2 changes):

1. Copy SQL migration files into the production image:
   ```dockerfile
   COPY backend/src/db/migrations ./backend/dist/db/migrations
   ```
   `migrate.ts` reads `./migrations` relative to its own `__dirname` (`dist/db/`), so the `.sql` files must live at `dist/db/migrations/` in the runner image.

2. Update `CMD` to run migration then server:
   ```dockerfile
   CMD ["sh", "-c", "node backend/dist/db/migrate.js && node backend/dist/index.js"]
   ```

No `tsconfig.json` changes needed — `migrate.ts` lives under `src/` and is already compiled to `dist/db/migrate.js` by the existing build step.

## Safety

The migration runner (`src/db/migrate.ts`) is idempotent: it tracks applied files in the `schema_migrations` table and skips any already-applied migration. Re-running on every container start is safe.

## Testing

After `docker compose up --build`:
- Container logs will show `✅ migrate-001-initial-schema.sql — already applied` (and `✅ migrate-002-blog-outlines.sql — applied` on first run after PR #20 merges)
- Server starts only after migration completes successfully
- If migration fails the container exits (non-zero), preventing a broken server from accepting traffic

## Glossary

- **schema_migrations** — tracking table that records which `.sql` files have been applied, making the runner idempotent
- **CMD** — the Docker instruction that specifies the default command run when a container starts
- **`__dirname`** — resolved at runtime to the directory of `dist/db/migrate.js`, so migrations are looked up at `dist/db/migrations/`

Closes https://github.com/mohamednaseramein/blog-generator/issues/21

Made with [Cursor](https://cursor.com)