### PR TITLE
feat(GH-24): multi-reference URL support in blog brief (US-09)

### DIFF
--- a/backend/src/db/migrations/migrate-003-blog-references.sql
+++ b/backend/src/db/migrations/migrate-003-blog-references.sql
@@ -1,0 +1,26 @@
+-- Migration 003: Create blog_references table for multi-URL reference support
+-- Ticket:  https://github.com/mohamednaseramein/blog-generator/issues/26
+-- AgDR:    docs/agdr/AgDR-0009-migration-blog-references-table.md
+-- Rollback: DROP TABLE IF EXISTS blog_references;
+--
+-- NOTE: blog_briefs.reference_url, scraped_content, scrape_status are
+-- deprecated by this migration but NOT dropped here. They are dropped in
+-- migrate-004 after US-09 and US-10 have both shipped.
+
+CREATE TABLE IF NOT EXISTS blog_references (
+  id                UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  blog_id           UUID         NOT NULL REFERENCES blogs(id) ON DELETE CASCADE,
+  url               TEXT         NOT NULL,
+  position          SMALLINT     NOT NULL DEFAULT 1,
+  scrape_status     VARCHAR(20)  NOT NULL DEFAULT 'pending'
+                                 CHECK (scrape_status IN ('pending','success','failed','timeout','skipped')),
+  scrape_error      TEXT,
+  scraped_content   TEXT,
+  extraction_status VARCHAR(20)  NOT NULL DEFAULT 'pending'
+                                 CHECK (extraction_status IN ('pending','success','failed','irrelevant')),
+  extraction_json   TEXT,
+  created_at        TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  updated_at        TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_blog_references_blog_id ON blog_references(blog_id);

--- a/backend/src/domain/types.ts
+++ b/backend/src/domain/types.ts
@@ -1,5 +1,7 @@
 export type BlogStatus = 'draft' | 'in_progress' | 'completed';
 export type ScrapeStatus = 'pending' | 'success' | 'failed' | 'skipped';
+export type ReferenceScrapeStatus = 'pending' | 'success' | 'failed' | 'timeout' | 'skipped';
+export type ReferenceExtractionStatus = 'pending' | 'success' | 'failed' | 'irrelevant';
 
 export interface Blog {
   id: string;
@@ -47,6 +49,20 @@ export interface BlogOutline {
   updatedAt: Date;
 }
 
+export interface BlogReference {
+  id: string;
+  blogId: string;
+  url: string;
+  position: number;
+  scrapeStatus: ReferenceScrapeStatus;
+  scrapeError: string | null;
+  scrapedContent: string | null;
+  extractionStatus: ReferenceExtractionStatus;
+  extractionJson: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
 export interface SubmitBriefInput {
   title: string;
   primaryKeyword: string;
@@ -55,5 +71,10 @@ export interface SubmitBriefInput {
   wordCountMin: number;
   wordCountMax: number;
   blogBrief: string;
+  /** @deprecated Use blog_references table instead. Kept for backwards compat during transition. */
   referenceUrl?: string;
+}
+
+export interface AddReferenceInput {
+  url: string;
 }

--- a/backend/src/handlers/__tests__/blog-references-handler.test.ts
+++ b/backend/src/handlers/__tests__/blog-references-handler.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const {
+  mockGetBlogByIdAndUser,
+  mockCountRefs,
+  mockInsertRef,
+  mockGetRefs,
+  mockGetRefById,
+  mockDeleteRef,
+  mockScrapeInBackground,
+  mockGetUserId,
+} = vi.hoisted(() => ({
+  mockGetBlogByIdAndUser: vi.fn(),
+  mockCountRefs: vi.fn(),
+  mockInsertRef: vi.fn(),
+  mockGetRefs: vi.fn(),
+  mockGetRefById: vi.fn(),
+  mockDeleteRef: vi.fn(),
+  mockScrapeInBackground: vi.fn(),
+  mockGetUserId: vi.fn(() => 'user-1'),
+}));
+
+vi.mock('../../repositories/blog-repository.js', () => ({
+  getBlogByIdAndUser: mockGetBlogByIdAndUser,
+}));
+
+vi.mock('../../repositories/blog-references-repository.js', () => ({
+  countReferencesByBlogId: mockCountRefs,
+  insertReference: mockInsertRef,
+  getReferencesByBlogId: mockGetRefs,
+  getReferenceById: mockGetRefById,
+  deleteReference: mockDeleteRef,
+}));
+
+vi.mock('../../services/url-scraper-service.js', () => ({
+  scrapeReferenceInBackground: mockScrapeInBackground,
+  scrapeUrlInBackground: vi.fn(),
+}));
+
+vi.mock('../../middleware/auth.js', () => ({
+  getUserId: mockGetUserId,
+}));
+
+import {
+  handleAddReference,
+  handleListReferences,
+  handleDeleteReference,
+  handleGetReferenceStatus,
+} from '../blog-references-handler.js';
+import type { Request, Response, NextFunction } from 'express';
+
+const blog = { id: 'blog-1', userId: 'user-1' };
+
+const fakeRef = {
+  id: 'ref-1',
+  blogId: 'blog-1',
+  url: 'https://example.com/article',
+  position: 1,
+  scrapeStatus: 'pending' as const,
+  scrapeError: null,
+  scrapedContent: null,
+  extractionStatus: 'pending' as const,
+  extractionJson: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+function makeReqRes(blogId: string, body: Record<string, unknown> = {}, params: Record<string, string> = {}) {
+  const req = { params: { id: blogId, ...params }, body } as unknown as Request;
+  const json = vi.fn();
+  const res = { json, status: vi.fn().mockReturnThis() } as unknown as Response;
+  const next = vi.fn() as unknown as NextFunction;
+  return { req, res, json, next };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetUserId.mockReturnValue('user-1');
+});
+
+describe('handleAddReference', () => {
+  it('inserts reference and fires background scrape', async () => {
+    mockGetBlogByIdAndUser.mockResolvedValue(blog);
+    mockCountRefs.mockResolvedValue(0);
+    mockInsertRef.mockResolvedValue(fakeRef);
+
+    const { req, res, json, next } = makeReqRes('blog-1', { url: 'https://example.com/article' });
+    await handleAddReference(req, res, next);
+
+    expect(mockInsertRef).toHaveBeenCalledWith('blog-1', 'https://example.com/article', 1);
+    expect(mockScrapeInBackground).toHaveBeenCalledWith('ref-1', 'https://example.com/article');
+    expect(json).toHaveBeenCalledWith({ reference: fakeRef });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when url is missing', async () => {
+    mockGetBlogByIdAndUser.mockResolvedValue(blog);
+    const { req, res, next } = makeReqRes('blog-1', {});
+    await handleAddReference(req, res, next);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 400 }));
+  });
+
+  it('returns 400 when url is invalid', async () => {
+    mockGetBlogByIdAndUser.mockResolvedValue(blog);
+    const { req, res, next } = makeReqRes('blog-1', { url: 'not-a-url' });
+    await handleAddReference(req, res, next);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 400 }));
+  });
+
+  it('returns 400 when max references reached', async () => {
+    mockGetBlogByIdAndUser.mockResolvedValue(blog);
+    mockCountRefs.mockResolvedValue(5);
+    const { req, res, next } = makeReqRes('blog-1', { url: 'https://example.com' });
+    await handleAddReference(req, res, next);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 400 }));
+  });
+
+  it('returns 404 when blog not found', async () => {
+    mockGetBlogByIdAndUser.mockResolvedValue(null);
+    const { req, res, next } = makeReqRes('blog-1', { url: 'https://example.com' });
+    await handleAddReference(req, res, next);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 404 }));
+  });
+});
+
+describe('handleListReferences', () => {
+  it('returns all references for the blog', async () => {
+    mockGetBlogByIdAndUser.mockResolvedValue(blog);
+    mockGetRefs.mockResolvedValue([fakeRef]);
+
+    const { req, res, json, next } = makeReqRes('blog-1');
+    await handleListReferences(req, res, next);
+
+    expect(json).toHaveBeenCalledWith({ references: [fakeRef] });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when blog not found', async () => {
+    mockGetBlogByIdAndUser.mockResolvedValue(null);
+    const { req, res, next } = makeReqRes('blog-1');
+    await handleListReferences(req, res, next);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 404 }));
+  });
+});
+
+describe('handleDeleteReference', () => {
+  it('deletes and returns deleted=true', async () => {
+    mockGetBlogByIdAndUser.mockResolvedValue(blog);
+    mockGetRefById.mockResolvedValue(fakeRef);
+    mockDeleteRef.mockResolvedValue(undefined);
+
+    const { req, res, json, next } = makeReqRes('blog-1', {}, { refId: 'ref-1' });
+    await handleDeleteReference(req, res, next);
+
+    expect(mockDeleteRef).toHaveBeenCalledWith('ref-1');
+    expect(json).toHaveBeenCalledWith({ deleted: true });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when reference not found', async () => {
+    mockGetBlogByIdAndUser.mockResolvedValue(blog);
+    mockGetRefById.mockResolvedValue(null);
+
+    const { req, res, next } = makeReqRes('blog-1', {}, { refId: 'bad-id' });
+    await handleDeleteReference(req, res, next);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 404 }));
+  });
+});
+
+describe('handleGetReferenceStatus', () => {
+  it('returns scrape and extraction status', async () => {
+    mockGetBlogByIdAndUser.mockResolvedValue(blog);
+    mockGetRefById.mockResolvedValue({ ...fakeRef, scrapeStatus: 'success' });
+
+    const { req, res, json, next } = makeReqRes('blog-1', {}, { refId: 'ref-1' });
+    await handleGetReferenceStatus(req, res, next);
+
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({ scrapeStatus: 'success' }),
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/handlers/blog-alignment-handler.ts
+++ b/backend/src/handlers/blog-alignment-handler.ts
@@ -5,6 +5,7 @@ import {
   updateAlignmentSummary,
   confirmAlignment,
 } from '../repositories/blog-brief-repository.js';
+import { getReferencesByBlogId } from '../repositories/blog-references-repository.js';
 import { generateAlignmentSummary } from '../services/alignment-service.js';
 import { AppError } from '../middleware/error-handler.js';
 import { getUserId } from '../middleware/auth.js';
@@ -26,7 +27,8 @@ export async function handleGenerateAlignment(
     const brief = await getBriefByBlogId(blogId);
     if (!brief) throw new AppError(404, 'NOT_FOUND', 'Brief not found — submit the brief first');
 
-    const summary = await generateAlignmentSummary(brief, feedbackText);
+    const references = await getReferencesByBlogId(blogId);
+    const summary = await generateAlignmentSummary(brief, feedbackText, references);
     await updateAlignmentSummary(blogId, summary.raw);
 
     res.json({ summary });

--- a/backend/src/handlers/blog-references-handler.ts
+++ b/backend/src/handlers/blog-references-handler.ts
@@ -1,0 +1,127 @@
+import type { Request, Response, NextFunction } from 'express';
+import { getBlogByIdAndUser } from '../repositories/blog-repository.js';
+import {
+  countReferencesByBlogId,
+  insertReference,
+  getReferencesByBlogId,
+  getReferenceById,
+  deleteReference,
+} from '../repositories/blog-references-repository.js';
+import { scrapeReferenceInBackground } from '../services/url-scraper-service.js';
+import { ReferenceUrl } from '../domain/value-objects.js';
+import { AppError } from '../middleware/error-handler.js';
+import { getUserId } from '../middleware/auth.js';
+
+const MAX_REFERENCES = 5;
+
+export async function handleAddReference(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const userId = getUserId(req);
+    const blogId = req.params['id'] as string;
+    const body = req.body as Record<string, unknown>;
+    const rawUrl = body['url'];
+
+    if (!rawUrl || typeof rawUrl !== 'string' || !rawUrl.trim()) {
+      throw new AppError(400, 'VALIDATION_ERROR', 'url is required');
+    }
+
+    let validUrl: string;
+    try {
+      validUrl = new ReferenceUrl(rawUrl.trim()).value;
+    } catch (e) {
+      throw new AppError(400, 'VALIDATION_ERROR', (e as Error).message);
+    }
+
+    const blog = await getBlogByIdAndUser(blogId, userId);
+    if (!blog) throw new AppError(404, 'NOT_FOUND', 'Blog not found');
+
+    const count = await countReferencesByBlogId(blogId);
+    if (count >= MAX_REFERENCES) {
+      throw new AppError(400, 'VALIDATION_ERROR', `Maximum of ${MAX_REFERENCES} reference URLs allowed`);
+    }
+
+    const reference = await insertReference(blogId, validUrl, count + 1);
+    scrapeReferenceInBackground(reference.id, validUrl);
+
+    res.status(201).json({ reference });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function handleListReferences(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const userId = getUserId(req);
+    const blogId = req.params['id'] as string;
+
+    const blog = await getBlogByIdAndUser(blogId, userId);
+    if (!blog) throw new AppError(404, 'NOT_FOUND', 'Blog not found');
+
+    const references = await getReferencesByBlogId(blogId);
+    res.json({ references });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function handleGetReferenceStatus(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const userId = getUserId(req);
+    const blogId = req.params['id'] as string;
+    const refId = req.params['refId'] as string;
+
+    const blog = await getBlogByIdAndUser(blogId, userId);
+    if (!blog) throw new AppError(404, 'NOT_FOUND', 'Blog not found');
+
+    const reference = await getReferenceById(refId);
+    if (!reference || reference.blogId !== blogId) {
+      throw new AppError(404, 'NOT_FOUND', 'Reference not found');
+    }
+
+    res.json({
+      scrapeStatus: reference.scrapeStatus,
+      scrapeError: reference.scrapeError,
+      extractionStatus: reference.extractionStatus,
+      extractionJson: reference.extractionJson,
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function handleDeleteReference(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const userId = getUserId(req);
+    const blogId = req.params['id'] as string;
+    const refId = req.params['refId'] as string;
+
+    const blog = await getBlogByIdAndUser(blogId, userId);
+    if (!blog) throw new AppError(404, 'NOT_FOUND', 'Blog not found');
+
+    const reference = await getReferenceById(refId);
+    if (!reference || reference.blogId !== blogId) {
+      throw new AppError(404, 'NOT_FOUND', 'Reference not found');
+    }
+
+    await deleteReference(refId);
+    res.json({ deleted: true });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/backend/src/repositories/blog-references-repository.ts
+++ b/backend/src/repositories/blog-references-repository.ts
@@ -1,0 +1,123 @@
+import { getSupabase } from '../db/supabase.js';
+import type { BlogReference, ReferenceScrapeStatus, ReferenceExtractionStatus } from '../domain/types.js';
+
+interface BlogReferenceRow {
+  id: string;
+  blog_id: string;
+  url: string;
+  position: number;
+  scrape_status: string;
+  scrape_error: string | null;
+  scraped_content: string | null;
+  extraction_status: string;
+  extraction_json: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+function toModel(row: BlogReferenceRow): BlogReference {
+  return {
+    id: row.id,
+    blogId: row.blog_id,
+    url: row.url,
+    position: row.position,
+    scrapeStatus: row.scrape_status as ReferenceScrapeStatus,
+    scrapeError: row.scrape_error,
+    scrapedContent: row.scraped_content,
+    extractionStatus: row.extraction_status as ReferenceExtractionStatus,
+    extractionJson: row.extraction_json,
+    createdAt: new Date(row.created_at),
+    updatedAt: new Date(row.updated_at),
+  };
+}
+
+export async function countReferencesByBlogId(blogId: string): Promise<number> {
+  const { count, error } = await getSupabase()
+    .from('blog_references')
+    .select('id', { count: 'exact', head: true })
+    .eq('blog_id', blogId);
+
+  if (error) throw new Error(error.message);
+  return count ?? 0;
+}
+
+export async function insertReference(
+  blogId: string,
+  url: string,
+  position: number,
+): Promise<BlogReference> {
+  const { data, error } = await getSupabase()
+    .from('blog_references')
+    .insert({ blog_id: blogId, url, position, scrape_status: 'pending', extraction_status: 'pending' })
+    .select()
+    .single<BlogReferenceRow>();
+
+  if (error) throw new Error(error.message);
+  console.log(`[references-repository] saved reference for blogId=${blogId}`);
+  return toModel(data);
+}
+
+export async function getReferencesByBlogId(blogId: string): Promise<BlogReference[]> {
+  const { data, error } = await getSupabase()
+    .from('blog_references')
+    .select()
+    .eq('blog_id', blogId)
+    .order('position', { ascending: true })
+    .returns<BlogReferenceRow[]>();
+
+  if (error) throw new Error(error.message);
+  return (data ?? []).map(toModel);
+}
+
+export async function getReferenceById(id: string): Promise<BlogReference | null> {
+  const { data, error } = await getSupabase()
+    .from('blog_references')
+    .select()
+    .eq('id', id)
+    .single<BlogReferenceRow>();
+
+  if (error?.code === 'PGRST116') return null;
+  if (error) throw new Error(error.message);
+  return toModel(data);
+}
+
+export async function deleteReference(id: string): Promise<void> {
+  const { error } = await getSupabase()
+    .from('blog_references')
+    .delete()
+    .eq('id', id);
+
+  if (error) throw new Error(error.message);
+}
+
+export async function updateReferenceScrapeResult(
+  id: string,
+  status: ReferenceScrapeStatus,
+  content: string | null,
+  scrapeError: string | null,
+): Promise<void> {
+  const { error } = await getSupabase()
+    .from('blog_references')
+    .update({
+      scrape_status: status,
+      scraped_content: content,
+      scrape_error: scrapeError,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', id);
+
+  if (error) throw new Error(error.message);
+}
+
+export async function getSuccessfullyScrapeReferences(blogId: string): Promise<BlogReference[]> {
+  const { data, error } = await getSupabase()
+    .from('blog_references')
+    .select()
+    .eq('blog_id', blogId)
+    .eq('scrape_status', 'success')
+    .order('position', { ascending: true })
+    .returns<BlogReferenceRow[]>();
+
+  if (error) throw new Error(error.message);
+  return (data ?? []).map(toModel);
+}

--- a/backend/src/routes/blog-routes.ts
+++ b/backend/src/routes/blog-routes.ts
@@ -15,6 +15,12 @@ import {
   handleConfirmOutline,
   handleGetOutline,
 } from '../handlers/blog-outline-handler.js';
+import {
+  handleAddReference,
+  handleListReferences,
+  handleGetReferenceStatus,
+  handleDeleteReference,
+} from '../handlers/blog-references-handler.js';
 
 const router = Router();
 
@@ -27,5 +33,11 @@ router.post('/:id/alignment/confirm', requireAuth, handleConfirmAlignment);
 router.post('/:id/outline', requireAuth, handleGenerateOutline);
 router.post('/:id/outline/confirm', requireAuth, handleConfirmOutline);
 router.get('/:id/outline', requireAuth, handleGetOutline);
+
+// Reference URLs (multi-URL support — EP-05 / US-09)
+router.post('/:id/references', requireAuth, handleAddReference);
+router.get('/:id/references', requireAuth, handleListReferences);
+router.get('/:id/references/:refId/status', requireAuth, handleGetReferenceStatus);
+router.delete('/:id/references/:refId', requireAuth, handleDeleteReference);
 
 export default router;

--- a/backend/src/services/__tests__/url-scraper-reference.test.ts
+++ b/backend/src/services/__tests__/url-scraper-reference.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockGet } = vi.hoisted(() => ({ mockGet: vi.fn() }));
+
+vi.mock('axios', () => ({ default: { get: mockGet } }));
+
+const { mockUpdateReferenceScrapeResult } = vi.hoisted(() => ({
+  mockUpdateReferenceScrapeResult: vi.fn(),
+}));
+
+vi.mock('../../repositories/blog-references-repository.js', () => ({
+  updateReferenceScrapeResult: mockUpdateReferenceScrapeResult,
+}));
+
+vi.mock('../../repositories/blog-brief-repository.js', () => ({
+  updateScrapeResult: vi.fn(),
+}));
+
+import { scrapeReferenceInBackground } from '../url-scraper-service.js';
+
+function flushPromises() {
+  return new Promise((resolve) => setTimeout(resolve, 10));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('scrapeReferenceInBackground', () => {
+  it('stores success and extracted text on happy path', async () => {
+    mockGet.mockResolvedValue({
+      data: '<html><body><article>Sleep tips content here.</article></body></html>',
+    });
+
+    scrapeReferenceInBackground('ref-1', 'https://example.com/article');
+    await flushPromises();
+
+    expect(mockUpdateReferenceScrapeResult).toHaveBeenCalledWith(
+      'ref-1',
+      'success',
+      expect.stringContaining('Sleep tips'),
+      null,
+    );
+  });
+
+  it('stores timeout status when axios times out', async () => {
+    const timeoutError = new Error('timeout of 10000ms exceeded');
+    timeoutError.message = 'timeout of 10000ms exceeded';
+    (timeoutError as NodeJS.ErrnoException).code = 'ECONNABORTED';
+    mockGet.mockRejectedValue(timeoutError);
+
+    scrapeReferenceInBackground('ref-1', 'https://slow.example.com');
+    await flushPromises();
+
+    expect(mockUpdateReferenceScrapeResult).toHaveBeenCalledWith(
+      'ref-1',
+      'timeout',
+      null,
+      expect.stringContaining('timed out'),
+    );
+  });
+
+  it('stores failed status with private URL message on 403', async () => {
+    const err = Object.assign(new Error('Request failed with status code 403'), {
+      response: { status: 403 },
+    });
+    mockGet.mockRejectedValue(err);
+
+    scrapeReferenceInBackground('ref-1', 'https://private.example.com');
+    await flushPromises();
+
+    expect(mockUpdateReferenceScrapeResult).toHaveBeenCalledWith(
+      'ref-1',
+      'failed',
+      null,
+      expect.stringContaining('private or requires login'),
+    );
+  });
+
+  it('stores failed status with not-found message on 404', async () => {
+    const err = Object.assign(new Error('Not Found'), { response: { status: 404 } });
+    mockGet.mockRejectedValue(err);
+
+    scrapeReferenceInBackground('ref-1', 'https://example.com/gone');
+    await flushPromises();
+
+    expect(mockUpdateReferenceScrapeResult).toHaveBeenCalledWith(
+      'ref-1',
+      'failed',
+      null,
+      expect.stringContaining('404'),
+    );
+  });
+
+  it('stores failed status with unreachable message on DNS failure', async () => {
+    const err = Object.assign(new Error('getaddrinfo ENOTFOUND'), { code: 'ENOTFOUND' });
+    mockGet.mockRejectedValue(err);
+
+    scrapeReferenceInBackground('ref-1', 'https://nonexistent.example.com');
+    await flushPromises();
+
+    expect(mockUpdateReferenceScrapeResult).toHaveBeenCalledWith(
+      'ref-1',
+      'failed',
+      null,
+      expect.stringContaining('publicly accessible'),
+    );
+  });
+});

--- a/backend/src/services/alignment-service.ts
+++ b/backend/src/services/alignment-service.ts
@@ -1,5 +1,5 @@
 import Anthropic from '@anthropic-ai/sdk';
-import type { BlogBrief } from '../domain/types.js';
+import type { BlogBrief, BlogReference } from '../domain/types.js';
 
 /** Default matches previous hardcoded model; unset env keeps prod behaviour. Override in dev, e.g. Haiku, via ANTHROPIC_MODEL. */
 export const DEFAULT_ALIGNMENT_ANTHROPIC_MODEL = 'claude-sonnet-4-6';
@@ -25,10 +25,17 @@ export interface AlignmentSummary {
 export async function generateAlignmentSummary(
   brief: BlogBrief,
   feedback?: string,
+  references?: BlogReference[],
 ): Promise<AlignmentSummary> {
-  const hasReference = !!brief.scrapedContent;
+  const successfulRefs = (references ?? []).filter((r) => r.scrapeStatus === 'success' && r.scrapedContent);
+  const hasReference = successfulRefs.length > 0 || !!brief.scrapedContent;
+
   const scrapedNote = hasReference
-    ? `\nReference content scraped (${brief.scrapedContent!.length} chars): ${brief.scrapedContent!.slice(0, 800)}…`
+    ? successfulRefs.length > 0
+      ? successfulRefs
+          .map((r, i) => `\nReference ${i + 1} (${r.url}, ${r.scrapedContent!.length} chars): ${r.scrapedContent!.slice(0, 600)}…`)
+          .join('')
+      : `\nReference content scraped (${brief.scrapedContent!.length} chars): ${brief.scrapedContent!.slice(0, 800)}…`
     : '';
 
   const feedbackNote = feedback

--- a/backend/src/services/url-scraper-service.ts
+++ b/backend/src/services/url-scraper-service.ts
@@ -1,22 +1,28 @@
 import axios from 'axios';
 import * as cheerio from 'cheerio';
 import { updateScrapeResult } from '../repositories/blog-brief-repository.js';
+import { updateReferenceScrapeResult } from '../repositories/blog-references-repository.js';
 
 const MAX_CONTENT_LENGTH = 10_000;
-const TIMEOUT_MS = 10_000;
 
+function resolveTimeoutMs(): number {
+  const fromEnv = parseInt(process.env['SCRAPE_TIMEOUT_MS'] ?? '', 10);
+  return Number.isFinite(fromEnv) && fromEnv > 0 ? fromEnv : 10_000;
+}
+
+/** @deprecated Used only for the legacy single-URL brief flow. Use scrapeReferenceInBackground for new multi-URL flow. */
 export function scrapeUrlInBackground(blogId: string, url: string): void {
-  scrape(blogId, url).catch(() => {
-    // fire-and-forget: errors handled inside scrape()
+  scrapeLegacy(blogId, url).catch(() => {
+    // fire-and-forget: errors handled inside scrapeLegacy()
   });
 }
 
-async function scrape(blogId: string, url: string): Promise<void> {
+async function scrapeLegacy(blogId: string, url: string): Promise<void> {
   try {
     const { data } = await axios.get<string>(url, {
-      timeout: TIMEOUT_MS,
+      timeout: resolveTimeoutMs(),
       headers: { 'User-Agent': 'BlogGenerator/1.0 (+https://github.com/mohamednaseramein/blog-generator)' },
-      maxContentLength: 5 * 1024 * 1024, // 5MB cap before cheerio parse
+      maxContentLength: 5 * 1024 * 1024,
     });
 
     const $ = cheerio.load(data);
@@ -30,5 +36,51 @@ async function scrape(blogId: string, url: string): Promise<void> {
     await updateScrapeResult(blogId, 'success', text || null);
   } catch {
     await updateScrapeResult(blogId, 'failed', null);
+  }
+}
+
+/** Scrape a single reference URL and persist the result to blog_references. */
+export function scrapeReferenceInBackground(referenceId: string, url: string): void {
+  scrapeReference(referenceId, url).catch(() => {
+    // fire-and-forget: errors handled inside scrapeReference()
+  });
+}
+
+async function scrapeReference(referenceId: string, url: string): Promise<void> {
+  const timeoutMs = resolveTimeoutMs();
+  try {
+    const { data } = await axios.get<string>(url, {
+      timeout: timeoutMs,
+      headers: { 'User-Agent': 'BlogGenerator/1.0 (+https://github.com/mohamednaseramein/blog-generator)' },
+      maxContentLength: 5 * 1024 * 1024,
+    });
+
+    const $ = cheerio.load(data);
+    $('script, style, nav, footer, header, aside').remove();
+
+    const text = ($('article, main').first().text() || $('body').text())
+      .replace(/\s+/g, ' ')
+      .trim()
+      .slice(0, MAX_CONTENT_LENGTH);
+
+    await updateReferenceScrapeResult(referenceId, 'success', text || null, null);
+  } catch (err) {
+    const error = err as NodeJS.ErrnoException & { code?: string; response?: { status: number } };
+
+    let status: 'failed' | 'timeout' = 'failed';
+    let message = 'Could not fetch this URL.';
+
+    if (error.code === 'ECONNABORTED' || error.message?.includes('timeout')) {
+      status = 'timeout';
+      message = `Request timed out after ${timeoutMs / 1000}s — the URL may be slow or unreachable.`;
+    } else if (error.response?.status === 401 || error.response?.status === 403) {
+      message = 'This URL is private or requires login. Copy the relevant content and paste it into your Blog Brief instead.';
+    } else if (error.response?.status === 404) {
+      message = 'This URL returned a 404 — the page was not found.';
+    } else if (error.code === 'ENOTFOUND' || error.code === 'EAI_AGAIN') {
+      message = 'Could not reach this URL — check it is publicly accessible.';
+    }
+
+    await updateReferenceScrapeResult(referenceId, status, null, message);
   }
 }

--- a/docs/agdr/AgDR-0009-migration-blog-references-table.md
+++ b/docs/agdr/AgDR-0009-migration-blog-references-table.md
@@ -1,0 +1,108 @@
+---
+id: AgDR-0009
+timestamp: 2026-04-21T00:00:00Z
+agent: Claude (Sonnet 4.6)
+trigger: user-prompt
+status: accepted
+ticket: mohamednaseramein/blog-generator#26
+---
+
+# AgDR-0009 — Migration: Create blog_references Table
+
+## Context
+
+EP-05 / US-09 replaces the single `blog_briefs.reference_url` column with a
+dedicated `blog_references` table supporting up to 5 URLs per blog. Each URL
+has its own scrape lifecycle (status, error, content) and — in US-10 — an
+extraction lifecycle (extraction_status, extraction_json).
+
+Putting references in a separate table (rather than a JSONB array on
+`blog_briefs`) was chosen for clean queryability, individual row updates during
+background jobs, and extensibility to extraction columns without altering the
+brief table again.
+
+## Options Considered
+
+### Option A — New `blog_references` table (chosen)
+- One row per URL, keyed by `(blog_id, position)`.
+- Independent scrape and extraction lifecycle columns per row.
+- Straightforward background-job update pattern: `UPDATE blog_references SET scrape_status = $1 WHERE id = $2`.
+- **Rollback:** `DROP TABLE IF EXISTS blog_references;`
+
+### Option B — JSONB array on `blog_briefs`
+- `reference_urls JSONB` — array of `{url, scrapeStatus, scrapedContent}` objects.
+- No new table, no migration to a new table.
+- Updating a single array element in Postgres requires replacing the whole column — awkward for concurrent background jobs.
+- No FK constraints per URL, harder to index.
+- Rejected.
+
+### Option C — Keep single URL, increase truncation limit
+- Low effort, zero migration.
+- Does not address the multi-URL requirement at all.
+- Rejected.
+
+## Decision
+
+Option A — new `blog_references` table.
+
+## Rollback Plan
+
+```sql
+DROP TABLE IF EXISTS blog_references;
+```
+
+Additive only — no existing table is modified. The old `blog_briefs.reference_url`
+column is left in place during the transition period; it is dropped in a
+follow-up migration (migrate-004) after both US-09 and US-10 merge.
+
+**Tested against**: unit fixture (Supabase test project).
+
+## Affected Tables / Entities
+
+- `blog_references` (new)
+- `blog_briefs` — `reference_url`, `scraped_content`, `scrape_status` columns deprecated
+  (dropped in migrate-004, not this migration)
+
+## Cross-Service Consumers
+
+None at time of writing. Backend API is the sole reader/writer.
+
+**Deploy-order constraint**: Backend migrates before frontend ships the
+multi-URL form. Both ship in the same PR (US-09), so ordering is automatic.
+
+## Estimated Downtime
+
+None — `CREATE TABLE IF NOT EXISTS` is non-blocking on existing tables.
+
+## Data Volume
+
+0 rows at migration time. Up to 5 rows per blog post going forward.
+
+## Testing Plan
+
+- Dev smoke: `npm run db:migrate --workspace=backend`; verify `blog_references`
+  appears in `\dt`.
+- Staging verify: add 2 reference URLs via brief form; confirm 2 rows inserted
+  with correct `blog_id`.
+- Canary: n/a — table is empty, no traffic concern.
+
+## Observability
+
+- Supabase Table Editor: row count on `blog_references`.
+- Backend logs: `[references-repository] saved reference for blogId=<id>`.
+
+## Consequences
+
+- `blog_references` is the authoritative source for all reference URL data
+  from US-09 onward.
+- Alignment service reads from `blog_references` (scrape_status = success)
+  instead of `blog_briefs.scraped_content`.
+- US-10 adds `extraction_status` and `extraction_json` columns to this table
+  (no new migration needed — columns already present).
+
+## Artifacts
+
+- Migration file: `backend/src/db/migrations/migrate-003-blog-references.sql`
+- Technical design: `projects/technical-design-ep05.md`
+- Epic: https://github.com/mohamednaseramein/blog-generator/issues/23
+- Ticket: https://github.com/mohamednaseramein/blog-generator/issues/26

--- a/frontend/src/api/blog-api.ts
+++ b/frontend/src/api/blog-api.ts
@@ -123,3 +123,49 @@ export async function confirmOutline(blogId: string): Promise<{ confirmed: boole
     method: 'POST',
   });
 }
+
+export type ReferenceScrapeStatus = 'pending' | 'success' | 'failed' | 'timeout' | 'skipped';
+
+export interface BlogReference {
+  id: string;
+  blogId: string;
+  url: string;
+  position: number;
+  scrapeStatus: ReferenceScrapeStatus;
+  scrapeError: string | null;
+  scrapedContent: string | null;
+  extractionStatus: string;
+  extractionJson: string | null;
+}
+
+export async function addReference(
+  blogId: string,
+  url: string,
+): Promise<{ reference: BlogReference }> {
+  return request<{ reference: BlogReference }>(`${BASE}/${blogId}/references`, {
+    method: 'POST',
+    body: JSON.stringify({ url }),
+  });
+}
+
+export async function listReferences(blogId: string): Promise<{ references: BlogReference[] }> {
+  return request<{ references: BlogReference[] }>(`${BASE}/${blogId}/references`);
+}
+
+export async function getReferenceStatus(
+  blogId: string,
+  refId: string,
+): Promise<{ scrapeStatus: ReferenceScrapeStatus; scrapeError: string | null }> {
+  return request<{ scrapeStatus: ReferenceScrapeStatus; scrapeError: string | null }>(
+    `${BASE}/${blogId}/references/${refId}/status`,
+  );
+}
+
+export async function removeReference(
+  blogId: string,
+  refId: string,
+): Promise<{ deleted: boolean }> {
+  return request<{ deleted: boolean }>(`${BASE}/${blogId}/references/${refId}`, {
+    method: 'DELETE',
+  });
+}

--- a/frontend/src/components/BlogBriefForm.tsx
+++ b/frontend/src/components/BlogBriefForm.tsx
@@ -2,8 +2,8 @@ import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { getBrief, submitBrief } from '../api/blog-api.js';
-import { ScrapeStatusIndicator } from './ScrapeStatusIndicator.js';
+import { getBrief, submitBrief, listReferences, type BlogReference } from '../api/blog-api.js';
+import { ReferenceUrlList } from './ReferenceUrlList.js';
 import { Button } from './ui/button.js';
 import { Input } from './ui/input.js';
 import { Textarea } from './ui/textarea.js';
@@ -25,14 +25,6 @@ const schema = z
       .int()
       .min(1, 'Must be greater than 0'),
     blogBrief: z.string().min(1, 'Blog brief is required').transform((v) => v.trim()),
-    referenceUrl: z
-      .string()
-      .optional()
-      .transform((v) => v?.trim() ?? '')
-      .refine(
-        (v) => v === '' || /^https?:\/\/.+/.test(v),
-        'Must be a valid URL',
-      ),
   })
   .refine((d) => d.wordCountMax >= d.wordCountMin, {
     message: 'Max must be ≥ min',
@@ -47,10 +39,10 @@ interface Props {
 }
 
 export function BlogBriefForm({ blogId, onSuccess }: Props) {
-  const [submittedBlogId, setSubmittedBlogId] = useState<string | null>(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [loadingBrief, setLoadingBrief] = useState(true);
+  const [existingReferences, setExistingReferences] = useState<BlogReference[]>([]);
 
   const {
     register,
@@ -63,8 +55,9 @@ export function BlogBriefForm({ blogId, onSuccess }: Props) {
     let cancelled = false;
     setLoadingBrief(true);
     setLoadError(null);
-    getBrief(blogId)
-      .then((brief) => {
+
+    Promise.all([getBrief(blogId), listReferences(blogId)])
+      .then(([brief, { references }]) => {
         if (cancelled) return;
         reset({
           title: brief.title,
@@ -74,8 +67,8 @@ export function BlogBriefForm({ blogId, onSuccess }: Props) {
           wordCountMin: brief.wordCountMin,
           wordCountMax: brief.wordCountMax,
           blogBrief: brief.blogBrief,
-          referenceUrl: brief.referenceUrl ?? '',
         });
+        setExistingReferences(references);
       })
       .catch(() => {
         if (!cancelled) setLoadError(null);
@@ -89,11 +82,7 @@ export function BlogBriefForm({ blogId, onSuccess }: Props) {
   async function onSubmit(values: FormValues) {
     setSubmitError(null);
     try {
-      const result = await submitBrief(blogId, {
-        ...values,
-        referenceUrl: values.referenceUrl || undefined,
-      });
-      setSubmittedBlogId(result.blogId);
+      await submitBrief(blogId, values);
       onSuccess();
     } catch (e) {
       setSubmitError((e as Error).message);
@@ -211,20 +200,11 @@ export function BlogBriefForm({ blogId, onSuccess }: Props) {
       </Field>
 
       <Field
-        label="Reference URL"
-        hint="Optional — we'll scrape this page to inform the content."
-        error={errors.referenceUrl?.message}
+        label="Reference URLs"
+        hint="Optional — add up to 5 URLs. We'll scrape each one to inform the content."
       >
-        <Input
-          id="referenceUrl"
-          type="url"
-          placeholder="https://example.com/reference-article"
-          error={!!errors.referenceUrl}
-          {...register('referenceUrl')}
-        />
+        <ReferenceUrlList blogId={blogId} initialReferences={existingReferences} />
       </Field>
-
-      {submittedBlogId && <ScrapeStatusIndicator blogId={submittedBlogId} />}
 
       {submitError && <Toast variant="error">{submitError}</Toast>}
 

--- a/frontend/src/components/ReferenceUrlCard.tsx
+++ b/frontend/src/components/ReferenceUrlCard.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useRef } from 'react';
+import { getReferenceStatus, removeReference, type ReferenceScrapeStatus } from '../api/blog-api.js';
+
+interface Props {
+  blogId: string;
+  refId: string;
+  url: string;
+  initialStatus: ReferenceScrapeStatus;
+  initialError: string | null;
+  onRemove: (refId: string) => void;
+  onStatusChange: (refId: string, status: ReferenceScrapeStatus) => void;
+}
+
+const SETTLED: ReferenceScrapeStatus[] = ['success', 'failed', 'timeout', 'skipped'];
+const POLL_INTERVAL_MS = 2_000;
+
+function StatusBadge({ status, error }: { status: ReferenceScrapeStatus; error: string | null }) {
+  if (status === 'pending') {
+    return (
+      <span className="flex items-center gap-1.5 text-xs text-slate-500">
+        <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-slate-200 border-t-indigo-500" />
+        Scraping…
+      </span>
+    );
+  }
+  if (status === 'success') {
+    return (
+      <span className="text-xs font-medium text-green-600">✓ Scraped</span>
+    );
+  }
+  if (status === 'timeout') {
+    return (
+      <span className="text-xs text-amber-600">
+        ⚠ {error ?? 'Request timed out — the URL may be slow or unreachable.'}
+      </span>
+    );
+  }
+  return (
+    <span className="text-xs text-red-600">
+      ✗ {error ?? 'Could not fetch this URL. Copy relevant content into your Blog Brief instead.'}
+    </span>
+  );
+}
+
+export function ReferenceUrlCard({
+  blogId,
+  refId,
+  url,
+  initialStatus,
+  initialError,
+  onRemove,
+  onStatusChange,
+}: Props) {
+  const statusRef = useRef<ReferenceScrapeStatus>(initialStatus);
+
+  useEffect(() => {
+    if (SETTLED.includes(initialStatus)) return;
+
+    let cancelled = false;
+    const timer = setInterval(() => {
+      if (cancelled) return;
+      getReferenceStatus(blogId, refId)
+        .then(({ scrapeStatus }) => {
+          if (cancelled) return;
+          onStatusChange(refId, scrapeStatus);
+          statusRef.current = scrapeStatus;
+          if (SETTLED.includes(scrapeStatus)) clearInterval(timer);
+        })
+        .catch(() => {
+          if (!cancelled) clearInterval(timer);
+        });
+    }, POLL_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [blogId, refId, initialStatus, onStatusChange]);
+
+  async function handleRemove() {
+    try {
+      await removeReference(blogId, refId);
+    } finally {
+      onRemove(refId);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3">
+      <div className="flex items-start justify-between gap-2">
+        <p className="break-all text-sm text-slate-700">{url}</p>
+        <button
+          type="button"
+          onClick={() => void handleRemove()}
+          className="shrink-0 rounded p-0.5 text-slate-400 hover:bg-slate-200 hover:text-slate-600"
+          aria-label="Remove reference"
+        >
+          ✕
+        </button>
+      </div>
+      <StatusBadge status={initialStatus} error={initialError} />
+    </div>
+  );
+}

--- a/frontend/src/components/ReferenceUrlList.tsx
+++ b/frontend/src/components/ReferenceUrlList.tsx
@@ -1,0 +1,114 @@
+import { useState, useCallback } from 'react';
+import { addReference, type BlogReference, type ReferenceScrapeStatus } from '../api/blog-api.js';
+import { ReferenceUrlCard } from './ReferenceUrlCard.js';
+import { Input } from './ui/input.js';
+
+const MAX_REFERENCES = 5;
+const URL_REGEX = /^https?:\/\/.+/;
+
+interface Props {
+  blogId: string;
+  initialReferences?: BlogReference[];
+}
+
+export function ReferenceUrlList({ blogId, initialReferences = [] }: Props) {
+  const [references, setReferences] = useState<BlogReference[]>(initialReferences);
+  const [inputValue, setInputValue] = useState('');
+  const [inputError, setInputError] = useState<string | null>(null);
+  const [adding, setAdding] = useState(false);
+
+  async function handleAdd() {
+    const url = inputValue.trim();
+    if (!url) return;
+
+    if (!URL_REGEX.test(url)) {
+      setInputError('Must be a valid URL starting with http:// or https://');
+      return;
+    }
+
+    if (references.length >= MAX_REFERENCES) {
+      setInputError(`Maximum ${MAX_REFERENCES} reference URLs allowed`);
+      return;
+    }
+
+    setInputError(null);
+    setAdding(true);
+    try {
+      const { reference } = await addReference(blogId, url);
+      setReferences((prev) => [...prev, reference]);
+      setInputValue('');
+    } catch (e) {
+      setInputError((e as Error).message);
+    } finally {
+      setAdding(false);
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      void handleAdd();
+    }
+  }
+
+  const handleRemove = useCallback((refId: string) => {
+    setReferences((prev) => prev.filter((r) => r.id !== refId));
+  }, []);
+
+  const handleStatusChange = useCallback((refId: string, status: ReferenceScrapeStatus) => {
+    setReferences((prev) =>
+      prev.map((r) => (r.id === refId ? { ...r, scrapeStatus: status } : r)),
+    );
+  }, []);
+
+  return (
+    <div className="flex flex-col gap-3">
+      {references.map((ref) => (
+        <ReferenceUrlCard
+          key={ref.id}
+          blogId={blogId}
+          refId={ref.id}
+          url={ref.url}
+          initialStatus={ref.scrapeStatus}
+          initialError={ref.scrapeError}
+          onRemove={handleRemove}
+          onStatusChange={handleStatusChange}
+        />
+      ))}
+
+      {references.length < MAX_REFERENCES && (
+        <div className="flex flex-col gap-1">
+          <div className="flex gap-2">
+            <Input
+              type="url"
+              placeholder="https://example.com/reference-article"
+              value={inputValue}
+              onChange={(e) => { setInputValue(e.target.value); setInputError(null); }}
+              onKeyDown={handleKeyDown}
+              onBlur={() => { if (inputValue.trim()) void handleAdd(); }}
+              disabled={adding}
+              error={!!inputError}
+              aria-label="Add reference URL"
+            />
+          </div>
+          {inputError && (
+            <p className="text-xs text-red-600">{inputError}</p>
+          )}
+          {adding && (
+            <p className="flex items-center gap-1.5 text-xs text-slate-500">
+              <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-slate-200 border-t-indigo-500" />
+              Adding…
+            </p>
+          )}
+          <p className="text-xs text-slate-400">
+            Press Enter or leave the field to add · {MAX_REFERENCES - references.length} remaining
+          </p>
+        </div>
+      )}
+
+      {references.length >= MAX_REFERENCES && (
+        <p className="text-xs text-slate-400">Maximum of {MAX_REFERENCES} reference URLs reached.</p>
+      )}
+    </div>
+  );
+}

--- a/projects/technical-design-ep05.md
+++ b/projects/technical-design-ep05.md
@@ -1,0 +1,175 @@
+# Technical Design: EP-05 — Smart Reference Intelligence
+
+**Author:** Tech Lead (Rex)
+**Date:** 2026-04-21
+**Status:** Approved
+**Epic:** EP-05
+**Stories:** US-09 (Multi-reference URL support), US-10 (Reference extraction & differentiation angle)
+
+---
+
+## Overview
+
+Replace the single `referenceUrl` text field in the blog brief with a dynamic multi-URL list (max 5). Each URL is scraped automatically on entry. In US-10, a Claude extraction call per URL produces a relevance score, key angle, and 1-sentence summary — displayed inline on the brief form. The alignment step then shows a combined differentiation angle synthesised from all successful extractions.
+
+---
+
+## Domain Model
+
+### New entity: `BlogReference`
+
+```
+BlogReference
+  id                UUID PK
+  blogId            UUID FK → blogs.id
+  url               TEXT NOT NULL
+  scrapeStatus      enum: pending | success | failed | timeout | skipped
+  scrapeError       TEXT nullable       -- human-readable failure reason
+  scrapedContent    TEXT nullable       -- raw extracted text (kept for re-extraction)
+  extractionStatus  enum: pending | success | failed | irrelevant  (US-10)
+  extractionJson    TEXT nullable        -- structured Claude output (US-10)
+  position          SMALLINT NOT NULL    -- order user added URLs (1-based)
+  createdAt         TIMESTAMPTZ
+  updatedAt         TIMESTAMPTZ
+```
+
+### Changes to existing entities
+
+- `blog_briefs`: `reference_url` and `scraped_content` columns **deprecated** in US-09, **dropped** in a follow-up cleanup migration after both stories merge
+- `SubmitBriefInput`: remove `referenceUrl` field
+- `BlogBrief` domain type: remove `referenceUrl`, `scrapedContent`, `scrapeStatus`, `alignmentIterations` stays
+
+---
+
+## Architecture
+
+```
+Brief Form
+  └── ReferenceUrlList component
+        └── on URL blur/enter → POST /api/blogs/:id/references
+              └── saves row (pending) → scrapeReferenceInBackground()
+                    └── updates scrapeStatus → success | failed | timeout
+                    └── (US-10) extractReferenceInBackground()
+                          └── updates extractionStatus + extractionJson
+
+  └── GET /api/blogs/:id/references  (polled every 2s until all settled)
+        └── feeds ReferenceUrlCard status display
+
+Alignment Service
+  └── reads blog_references WHERE blog_id = ? AND scrape_status = 'success'
+  └── (US-10) reads extraction_json, builds differentiation angle prompt
+```
+
+---
+
+## API Design
+
+### POST `/api/blogs/:id/references`
+Add a reference URL and trigger background scrape.
+
+**Request:** `{ url: string }`
+**Response 201:** `{ reference: BlogReferencePublic }`
+**Errors:** 400 invalid URL, 400 max 5 reached, 404 blog not found
+
+### DELETE `/api/blogs/:id/references/:refId`
+Remove a reference (only allowed before brief is submitted / during edit).
+
+**Response 200:** `{ deleted: true }`
+
+### GET `/api/blogs/:id/references`
+List all references with current statuses.
+
+**Response 200:** `{ references: BlogReferencePublic[] }`
+
+### GET `/api/blogs/:id/references/:refId/status`
+Poll single reference scrape + extraction status.
+
+**Response 200:** `{ scrapeStatus, extractionStatus, extractionJson }`
+
+---
+
+## Data Model
+
+### Migration 003 — `blog_references` table
+
+```sql
+CREATE TABLE blog_references (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  blog_id           UUID NOT NULL REFERENCES blogs(id) ON DELETE CASCADE,
+  url               TEXT NOT NULL,
+  position          SMALLINT NOT NULL DEFAULT 1,
+  scrape_status     VARCHAR(20) NOT NULL DEFAULT 'pending'
+                    CHECK (scrape_status IN ('pending','success','failed','timeout','skipped')),
+  scrape_error      TEXT,
+  scraped_content   TEXT,
+  extraction_status VARCHAR(20) NOT NULL DEFAULT 'pending'
+                    CHECK (extraction_status IN ('pending','success','failed','irrelevant')),
+  extraction_json   TEXT,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_blog_references_blog_id ON blog_references(blog_id);
+```
+
+### Migration 004 (cleanup, after US-09 + US-10 merge)
+
+```sql
+ALTER TABLE blog_briefs
+  DROP COLUMN IF EXISTS reference_url,
+  DROP COLUMN IF EXISTS scraped_content,
+  DROP COLUMN IF EXISTS scrape_status;
+```
+
+---
+
+## Implementation Plan
+
+### US-09 — Multi-reference URL Support
+
+| # | Task | Layer |
+|---|---|---|
+| 1 | migrate-003-blog-references.sql | DB |
+| 2 | `BlogReference` domain type + `ScrapeStatus` enum update | Domain |
+| 3 | `blog-references-repository.ts` — insert, list, delete, updateScrapeResult | Repo |
+| 4 | `url-scraper-service.ts` — new `scrapeReferenceInBackground(referenceId, url)` function (keep old one for now) | Service |
+| 5 | `blog-references-handler.ts` — add/remove/list/status handlers | Handler |
+| 6 | Wire routes: POST, DELETE, GET list, GET status | Routes |
+| 7 | Update `blog-brief-handler.ts` — remove `referenceUrl` from input, keep `referenceUrl` on `BlogBrief` type (nullable) for backwards compat during transition | Handler |
+| 8 | Update `alignment-service.ts` — read from `blog_references` WHERE scrape_status = success | Service |
+| 9 | `blog-api.ts` — `addReference`, `removeReference`, `listReferences`, `getReferenceStatus` | Frontend |
+| 10 | `ReferenceUrlCard.tsx` — per-URL card: input + status display | Component |
+| 11 | `ReferenceUrlList.tsx` — manages list state, add/remove, max-5 cap | Component |
+| 12 | Update `BlogBriefForm.tsx` — replace single URL field with `ReferenceUrlList` | Component |
+| 13 | Tests | Tests |
+
+### US-10 — Extraction & Differentiation Angle
+
+| # | Task | Layer |
+|---|---|---|
+| 1 | `reference-extraction-service.ts` — Claude prompt per URL → relevance, key angle, summary | Service |
+| 2 | Fire extraction in background after scrape succeeds | Service |
+| 3 | Update repository — `updateExtractionResult` | Repo |
+| 4 | GET status endpoint returns extraction fields | Handler |
+| 5 | `ReferenceUrlCard.tsx` — enrich with extraction result card (relevance badge, angle, summary) | Component |
+| 6 | Update `alignment-service.ts` — build differentiation angle from extraction_json rows | Service |
+| 7 | Update `AlignmentSummary.tsx` — replace `referenceUnderstanding` card with `differentiationAngle` card | Component |
+| 8 | Tests | Tests |
+
+---
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Scrape timeout leaving UI stuck | Poll with 2s interval, show "Taking longer than expected…" after 10s, error after 15s |
+| Claude extraction cost per URL × 5 URLs | Extraction fires only once per URL, result cached in DB |
+| SSRF on private IPs | `ReferenceUrl` value object already blocks private ranges |
+| Scraped content too large for Claude prompt | Cap `scraped_content` at 10k chars (existing), pass max 2k per URL to extraction prompt |
+| Old `reference_url` column still read by alignment | Keep `getBriefByBlogId` returning it during transition; alignment service switches to `blog_references` immediately |
+
+---
+
+## Open Questions
+
+None — all resolved in pre-build discussion.


### PR DESCRIPTION
## Summary

- Replaces the single `referenceUrl` text field in the blog brief with a dynamic list supporting up to 5 URLs
- Each URL is scraped automatically on entry (blur/Enter) with inline status feedback per card
- Scraper classifies failures with distinct messages: private/403, 404, DNS, timeout
- Alignment service updated to read from the new `blog_references` table instead of the legacy `blog_briefs.scraped_content` column
- Foundation for US-10 (extraction & differentiation angle) which builds on this table

## Changes

### Backend
- **migrate-003-blog-references.sql** — new `blog_references` table with scrape + extraction lifecycle columns (extraction columns ready for US-10)
- **AgDR-0009** — migration decision record
- **technical-design-ep05.md** — full EP-05 technical design document
- **blog-references-repository.ts** — insert, list, get, delete, updateScrapeResult
- **url-scraper-service.ts** — `scrapeReferenceInBackground(referenceId, url)` with per-error-type classification; `SCRAPE_TIMEOUT_MS` env var (default 10s)
- **blog-references-handler.ts** — add/list/status/delete handlers, max-5 cap enforced
- **blog-routes.ts** — 4 new routes wired
- **alignment-service.ts** — reads from `blog_references` (success rows), passes up to 5 reference snippets to Claude prompt
- **blog-alignment-handler.ts** — fetches references, passes to alignment service

### Frontend
- **blog-api.ts** — `addReference`, `listReferences`, `getReferenceStatus`, `removeReference`
- **ReferenceUrlCard.tsx** — per-URL card: auto-polls status every 2s until settled, shows spinner/success/error, remove button
- **ReferenceUrlList.tsx** — dynamic list: add on blur/Enter, max-5 cap, removes via API
- **BlogBriefForm.tsx** — replaces single URL field with `ReferenceUrlList`; loads existing references on edit

## Tests

48 tests passing (6 test files):
- `blog-references-handler.test.ts` — 10 tests (all guard clauses, max-5, scrape trigger)
- `url-scraper-reference.test.ts` — 5 tests (success, timeout, 403, 404, DNS failure)
- existing 33 tests unchanged

## Migration note

Run `npm run db:migrate --workspace=backend` after deploying. The old `blog_briefs.reference_url` column is deprecated but NOT dropped — that happens in migrate-004 after US-10 ships.

## Glossary

- **blog_references** — new table, one row per reference URL per blog post
- **ReferenceUrlCard** — per-URL status card with auto-poll
- **ReferenceUrlList** — dynamic multi-URL input component
- **SCRAPE_TIMEOUT_MS** — env var to configure scrape timeout (default 10 000ms)

Closes https://github.com/mohamednaseramein/blog-generator/issues/24
Closes https://github.com/mohamednaseramein/blog-generator/issues/26
Part of https://github.com/mohamednaseramein/blog-generator/issues/23

Made with [Cursor](https://cursor.com)