### PR TITLE
fix(GH-28): load repo-root .env for migrations + document single-root env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# Copy to .env at this repo root (next to docker-compose.yml).
+# Convention + security: docs/environment-configuration.md
+#
 # Supabase — get these from your Supabase project Settings > API
 SUPABASE_URL=https://your-project-ref.supabase.co
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key   # backend only — never expose to browser

--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@ SUPABASE_ANON_KEY=your-anon-key                   # safe for frontend
 
 # Supabase direct PostgreSQL connection — used by db:migrate only
 # Get from: Supabase Dashboard → Settings → Database → Connection string → URI
+# Put this file at workspace/blog-generator/.env (repo root). db:migrate loads
+# that path even though npm runs the script with cwd=backend/.
 SUPABASE_DB_URL=postgresql://postgres:[password]@db.[ref].supabase.co:5432/postgres
 
 # Backend

--- a/backend/src/db/load-env.ts
+++ b/backend/src/db/load-env.ts
@@ -1,0 +1,16 @@
+import { config } from 'dotenv';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+/**
+ * npm workspace runs scripts with cwd = backend/, but .env usually lives at
+ * blog-generator/.env (repo root). Default `dotenv/config` only reads cwd/.env
+ * and misses SUPABASE_DB_URL etc.
+ */
+export function loadBlogGeneratorEnv(): void {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const backendRoot = resolve(here, '../..');
+  const repoRoot = resolve(backendRoot, '..');
+  config({ path: resolve(repoRoot, '.env') });
+  config({ path: resolve(backendRoot, '.env') });
+}

--- a/backend/src/db/migrate.ts
+++ b/backend/src/db/migrate.ts
@@ -12,7 +12,9 @@ import { readFileSync, readdirSync } from 'fs';
 import pg from 'pg';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
-import 'dotenv/config';
+import { loadBlogGeneratorEnv } from './load-env.js';
+
+loadBlogGeneratorEnv();
 
 const { Client } = pg;
 

--- a/backend/src/db/setup.ts
+++ b/backend/src/db/setup.ts
@@ -6,7 +6,9 @@ import { readFileSync } from 'fs';
 import { createClient } from '@supabase/supabase-js';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
-import 'dotenv/config';
+import { loadBlogGeneratorEnv } from './load-env.js';
+
+loadBlogGeneratorEnv();
 
 const url = process.env['SUPABASE_URL'];
 const key = process.env['SUPABASE_SERVICE_ROLE_KEY'];

--- a/docs/agdr/AgDR-0010-single-root-env-configuration.md
+++ b/docs/agdr/AgDR-0010-single-root-env-configuration.md
@@ -1,0 +1,72 @@
+---
+id: AgDR-0010
+timestamp: 2026-04-22T00:00:00Z
+agent: Claude
+trigger: user-prompt
+status: accepted
+ticket: mohamednaseramein/blog-generator#28
+---
+
+# AgDR-0010 — Single Root `.env` and Explicit Dotenv Loading for CLI
+
+## Context
+
+The blog-generator repo is an npm **workspace** (`backend`, `frontend`) with
+**Docker Compose** at the monorepo root. Environment variables were stored in
+`blog-generator/.env`, but `npm run db:migrate --workspace=backend` runs with
+`process.cwd()` equal to `backend/`. The default `import 'dotenv/config'` only
+loads `backend/.env`, so `SUPABASE_DB_URL` and other root-level variables were
+invisible to `migrate.ts` and `setup.ts`, causing confusing "not set" errors even
+when the file was correct.
+
+We needed a **documented convention** and **reliable loading** for CLI scripts.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **A — Single canonical `.env` at repo root** (chosen) | Matches Docker Compose `env_file: .env`; one place for secrets; no drift between services | npm workspace scripts default cwd=`backend/` — must load parent `.env` explicitly in CLI entrypoints |
+| **B — Split `backend/.env` and `frontend/.env`** | Matches some per-tool defaults (Vite in `frontend/`) | Duplicates shared keys (`SUPABASE_URL`, anon key); easy to update one file and forget the other; Compose still wants a compose-level source |
+| **C — Only root `.env` + symlink `backend/.env` → ../.env** | Tools that only read cwd `.env` work | Symlinks fragile on Windows; opaque for new contributors |
+
+## Decision
+
+**Option A — single canonical `.env` at `workspace/blog-generator/.env`**
+(next to `docker-compose.yml`).
+
+Implementation:
+
+- Add `backend/src/db/load-env.ts` which loads, in order:
+  1. `resolve(repoRoot, '.env')` — canonical file
+  2. `resolve(backendRoot, '.env')` — optional overrides for backend-only local experiments
+- Call `loadBlogGeneratorEnv()` at the top of `migrate.ts` and `setup.ts` before
+  reading `process.env`.
+
+Second file does not override already-set variables (dotenv default), so repo
+root wins for shared keys unless backend `.env` is used only for keys not set
+in root (rare).
+
+## Security and Frontend Build
+
+- **Server-only** variables (`SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_DB_URL`,
+  `JWT_SECRET`, `ANTHROPIC_API_KEY`) must never use the `VITE_` prefix — Vite
+  inlines `VITE_*` into the browser bundle.
+- **Public** client config uses `VITE_*` only (e.g. `VITE_SUPABASE_URL`,
+  `VITE_SUPABASE_ANON_KEY`) as already documented in `.env.example`.
+
+## Consequences
+
+- Developers and CI run `db:migrate` / `db:setup` from repo root with workspace
+  npm scripts without copying `.env` into `backend/`.
+- Docker Compose continues to use root `.env` unchanged.
+- Human-readable convention is documented in `docs/environment-configuration.md`.
+- Optional `backend/.env` remains supported for local-only overrides without
+  committing it.
+
+## Artifacts
+
+- `backend/src/db/load-env.ts`
+- `backend/src/db/migrate.ts`, `backend/src/db/setup.ts` — call loader
+- `.env.example` — note on root placement
+- `docs/environment-configuration.md`
+- Tracker: https://github.com/mohamednaseramein/blog-generator/issues/28

--- a/docs/environment-configuration.md
+++ b/docs/environment-configuration.md
@@ -1,0 +1,55 @@
+# Environment configuration (blog-generator)
+
+This document is the **source of truth** for where environment variables live and how they are loaded. It implements the decision in [AgDR-0010 — Single root `.env`](./agdr/AgDR-0010-single-root-env-configuration.md).
+
+## Canonical location
+
+Use **one `.env` file at the repository root**:
+
+`workspace/blog-generator/.env` — same directory as `docker-compose.yml`.
+
+That file is **gitignored**. Copy from `.env.example` and fill in real values.
+
+## Why not `backend/.env` only?
+
+- **Docker Compose** injects variables from the root `.env` via `env_file: .env`.
+- **npm workspace** runs package scripts (e.g. `db:migrate`) with `cwd` set to
+  `backend/`. Plain `dotenv/config` only reads `backend/.env`, so root secrets
+  would be missed. The backend CLI tools `migrate.ts` and `setup.ts` call
+  `loadBlogGeneratorEnv()` to load the **parent** `.env` first, then optional
+  `backend/.env` for local overrides.
+
+## Variable categories
+
+| Category | Examples | Where used |
+|----------|-----------|------------|
+| Supabase HTTP API | `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY` | Backend (server) |
+| Direct Postgres (migrations) | `SUPABASE_DB_URL` | `npm run db:migrate` only |
+| Browser-safe (Vite) | `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY` | Frontend build / runtime |
+| Server secrets | `JWT_SECRET`, `ANTHROPIC_API_KEY` | Backend only |
+
+**Never** prefix server-only or database credentials with `VITE_` — Vite embeds
+those names into the client bundle.
+
+## Local development
+
+From repo root:
+
+```bash
+cp .env.example .env
+# edit .env
+
+npm run db:migrate --workspace=backend
+npm run dev   # or docker compose up --build
+```
+
+## Docker
+
+Compose reads root `.env` automatically for variable substitution and
+`env_file` on services. No separate compose env file is required for the default
+layout.
+
+## Related documents
+
+- [AgDR-0010 — Single root `.env`](./agdr/AgDR-0010-single-root-env-configuration.md)
+- [AgDR-0004 — Docker containerisation](./agdr/AgDR-0004-docker-containerisation.md)


### PR DESCRIPTION
## Summary

- Fixes `db:migrate` / `db:setup` not seeing `SUPABASE_DB_URL` when vars live in repo-root `.env` (npm workspace cwd=`backend/`).
- Documents the **single canonical `.env`** convention per SDLC (AgDR + guide).

## Changes

- `backend/src/db/load-env.ts` — loads `blog-generator/.env` then optional `backend/.env`
- `migrate.ts` / `setup.ts` — call loader before reading env
- **AgDR-0010** — technical decision (options, security, consequences)
- **`docs/environment-configuration.md`** — developer source of truth
- `.env.example` — pointer to the guide

## Glossary

- **Canonical `.env`** — the one file at repo root next to `docker-compose.yml`
- **loadBlogGeneratorEnv** — explicit dotenv bootstrap for CLI tools
- **VITE_*** — only browser-safe variables; never service role or DB URL

Closes https://github.com/mohamednaseramein/blog-generator/issues/28

Made with [Cursor](https://cursor.com)