### PR TITLE
feat(GH-31): brief form empty state for new blogs before first save

### DIFF
--- a/frontend/src/components/BlogBriefForm.js
+++ b/frontend/src/components/BlogBriefForm.js
@@ -1,10 +1,10 @@
 import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { submitBrief } from '../api/blog-api.js';
-import { ScrapeStatusIndicator } from './ScrapeStatusIndicator.js';
+import { getBrief, submitBrief, listReferences } from '../api/blog-api.js';
+import { ReferenceUrlList } from './ReferenceUrlList.js';
 import { Button } from './ui/button.js';
 import { Input } from './ui/input.js';
 import { Textarea } from './ui/textarea.js';
@@ -25,33 +25,89 @@ const schema = z
         .int()
         .min(1, 'Must be greater than 0'),
     blogBrief: z.string().min(1, 'Blog brief is required').transform((v) => v.trim()),
-    referenceUrl: z
-        .string()
-        .optional()
-        .transform((v) => v?.trim() ?? '')
-        .refine((v) => v === '' || /^https?:\/\/.+/.test(v), 'Must be a valid URL'),
 })
     .refine((d) => d.wordCountMax >= d.wordCountMin, {
     message: 'Max must be ≥ min',
     path: ['wordCountMax'],
 });
+/** New blogs have no `blog_briefs` row yet — GET /brief returns 404 with this message. */
+function isBriefNotFoundError(e) {
+    return e instanceof Error && e.message === 'Brief not found';
+}
+const EMPTY_BRIEF_FORM = {
+    title: '',
+    primaryKeyword: '',
+    audiencePersona: '',
+    toneOfVoice: '',
+    wordCountMin: 800,
+    wordCountMax: 1500,
+    blogBrief: '',
+};
 export function BlogBriefForm({ blogId, onSuccess }) {
-    const [submittedBlogId, setSubmittedBlogId] = useState(null);
     const [submitError, setSubmitError] = useState(null);
-    const { register, handleSubmit, formState: { errors, isSubmitting }, } = useForm({ resolver: zodResolver(schema) });
+    const [loadError, setLoadError] = useState(null);
+    const [loadingBrief, setLoadingBrief] = useState(true);
+    const [existingReferences, setExistingReferences] = useState([]);
+    const { register, handleSubmit, reset, formState: { errors, isSubmitting }, } = useForm({ resolver: zodResolver(schema) });
+    useEffect(() => {
+        let cancelled = false;
+        setLoadingBrief(true);
+        setLoadError(null);
+        void (async () => {
+            try {
+                const { references } = await listReferences(blogId);
+                if (cancelled)
+                    return;
+                setExistingReferences(references);
+                try {
+                    const brief = await getBrief(blogId);
+                    if (cancelled)
+                        return;
+                    reset({
+                        title: brief.title,
+                        primaryKeyword: brief.primaryKeyword,
+                        audiencePersona: brief.audiencePersona,
+                        toneOfVoice: brief.toneOfVoice,
+                        wordCountMin: brief.wordCountMin,
+                        wordCountMax: brief.wordCountMax,
+                        blogBrief: brief.blogBrief,
+                    });
+                }
+                catch (e) {
+                    if (cancelled)
+                        return;
+                    if (isBriefNotFoundError(e)) {
+                        reset(EMPTY_BRIEF_FORM);
+                    }
+                    else {
+                        throw e;
+                    }
+                }
+            }
+            catch (e) {
+                if (!cancelled) {
+                    setLoadError(e.message ?? 'Could not load your brief. Try refreshing the page.');
+                }
+            }
+            finally {
+                if (!cancelled)
+                    setLoadingBrief(false);
+            }
+        })();
+        return () => { cancelled = true; };
+    }, [blogId, reset]);
     async function onSubmit(values) {
         setSubmitError(null);
         try {
-            const result = await submitBrief(blogId, {
-                ...values,
-                referenceUrl: values.referenceUrl || undefined,
-            });
-            setSubmittedBlogId(result.blogId);
+            await submitBrief(blogId, values);
             onSuccess();
         }
         catch (e) {
             setSubmitError(e.message);
         }
     }
-    return (_jsxs("form", { onSubmit: handleSubmit(onSubmit), noValidate: true, "aria-label": "Blog brief form", className: "flex flex-col gap-6", children: [_jsxs("div", { className: "grid gap-6 sm:grid-cols-2", children: [_jsx(Field, { label: "Blog Title", error: errors.title?.message, required: true, children: _jsx(Input, { id: "title", type: "text", placeholder: "e.g. 10 Tips for Better Sleep", "aria-required": "true", error: !!errors.title, ...register('title') }) }), _jsx(Field, { label: "Primary Keyword", error: errors.primaryKeyword?.message, required: true, children: _jsx(Input, { id: "primaryKeyword", type: "text", placeholder: "e.g. sleep hygiene", "aria-required": "true", error: !!errors.primaryKeyword, ...register('primaryKeyword') }) })] }), _jsx(Field, { label: "Audience Persona", hint: "Describe who will read this post.", error: errors.audiencePersona?.message, required: true, children: _jsx(Textarea, { id: "audiencePersona", rows: 3, placeholder: "e.g. Busy professionals aged 30\u201345 looking for practical wellness advice", "aria-required": "true", error: !!errors.audiencePersona, ...register('audiencePersona') }) }), _jsx(Field, { label: "Tone of Voice", error: errors.toneOfVoice?.message, required: true, children: _jsx(Input, { id: "toneOfVoice", type: "text", placeholder: "e.g. Friendly, expert, conversational", "aria-required": "true", error: !!errors.toneOfVoice, ...register('toneOfVoice') }) }), _jsxs("div", { className: "grid gap-6 sm:grid-cols-2", children: [_jsx(Field, { label: "Word Count Min", error: errors.wordCountMin?.message, required: true, children: _jsx(Input, { id: "wordCountMin", type: "number", min: 1, placeholder: "800", "aria-required": "true", error: !!errors.wordCountMin, ...register('wordCountMin', { valueAsNumber: true }) }) }), _jsx(Field, { label: "Word Count Max", error: errors.wordCountMax?.message, required: true, children: _jsx(Input, { id: "wordCountMax", type: "number", min: 1, placeholder: "1500", "aria-required": "true", error: !!errors.wordCountMax, ...register('wordCountMax', { valueAsNumber: true }) }) })] }), _jsx(Field, { label: "Blog Brief", hint: "Summarise the key points, angle, and any must-include information.", error: errors.blogBrief?.message, required: true, children: _jsx(Textarea, { id: "blogBrief", rows: 6, placeholder: "Describe the blog post you want to create\u2026", "aria-required": "true", error: !!errors.blogBrief, ...register('blogBrief') }) }), _jsx(Field, { label: "Reference URL", hint: "Optional \u2014 we'll scrape this page to inform the content.", error: errors.referenceUrl?.message, children: _jsx(Input, { id: "referenceUrl", type: "url", placeholder: "https://example.com/reference-article", error: !!errors.referenceUrl, ...register('referenceUrl') }) }), submittedBlogId && _jsx(ScrapeStatusIndicator, { blogId: submittedBlogId }), submitError && _jsx(Toast, { variant: "error", children: submitError }), _jsx("div", { className: "flex justify-end pt-2", children: _jsx(Button, { type: "submit", disabled: isSubmitting, "aria-busy": isSubmitting, children: isSubmitting ? (_jsxs("span", { className: "flex items-center gap-2", children: [_jsx("span", { className: "inline-block h-3.5 w-3.5 animate-spin rounded-full border-2 border-white/40 border-t-white" }), "Saving\u2026"] })) : ('Save & Continue →') }) })] }));
+    if (loadingBrief) {
+        return (_jsxs("div", { className: "flex flex-col items-center gap-3 py-12 text-slate-500", role: "status", "aria-label": "Loading saved brief", children: [_jsx("span", { className: "inline-block h-6 w-6 animate-spin rounded-full border-2 border-slate-200 border-t-indigo-500" }), _jsx("p", { className: "text-sm", children: "Loading your saved inputs\u2026" })] }));
+    }
+    return (_jsxs("form", { onSubmit: handleSubmit(onSubmit), noValidate: true, "aria-label": "Blog brief form", className: "flex flex-col gap-6", children: [loadError && _jsx(Toast, { variant: "error", children: loadError }), _jsxs("div", { className: "grid gap-6 sm:grid-cols-2", children: [_jsx(Field, { label: "Blog Title", error: errors.title?.message, required: true, children: _jsx(Input, { id: "title", type: "text", placeholder: "e.g. 10 Tips for Better Sleep", "aria-required": "true", error: !!errors.title, ...register('title') }) }), _jsx(Field, { label: "Primary Keyword", error: errors.primaryKeyword?.message, required: true, children: _jsx(Input, { id: "primaryKeyword", type: "text", placeholder: "e.g. sleep hygiene", "aria-required": "true", error: !!errors.primaryKeyword, ...register('primaryKeyword') }) })] }), _jsx(Field, { label: "Audience Persona", hint: "Describe who will read this post.", error: errors.audiencePersona?.message, required: true, children: _jsx(Textarea, { id: "audiencePersona", rows: 3, placeholder: "e.g. Busy professionals aged 30\u201345 looking for practical wellness advice", "aria-required": "true", error: !!errors.audiencePersona, ...register('audiencePersona') }) }), _jsx(Field, { label: "Tone of Voice", error: errors.toneOfVoice?.message, required: true, children: _jsx(Input, { id: "toneOfVoice", type: "text", placeholder: "e.g. Friendly, expert, conversational", "aria-required": "true", error: !!errors.toneOfVoice, ...register('toneOfVoice') }) }), _jsxs("div", { className: "grid gap-6 sm:grid-cols-2", children: [_jsx(Field, { label: "Word Count Min", error: errors.wordCountMin?.message, required: true, children: _jsx(Input, { id: "wordCountMin", type: "number", min: 1, placeholder: "800", "aria-required": "true", error: !!errors.wordCountMin, ...register('wordCountMin', { valueAsNumber: true }) }) }), _jsx(Field, { label: "Word Count Max", error: errors.wordCountMax?.message, required: true, children: _jsx(Input, { id: "wordCountMax", type: "number", min: 1, placeholder: "1500", "aria-required": "true", error: !!errors.wordCountMax, ...register('wordCountMax', { valueAsNumber: true }) }) })] }), _jsx(Field, { label: "Blog Brief", hint: "Summarise the key points, angle, and any must-include information.", error: errors.blogBrief?.message, required: true, children: _jsx(Textarea, { id: "blogBrief", rows: 6, placeholder: "Describe the blog post you want to create\u2026", "aria-required": "true", error: !!errors.blogBrief, ...register('blogBrief') }) }), _jsx(Field, { label: "Reference URLs", hint: "Optional \u2014 add up to 5 URLs. We'll scrape each one to inform the content.", children: _jsx(ReferenceUrlList, { blogId: blogId, initialReferences: existingReferences }) }), submitError && _jsx(Toast, { variant: "error", children: submitError }), _jsx("div", { className: "flex justify-end pt-2", children: _jsx(Button, { type: "submit", disabled: isSubmitting, "aria-busy": isSubmitting, children: isSubmitting ? (_jsxs("span", { className: "flex items-center gap-2", children: [_jsx("span", { className: "inline-block h-3.5 w-3.5 animate-spin rounded-full border-2 border-white/40 border-t-white" }), "Saving\u2026"] })) : ('Save & Continue →') }) })] }));
 }

--- a/frontend/src/components/BlogBriefForm.tsx
+++ b/frontend/src/components/BlogBriefForm.tsx
@@ -33,6 +33,21 @@ const schema = z
 
 type FormValues = z.input<typeof schema>;
 
+/** New blogs have no `blog_briefs` row yet — GET /brief returns 404 with this message. */
+function isBriefNotFoundError(e: unknown): boolean {
+  return e instanceof Error && e.message === 'Brief not found';
+}
+
+const EMPTY_BRIEF_FORM: FormValues = {
+  title: '',
+  primaryKeyword: '',
+  audiencePersona: '',
+  toneOfVoice: '',
+  wordCountMin: 800,
+  wordCountMax: 1500,
+  blogBrief: '',
+};
+
 interface Props {
   blogId: string;
   onSuccess: () => void;
@@ -56,26 +71,41 @@ export function BlogBriefForm({ blogId, onSuccess }: Props) {
     setLoadingBrief(true);
     setLoadError(null);
 
-    Promise.all([getBrief(blogId), listReferences(blogId)])
-      .then(([brief, { references }]) => {
+    void (async () => {
+      try {
+        const { references } = await listReferences(blogId);
         if (cancelled) return;
-        reset({
-          title: brief.title,
-          primaryKeyword: brief.primaryKeyword,
-          audiencePersona: brief.audiencePersona,
-          toneOfVoice: brief.toneOfVoice,
-          wordCountMin: brief.wordCountMin,
-          wordCountMax: brief.wordCountMax,
-          blogBrief: brief.blogBrief,
-        });
         setExistingReferences(references);
-      })
-      .catch(() => {
-        if (!cancelled) setLoadError(null);
-      })
-      .finally(() => {
+
+        try {
+          const brief = await getBrief(blogId);
+          if (cancelled) return;
+          reset({
+            title: brief.title,
+            primaryKeyword: brief.primaryKeyword,
+            audiencePersona: brief.audiencePersona,
+            toneOfVoice: brief.toneOfVoice,
+            wordCountMin: brief.wordCountMin,
+            wordCountMax: brief.wordCountMax,
+            blogBrief: brief.blogBrief,
+          });
+        } catch (e) {
+          if (cancelled) return;
+          if (isBriefNotFoundError(e)) {
+            reset(EMPTY_BRIEF_FORM);
+          } else {
+            throw e;
+          }
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setLoadError((e as Error).message ?? 'Could not load your brief. Try refreshing the page.');
+        }
+      } finally {
         if (!cancelled) setLoadingBrief(false);
-      });
+      }
+    })();
+
     return () => { cancelled = true; };
   }, [blogId, reset]);
 


### PR DESCRIPTION
## Summary

New blogs have no `blog_briefs` row until the first successful brief save. `GET /brief` returns 404 `Brief not found`, which is expected. The form loads references first, treats that response as an empty draft (defaults 800–1500 words), and only sets `loadError` for real failures.

## Glossary

- **blog_briefs**: Row created on first brief submit; absent for a freshly created blog.
- **EMPTY_BRIEF_FORM**: Client-side defaults when no saved brief exists yet.

Closes https://github.com/mohamednaseramein/blog-generator/issues/31

Made with [Cursor](https://cursor.com)