### PR TITLE
fix(#42): persist current_step; correct Continue resume and My blogs badge

### DIFF
--- a/backend/src/handlers/__tests__/blog-draft-handler.test.ts
+++ b/backend/src/handlers/__tests__/blog-draft-handler.test.ts
@@ -10,6 +10,7 @@ const {
   mockGenerateBlogDraft,
   mockGenerateMetaAndSlug,
   mockGetUserId,
+  mockAdvanceBlogStep,
 } = vi.hoisted(() => ({
   mockGetBlogByIdAndUser: vi.fn(),
   mockGetBriefByBlogId: vi.fn(),
@@ -20,10 +21,12 @@ const {
   mockGenerateBlogDraft: vi.fn(),
   mockGenerateMetaAndSlug: vi.fn(),
   mockGetUserId: vi.fn(() => 'user-1'),
+  mockAdvanceBlogStep: vi.fn(),
 }));
 
 vi.mock('../../repositories/blog-repository.js', () => ({
   getBlogByIdAndUser: mockGetBlogByIdAndUser,
+  advanceBlogStep: mockAdvanceBlogStep,
 }));
 
 vi.mock('../../repositories/blog-brief-repository.js', () => ({
@@ -180,6 +183,7 @@ describe('handleConfirmDraft', () => {
       metaDescription: 'A meta description.',
       suggestedSlug: 'sleep-tips',
     });
+    expect(mockAdvanceBlogStep).toHaveBeenCalledWith('blog-1', 5);
     expect(next).not.toHaveBeenCalled();
   });
 

--- a/backend/src/handlers/__tests__/blog-outline-handler.test.ts
+++ b/backend/src/handlers/__tests__/blog-outline-handler.test.ts
@@ -8,6 +8,7 @@ const {
   mockConfirmOutline,
   mockGenerateBlogOutline,
   mockGetUserId,
+  mockAdvanceBlogStep,
 } = vi.hoisted(() => ({
   mockGetBlogByIdAndUser: vi.fn(),
   mockGetBriefByBlogId: vi.fn(),
@@ -16,10 +17,12 @@ const {
   mockConfirmOutline: vi.fn(),
   mockGenerateBlogOutline: vi.fn(),
   mockGetUserId: vi.fn(() => 'user-1'),
+  mockAdvanceBlogStep: vi.fn(),
 }));
 
 vi.mock('../../repositories/blog-repository.js', () => ({
   getBlogByIdAndUser: mockGetBlogByIdAndUser,
+  advanceBlogStep: mockAdvanceBlogStep,
 }));
 
 vi.mock('../../repositories/blog-brief-repository.js', () => ({
@@ -168,6 +171,7 @@ describe('handleConfirmOutline', () => {
     await handleConfirmOutline(req, res, next);
 
     expect(json).toHaveBeenCalledWith({ confirmed: true, blogId: 'blog-1' });
+    expect(mockAdvanceBlogStep).toHaveBeenCalledWith('blog-1', 4);
     expect(next).not.toHaveBeenCalled();
   });
 

--- a/backend/src/handlers/blog-alignment-handler.ts
+++ b/backend/src/handlers/blog-alignment-handler.ts
@@ -1,5 +1,5 @@
 import type { Request, Response, NextFunction } from 'express';
-import { getBlogByIdAndUser } from '../repositories/blog-repository.js';
+import { getBlogByIdAndUser, advanceBlogStep } from '../repositories/blog-repository.js';
 import {
   getBriefByBlogId,
   updateAlignmentSummary,
@@ -58,6 +58,7 @@ export async function handleConfirmAlignment(
     if (!brief.alignmentSummary) throw new AppError(400, 'BAD_REQUEST', 'Generate an alignment summary first');
 
     await confirmAlignment(blogId, brief.alignmentSummary);
+    await advanceBlogStep(blogId, 3);
 
     res.json({ confirmed: true, blogId });
   } catch (err) {

--- a/backend/src/handlers/blog-brief-handler.ts
+++ b/backend/src/handlers/blog-brief-handler.ts
@@ -1,5 +1,5 @@
 import type { Request, Response, NextFunction } from 'express';
-import { getBlogByIdAndUser } from '../repositories/blog-repository.js';
+import { getBlogByIdAndUser, advanceBlogStep } from '../repositories/blog-repository.js';
 import {
   upsertBrief,
   getBriefByBlogId,
@@ -41,6 +41,9 @@ export async function handleSubmitBrief(
     if (input.referenceUrl) {
       scrapeUrlInBackground(blogId, input.referenceUrl);
     }
+
+    // After a saved brief, the user proceeds to alignment (step 2 in the wizard).
+    await advanceBlogStep(blogId, 2);
 
     res.status(201).json({ blogId: brief.blogId, scrapeStatus: brief.scrapeStatus });
   } catch (err) {

--- a/backend/src/handlers/blog-draft-handler.ts
+++ b/backend/src/handlers/blog-draft-handler.ts
@@ -1,5 +1,5 @@
 import type { Request, Response, NextFunction } from 'express';
-import { getBlogByIdAndUser } from '../repositories/blog-repository.js';
+import { getBlogByIdAndUser, advanceBlogStep } from '../repositories/blog-repository.js';
 import { getBriefByBlogId } from '../repositories/blog-brief-repository.js';
 import { getOutlineByBlogId } from '../repositories/blog-outline-repository.js';
 import {
@@ -99,6 +99,7 @@ export async function handleConfirmDraft(
     );
 
     await confirmDraft(blogId, metaDescription, suggestedSlug);
+    await advanceBlogStep(blogId, 5);
 
     res.json({ confirmed: true, blogId, metaDescription, suggestedSlug });
   } catch (err) {

--- a/backend/src/handlers/blog-handler.ts
+++ b/backend/src/handlers/blog-handler.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, NextFunction } from 'express';
-import { createBlog, listBlogsByUser } from '../repositories/blog-repository.js';
+import { createBlog, getBlogByIdAndUser, listBlogsByUser, advanceBlogStep } from '../repositories/blog-repository.js';
+import { AppError } from '../middleware/error-handler.js';
 import { getUserId } from '../middleware/auth.js';
 
 export async function handleListBlogs(
@@ -25,6 +26,23 @@ export async function handleCreateBlog(
     const userId = getUserId(req as Request & { userId?: string });
     const blog = await createBlog(userId);
     res.status(201).json({ blogId: blog.id, currentStep: blog.currentStep });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function handleCompleteBlog(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const userId = getUserId(req);
+    const blogId = req.params['id'] as string;
+    const blog = await getBlogByIdAndUser(blogId, userId);
+    if (!blog) throw new AppError(404, 'NOT_FOUND', 'Blog not found');
+    await advanceBlogStep(blogId, 6);
+    res.json({ blogId, currentStep: 6 });
   } catch (err) {
     next(err);
   }

--- a/backend/src/handlers/blog-outline-handler.ts
+++ b/backend/src/handlers/blog-outline-handler.ts
@@ -1,5 +1,5 @@
 import type { Request, Response, NextFunction } from 'express';
-import { getBlogByIdAndUser } from '../repositories/blog-repository.js';
+import { getBlogByIdAndUser, advanceBlogStep } from '../repositories/blog-repository.js';
 import { getBriefByBlogId } from '../repositories/blog-brief-repository.js';
 import {
   getOutlineByBlogId,
@@ -66,6 +66,7 @@ export async function handleConfirmOutline(
     if (!outline) throw new AppError(400, 'BAD_REQUEST', 'Generate an outline first');
 
     await confirmOutline(blogId);
+    await advanceBlogStep(blogId, 4);
 
     res.json({ confirmed: true, blogId });
   } catch (err) {

--- a/backend/src/repositories/blog-repository.ts
+++ b/backend/src/repositories/blog-repository.ts
@@ -58,7 +58,7 @@ export interface BlogSummary {
 
 export async function listBlogsByUser(userId: string): Promise<BlogSummary[]> {
   // Inner join: only blogs with a saved brief. Excludes "abandoned" creates (no blog_briefs row)
-  // without relying on current_step, which can remain 0 if advanceBlogStep is not run (see GH-42).
+  // without relying on current_step for filtering (see GH-42).
   const { data, error } = await getSupabase()
     .from('blogs')
     .select('id, current_step, status, updated_at, blog_briefs!inner(title)')
@@ -88,9 +88,10 @@ export async function listBlogsByUser(userId: string): Promise<BlogSummary[]> {
 }
 
 export async function advanceBlogStep(id: string, step: number): Promise<void> {
+  const status: Blog['status'] = step >= 6 ? 'completed' : 'in_progress';
   const { error } = await getSupabase()
     .from('blogs')
-    .update({ current_step: step, status: 'in_progress', updated_at: new Date().toISOString() })
+    .update({ current_step: step, status, updated_at: new Date().toISOString() })
     .eq('id', id);
 
   if (error) throw new Error(error.message);

--- a/backend/src/routes/blog-routes.ts
+++ b/backend/src/routes/blog-routes.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { requireAuth } from '../middleware/auth.js';
-import { handleCreateBlog, handleListBlogs } from '../handlers/blog-handler.js';
+import { handleCreateBlog, handleCompleteBlog, handleListBlogs } from '../handlers/blog-handler.js';
 import {
   handleSubmitBrief,
   handleGetBrief,
@@ -32,6 +32,7 @@ const router = Router();
 
 router.get('/', requireAuth, handleListBlogs);
 router.post('/', requireAuth, handleCreateBlog);
+router.post('/:id/complete', requireAuth, handleCompleteBlog);
 router.post('/:id/brief', requireAuth, handleSubmitBrief);
 router.get('/:id/brief', requireAuth, handleGetBrief);
 router.get('/:id/brief/scrape-status', requireAuth, handleGetScrapeStatus);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -47,7 +47,9 @@ export function App() {
   }
 
   function resumeBlog(blogId: string, currentStep: number) {
-    const step = STEP_TO_APP[currentStep] ?? 'brief';
+    // DB default is 0; legacy rows may never have had advanceBlogStep. Treat 0 as "brief" (1).
+    const s = currentStep < 1 ? 1 : currentStep;
+    const step = STEP_TO_APP[s] ?? 'brief';
     if (step === 'idle' || step === 'history' || step === 'creating') return;
     setState({ step, blogId });
   }

--- a/frontend/src/api/blog-api.ts
+++ b/frontend/src/api/blog-api.ts
@@ -60,6 +60,12 @@ export async function createBlog(): Promise<{ blogId: string }> {
   return request<{ blogId: string }>(BASE, { method: 'POST' });
 }
 
+export async function completeBlog(blogId: string): Promise<{ blogId: string; currentStep: number }> {
+  return request<{ blogId: string; currentStep: number }>(`${BASE}/${blogId}/complete`, {
+    method: 'POST',
+  });
+}
+
 export async function submitBrief(
   blogId: string,
   payload: SubmitBriefPayload,

--- a/frontend/src/components/BlogHistory.tsx
+++ b/frontend/src/components/BlogHistory.tsx
@@ -83,7 +83,8 @@ export function BlogHistory({ onResume, onNew }: Props) {
       {!loading && blogs.length > 0 && (
         <ul className="flex flex-col gap-3">
           {blogs.map((blog) => {
-            const done = blog.currentStep >= 6;
+            const stepForUi = blog.currentStep < 1 ? 1 : blog.currentStep;
+            const done = stepForUi >= 6;
             const date = new Date(blog.updatedAt).toLocaleString(undefined, {
               month: 'short',
               day: 'numeric',
@@ -103,14 +104,14 @@ export function BlogHistory({ onResume, onNew }: Props) {
                     {title}
                   </span>
                   <div className="flex items-center gap-2">
-                    <StepBadge step={blog.currentStep} done={done} />
+                    <StepBadge step={stepForUi} done={done} />
                     <span className="text-xs text-slate-400">{date}</span>
                   </div>
                 </div>
                 <Button
                   size="sm"
                   variant={done ? 'ghost' : undefined}
-                  onClick={() => onResume(blog.id, blog.currentStep)}
+                  onClick={() => onResume(blog.id, stepForUi)}
                 >
                   {done ? 'View' : 'Continue →'}
                 </Button>

--- a/frontend/src/components/PublishStep.tsx
+++ b/frontend/src/components/PublishStep.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { getDraft, getBrief, recordExportEvent } from '../api/blog-api.js';
+import { getDraft, getBrief, recordExportEvent, completeBlog } from '../api/blog-api.js';
 import type { ExportSection } from '../api/blog-api.js';
 import { Button } from './ui/button.js';
 import { Toast } from './ui/toast.js';
@@ -247,7 +247,21 @@ export function PublishStep({ blogId, onBack, onFinish }: Props) {
         <Button variant="ghost" size="sm" onClick={onBack} disabled={loading}>
           ← Back to Draft
         </Button>
-        <Button variant="ghost" size="sm" onClick={onFinish}>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => {
+            void (async () => {
+              try {
+                await completeBlog(blogId);
+              } catch {
+                // still leave the wizard; completion is best-effort
+              } finally {
+                onFinish();
+              }
+            })();
+          }}
+        >
           Finish →
         </Button>
       </div>


### PR DESCRIPTION
## Summary
Closes #42. `current_step` stayed at 0 because `advanceBlogStep` was never called, so **Continue** always opened Blog Brief and the list showed **Not started**.

## Changes
- **Backend:** Call `advanceBlogStep` after brief save (→2), confirm alignment (3), outline (4), draft (5). Step 6 sets `status: completed`.
- **API:** `POST /api/blogs/:id/complete` for Publish **Finish**.
- **Frontend:** `completeBlog` on Finish; legacy `current_step === 0` coerced to 1 for badge/resume. Handler tests updated.

## Testing
- `cd backend && npm run build && npm test`
- `cd frontend && npm run typecheck`

## Glossary
| Term | Definition |
|------|------------|
| `current_step` | Wizard position stored on `blogs` (1–6): brief → … → done. |
| `advanceBlogStep` | Repository helper that updates `current_step` and `status` (completed at step 6). |

Made with [Cursor](https://cursor.com)