### PR TITLE
chore(#52): move .env and .env.example from root to backend/

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,4 @@
-# Copy to .env at this repo root (next to docker-compose.yml).
+# Copy to backend/.env (next to this file).
 # Convention + security: docs/environment-configuration.md
 #
 # Supabase — get these from your Supabase project Settings > API
@@ -8,8 +8,6 @@ SUPABASE_ANON_KEY=your-anon-key                   # safe for frontend
 
 # Supabase direct PostgreSQL connection — used by db:migrate only
 # Get from: Supabase Dashboard → Settings → Database → Connection string → URI
-# Put this file at workspace/blog-generator/.env (repo root). db:migrate loads
-# that path even though npm runs the script with cwd=backend/.
 SUPABASE_DB_URL=postgresql://postgres:[password]@db.[ref].supabase.co:5432/postgres
 
 # Backend

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,6 @@
 # Copy to backend/.env (next to this file).
-# Convention + security: docs/environment-configuration.md
+# Run docker compose as: docker compose --env-file backend/.env up
+# Convention + security: docs/environment-configuration.md (AgDR-0017)
 #
 # Supabase — get these from your Supabase project Settings > API
 SUPABASE_URL=https://your-project-ref.supabase.co

--- a/backend/src/db/load-env.ts
+++ b/backend/src/db/load-env.ts
@@ -2,15 +2,8 @@ import { config } from 'dotenv';
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 
-/**
- * npm workspace runs scripts with cwd = backend/, but .env usually lives at
- * blog-generator/.env (repo root). Default `dotenv/config` only reads cwd/.env
- * and misses SUPABASE_DB_URL etc.
- */
 export function loadBlogGeneratorEnv(): void {
   const here = dirname(fileURLToPath(import.meta.url));
   const backendRoot = resolve(here, '../..');
-  const repoRoot = resolve(backendRoot, '..');
-  config({ path: resolve(repoRoot, '.env') });
   config({ path: resolve(backendRoot, '.env') });
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       dockerfile: backend/Dockerfile
-    env_file: .env
+    env_file: backend/.env
     ports:
       - "3000:3000"
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,6 @@
+# Usage: docker compose --env-file backend/.env up
+# The --env-file flag is required for compose-level ${VAR} substitution
+# (frontend build args). env_file at service level only injects into containers.
 services:
   backend:
     build:

--- a/docs/agdr/AgDR-0010-single-root-env-configuration.md
+++ b/docs/agdr/AgDR-0010-single-root-env-configuration.md
@@ -3,7 +3,7 @@ id: AgDR-0010
 timestamp: 2026-04-22T00:00:00Z
 agent: Claude
 trigger: user-prompt
-status: accepted
+status: superseded-by AgDR-0017
 ticket: mohamednaseramein/blog-generator#28
 ---
 

--- a/docs/agdr/AgDR-0017-backend-env-colocation.md
+++ b/docs/agdr/AgDR-0017-backend-env-colocation.md
@@ -1,0 +1,41 @@
+# AgDR-0017 — Move .env to backend/ (supersedes AgDR-0010)
+
+> In the context of env file organisation, facing the need to co-locate secrets with the service that uses them, I decided to move `.env` to `backend/` and use `docker compose --env-file backend/.env` for compose-level variable substitution, accepting that developers must pass the `--env-file` flag when running `docker compose up`.
+
+## Context
+
+AgDR-0010 chose a single root `.env` primarily because Docker Compose auto-loads `.env` from the project root, enabling `${VAR}` interpolation in `docker-compose.yml` without any extra flags. The backend-specific `load-env.ts` was added to walk up to the root from `backend/` cwd.
+
+Two issues motivated revisiting this:
+
+1. **Discoverability** — all backend secrets live next to `docker-compose.yml`, not next to the backend code that consumes them. New contributors look in `backend/` first.
+2. **Vite `.env.example` precedent** — adding `frontend/.env.example` in PR #51 established per-workspace env files as the project convention. Keeping the backend file at the root is now inconsistent.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **A — Root `.env`** (AgDR-0010) | Compose auto-interpolation; no flag needed | Secrets not co-located with backend; inconsistent with frontend/.env.example |
+| **B — `backend/.env` + `--env-file` flag** (chosen) | Co-located with backend code; consistent with frontend convention; one canonical file | Compose users must pass `--env-file backend/.env`; documented in compose file and env.example |
+| **C — Symlink `backend/.env → ../.env`** | Satisfies both locations | Fragile on Windows, opaque to contributors (rejected in AgDR-0010) |
+
+## Decision
+
+**Option B** — `backend/.env` is the canonical file.
+
+- `docker-compose.yml` backend service: `env_file: backend/.env` (runtime injection)
+- Compose-level `${VAR}` interpolation for frontend build args: pass `--env-file backend/.env` to `docker compose`; documented via a comment at the top of `docker-compose.yml` and in `backend/.env.example`
+- `load-env.ts` simplified to load `backendRoot/.env` only (no repo-root walk-up)
+
+## Consequences
+
+- `docker compose up` must be run as `docker compose --env-file backend/.env up` — documented in the compose file header comment
+- `docs/environment-configuration.md` updated to reflect new location
+- AgDR-0010 status: **superseded** by this record
+
+## Artifacts
+
+- Ticket: https://github.com/mohamednaseramein/blog-generator/issues/52
+- `backend/.env.example`
+- `docker-compose.yml`
+- `backend/src/db/load-env.ts`

--- a/docs/environment-configuration.md
+++ b/docs/environment-configuration.md
@@ -1,23 +1,14 @@
 # Environment configuration (blog-generator)
 
-This document is the **source of truth** for where environment variables live and how they are loaded. It implements the decision in [AgDR-0010 — Single root `.env`](./agdr/AgDR-0010-single-root-env-configuration.md).
+This document is the **source of truth** for where environment variables live and how they are loaded. It implements the decision in [AgDR-0017 — Move .env to backend/](./agdr/AgDR-0017-backend-env-colocation.md) (supersedes AgDR-0010).
 
 ## Canonical location
 
-Use **one `.env` file at the repository root**:
+Use **one `.env` file in `backend/`**:
 
-`workspace/blog-generator/.env` — same directory as `docker-compose.yml`.
+`workspace/blog-generator/backend/.env` — co-located with the backend code that consumes it.
 
-That file is **gitignored**. Copy from `.env.example` and fill in real values.
-
-## Why not `backend/.env` only?
-
-- **Docker Compose** injects variables from the root `.env` via `env_file: .env`.
-- **npm workspace** runs package scripts (e.g. `db:migrate`) with `cwd` set to
-  `backend/`. Plain `dotenv/config` only reads `backend/.env`, so root secrets
-  would be missed. The backend CLI tools `migrate.ts` and `setup.ts` call
-  `loadBlogGeneratorEnv()` to load the **parent** `.env` first, then optional
-  `backend/.env` for local overrides.
+That file is **gitignored**. Copy from `backend/.env.example` and fill in real values.
 
 ## Variable categories
 
@@ -25,7 +16,7 @@ That file is **gitignored**. Copy from `.env.example` and fill in real values.
 |----------|-----------|------------|
 | Supabase HTTP API | `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY` | Backend (server) |
 | Direct Postgres (migrations) | `SUPABASE_DB_URL` | `npm run db:migrate` only |
-| Browser-safe (Vite) | `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY` | Frontend build / runtime |
+| Browser-safe (Vite build args) | `SUPABASE_URL`, `SUPABASE_ANON_KEY` | Injected into frontend build via docker compose |
 | Server secrets | `JWT_SECRET`, `ANTHROPIC_API_KEY` | Backend only |
 
 **Never** prefix server-only or database credentials with `VITE_` — Vite embeds
@@ -33,23 +24,27 @@ those names into the client bundle.
 
 ## Local development
 
-From repo root:
-
 ```bash
-cp .env.example .env
-# edit .env
+cp backend/.env.example backend/.env
+# edit backend/.env
 
 npm run db:migrate --workspace=backend
-npm run dev   # or docker compose up --build
+npm run dev
 ```
 
 ## Docker
 
-Compose reads root `.env` automatically for variable substitution and
-`env_file` on services. No separate compose env file is required for the default
-layout.
+Docker Compose `env_file` at the service level injects runtime variables into
+the container, but **does not** affect compose-level `${VAR}` substitution used
+in `build.args`. Pass `--env-file backend/.env` so compose can resolve the
+frontend build args:
+
+```bash
+docker compose --env-file backend/.env up --build
+```
 
 ## Related documents
 
-- [AgDR-0010 — Single root `.env`](./agdr/AgDR-0010-single-root-env-configuration.md)
+- [AgDR-0017 — Move .env to backend/](./agdr/AgDR-0017-backend-env-colocation.md)
+- [AgDR-0010 — Single root `.env` (superseded)](./agdr/AgDR-0010-single-root-env-configuration.md)
 - [AgDR-0004 — Docker containerisation](./agdr/AgDR-0004-docker-containerisation.md)


### PR DESCRIPTION
## Summary

- `git mv .env.example → backend/.env.example` — env template now lives beside the code that uses it
- `docker-compose.yml`: `env_file: .env` → `env_file: backend/.env`
- `load-env.ts`: drop the repo-root fallback path; load `backend/.env` directly (the fallback was only needed when the file lived at root)
- Updated `.env.example` header comment to reflect new location

## Test plan

- [ ] `docker compose up` resolves env vars from `backend/.env`
- [ ] `npm run dev --workspace=backend` starts without env-var errors
- [ ] Migration script (`npm run db:migrate --workspace=backend`) loads `SUPABASE_DB_URL` correctly

## Glossary

| Term | Definition |
|------|------------|
| `env_file` | docker-compose directive that loads variables from a file into the service's environment before container start |
| `dotenv config({ path })` | Explicit path override for dotenv; without it, dotenv reads only from `process.cwd()/.env` |

Refs #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)