### PR TITLE
fix(GH-4): widen primary_keyword past VARCHAR(255) + validate brief limits

### DIFF
--- a/backend/src/db/migrations/migrate-007-blog-briefs-primary-keyword-text.sql
+++ b/backend/src/db/migrations/migrate-007-blog-briefs-primary-keyword-text.sql
@@ -1,0 +1,8 @@
+-- primary_keyword: SEO phrases and multi-term keywords can exceed VARCHAR(255).
+-- tone_of_voice: allow richer descriptions (was 100).
+-- Fixes: value too long for type character varying(255) on blog_briefs upsert.
+ALTER TABLE blog_briefs
+  ALTER COLUMN primary_keyword TYPE TEXT;
+
+ALTER TABLE blog_briefs
+  ALTER COLUMN tone_of_voice TYPE VARCHAR(200);

--- a/backend/src/domain/value-objects.ts
+++ b/backend/src/domain/value-objects.ts
@@ -44,6 +44,14 @@ export class ReferenceUrl {
   }
 }
 
+/** Aligned with blog_briefs column limits / TEXT fields — enforce at API to avoid DoS. */
+export const BRIEF_FIELD_LIMITS = {
+  title: 500,
+  /** DB: TEXT; keep a cap for request size. */
+  primaryKeyword: 4_000,
+  toneOfVoice: 200,
+} as const;
+
 export function trimInput(value: string): string {
   return value.trim();
 }

--- a/backend/src/handlers/blog-brief-handler.ts
+++ b/backend/src/handlers/blog-brief-handler.ts
@@ -7,7 +7,7 @@ import {
 } from '../repositories/blog-brief-repository.js';
 import { scrapeUrlInBackground } from '../services/url-scraper-service.js';
 import { requeueReferenceExtractionsForBlog } from '../services/reference-extraction-runner.js';
-import { WordCountRange, ReferenceUrl, trimInput } from '../domain/value-objects.js';
+import { BRIEF_FIELD_LIMITS, WordCountRange, ReferenceUrl, trimInput } from '../domain/value-objects.js';
 import { AppError } from '../middleware/error-handler.js';
 import { getUserId } from '../middleware/auth.js';
 import type { SubmitBriefInput } from '../domain/types.js';
@@ -129,6 +129,23 @@ function validateBriefBody(body: Record<string, unknown>): string[] {
     } catch (e) {
       errors.push((e as Error).message);
     }
+  }
+
+  const title = trimInput(String(body['title']));
+  const primaryKeyword = trimInput(String(body['primaryKeyword']));
+  const tone = trimInput(String(body['toneOfVoice']));
+  if (title.length > BRIEF_FIELD_LIMITS.title) {
+    errors.push(`title must be at most ${BRIEF_FIELD_LIMITS.title} characters`);
+  }
+  if (primaryKeyword.length > BRIEF_FIELD_LIMITS.primaryKeyword) {
+    errors.push(
+      `primaryKeyword must be at most ${BRIEF_FIELD_LIMITS.primaryKeyword} characters`,
+    );
+  }
+  if (tone.length > BRIEF_FIELD_LIMITS.toneOfVoice) {
+    errors.push(
+      `toneOfVoice must be at most ${BRIEF_FIELD_LIMITS.toneOfVoice} characters`,
+    );
   }
 
   return errors;

--- a/frontend/src/components/BlogBriefForm.tsx
+++ b/frontend/src/components/BlogBriefForm.tsx
@@ -2,6 +2,10 @@ import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
+
+const PRIMARY_KEYWORD_MAX = 4_000;
+const TITLE_MAX = 500;
+const TONE_MAX = 200;
 import { getBrief, submitBrief, listReferences, type BlogReference } from '../api/blog-api.js';
 import { ReferenceUrlList } from './ReferenceUrlList.js';
 import { Button } from './ui/button.js';
@@ -12,10 +16,22 @@ import { Toast } from './ui/toast.js';
 
 const schema = z
   .object({
-    title: z.string().min(1, 'Title is required').transform((v) => v.trim()),
-    primaryKeyword: z.string().min(1, 'Primary keyword is required').transform((v) => v.trim()),
+    title: z
+      .string()
+      .min(1, 'Title is required')
+      .max(TITLE_MAX, `At most ${TITLE_MAX} characters`)
+      .transform((v) => v.trim()),
+    primaryKeyword: z
+      .string()
+      .min(1, 'Primary keyword is required')
+      .max(PRIMARY_KEYWORD_MAX, `At most ${PRIMARY_KEYWORD_MAX} characters`)
+      .transform((v) => v.trim()),
     audiencePersona: z.string().min(1, 'Audience persona is required').transform((v) => v.trim()),
-    toneOfVoice: z.string().min(1, 'Tone of voice is required').transform((v) => v.trim()),
+    toneOfVoice: z
+      .string()
+      .min(1, 'Tone of voice is required')
+      .max(TONE_MAX, `At most ${TONE_MAX} characters`)
+      .transform((v) => v.trim()),
     wordCountMin: z
       .number({ invalid_type_error: 'Must be a number' })
       .int()


### PR DESCRIPTION
## Summary
- **DB:** `migrate-007` — `blog_briefs.primary_keyword` → `TEXT`; `tone_of_voice` → `VARCHAR(200)`.
- **API:** `BRIEF_FIELD_LIMITS` + validation in `blog-brief-handler` before upsert.
- **UI:** Zod `max` on `BlogBriefForm` for title, primary keyword, tone.

Fixes Postgres error: `value too long for type character varying(255)` when saving a long primary keyword / SEO phrase.

**Ops context:** [apexyar#4](https://github.com/mohamednaseramein/apexyar/issues/4) · project issue [#54](https://github.com/mohamednaseramein/blog-generator/issues/54)

## Deploy
Run `npm run db:migrate --workspace=backend` (requires `SUPABASE_DB_URL`) after deploy.

## Test plan
- [x] `npm run typecheck` (backend + frontend)
- [x] `npm test --workspace=backend`

## Glossary
| Term | Definition |
|------|------------|
| `TEXT` | Postgres type with no 255-char limit (unlike `VARCHAR(255)`) |
| `BRIEF_FIELD_LIMITS` | Central max lengths for brief fields enforced at API edge |

Closes #54

Made with [Cursor](https://cursor.com)