### PR TITLE
fix(GH-5): hint migrate-007 when blog brief upsert hits varchar(255)

### DIFF
--- a/backend/src/repositories/blog-brief-repository.ts
+++ b/backend/src/repositories/blog-brief-repository.ts
@@ -77,7 +77,16 @@ export async function upsertBrief(
     .select()
     .single<BlogBriefRow>();
 
-  if (error) throw new Error(error.message);
+  if (error) {
+    if (error.message.includes('varying(255)')) {
+      throw new Error(
+        `${error.message} — The database is missing migration migrate-007 (primary_keyword should be TEXT). ` +
+          `Run: npm run db:migrate --workspace=backend (requires SUPABASE_DB_URL). ` +
+          'Docker: backend CMD runs migrate.js on start; rebuild image if migrations/ are old.',
+      );
+    }
+    throw new Error(error.message);
+  }
   return toModel(data);
 }
 


### PR DESCRIPTION
## Summary
When Postgres still has `primary_keyword` as `VARCHAR(255)` (migration **migrate-007** not applied), the brief upsert error is unchanged but now appends a short **operator hint** to the thrown `Error` message so Docker/server logs point to:
- `npm run db:migrate --workspace=backend`
- Or rebuild the backend image (CMD runs `migrate.js` on start).

**Root fix remains:** run migrate-007 on the Supabase DB (already shipped in [PR #55](https://github.com/mohamednaseramein/blog-generator/pull/55) `migrate-007-blog-briefs-primary-keyword-text.sql`).

## Test plan
- [x] `npm run typecheck --workspace=backend`
- [x] `npm test --workspace=backend`

## Glossary
| Term | Use |
|------|-----|
| migrate-007 | Alters `blog_briefs.primary_keyword` to `TEXT` |

Ref [apexyar#5](https://github.com/mohamednaseramein/apexyar/issues/5)

Made with [Cursor](https://cursor.com)