### PR TITLE
ci(#59): EC2 deploy, env validation, and deploy checks

### DIFF
--- a/.github/workflows/deploy-ec2.yml
+++ b/.github/workflows/deploy-ec2.yml
@@ -1,0 +1,65 @@
+# Deploys Docker Compose stack on EC2 after merges to main.
+# Secrets: SSH_HOST, SSH_USER, SSH_PRIVATE_KEY (required); DEPLOY_PATH (optional).
+# Docs: docs/deployment.md
+name: Deploy to EC2
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: deploy-ec2-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: SSH deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy over SSH
+        uses: appleboy/ssh-action@v1.2.3
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script_stop: true
+          command_timeout: 45m
+          script: |
+            set -e
+            DEPLOY_PATH="${{ secrets.DEPLOY_PATH }}"
+            if [ -z "$DEPLOY_PATH" ]; then
+              DEPLOY_PATH="${HOME}/blog-generator"
+            fi
+            echo "[deploy] Using DEPLOY_PATH=${DEPLOY_PATH}"
+            cd "$DEPLOY_PATH"
+            echo "[deploy] Syncing git to origin/main"
+            git fetch origin main
+            git checkout -B main origin/main
+            echo "[deploy] HEAD=$(git rev-parse --short HEAD) branch=$(git branch --show-current)"
+            if [ -x scripts/verify-deploy-env.sh ]; then
+              scripts/verify-deploy-env.sh .
+            else
+              echo "[deploy] WARN: scripts/verify-deploy-env.sh missing or not executable — skipping env verification"
+            fi
+            export APP_VERSION="$(grep -m1 '"version"' package.json | sed 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')"
+            export GIT_SHA="$(git rev-parse --short HEAD 2>/dev/null || echo "")"
+            echo "[deploy] APP_VERSION=${APP_VERSION} GIT_SHA=${GIT_SHA}"
+            dc() {
+              if docker compose version >/dev/null 2>&1; then
+                docker compose "$@"
+              elif command -v docker-compose >/dev/null 2>&1; then
+                docker-compose "$@"
+              else
+                echo "Neither 'docker compose' nor 'docker-compose' is available." >&2
+                return 1
+              fi
+            }
+            echo "[deploy] docker compose down"
+            dc --env-file backend/.env down
+            echo "[deploy] docker compose build --no-cache"
+            dc --env-file backend/.env build --no-cache
+            echo "[deploy] docker compose up -d"
+            dc --env-file backend/.env up -d
+            echo "[deploy] docker compose ps"
+            dc --env-file backend/.env ps
+            echo "[deploy] Finished successfully"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to this project are documented in this file. The format is b
 
 ## [Unreleased]
 
-- (nothing yet)
+### Added
+
+- **CI/CD** — GitHub Actions workflow [`.github/workflows/deploy-ec2.yml`](.github/workflows/deploy-ec2.yml) deploys Docker Compose on EC2 after pushes to `main`; documented in [`docs/deployment.md`](docs/deployment.md) (README and release docs updated).
+- **Config** — API startup validates `backend`/container env (URLs, JWT-shaped Supabase keys, Anthropic `sk-ant-` in production, JWT length, optional `SUPABASE_DB_URL` / `SCRAPE_TIMEOUT_MS` / `ANTHROPIC_MODEL`) and logs a masked `[config]` summary; see [`backend/src/config/env.ts`](backend/src/config/env.ts). Deploy runs [`scripts/verify-deploy-env.sh`](scripts/verify-deploy-env.sh) on the host before Compose.
 
 ## [0.1.0] — 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project are documented in this file. The format is b
 ### Added
 
 - **CI/CD** — GitHub Actions workflow [`.github/workflows/deploy-ec2.yml`](.github/workflows/deploy-ec2.yml) deploys Docker Compose on EC2 after pushes to `main`; documented in [`docs/deployment.md`](docs/deployment.md) (README and release docs updated).
-- **Config** — API startup validates `backend`/container env (URLs, JWT-shaped Supabase keys, Anthropic `sk-ant-` in production, JWT length, optional `SUPABASE_DB_URL` / `SCRAPE_TIMEOUT_MS` / `ANTHROPIC_MODEL`) and logs a masked `[config]` summary; see [`backend/src/config/env.ts`](backend/src/config/env.ts). Deploy runs [`scripts/verify-deploy-env.sh`](scripts/verify-deploy-env.sh) on the host before Compose.
+- **Config** — API startup validates `backend`/container env (URLs, JWT-shaped Supabase keys, Anthropic `sk-ant-` in production, JWT length, optional `SUPABASE_DB_URL` / `SCRAPE_TIMEOUT_MS` / `ANTHROPIC_MODEL`) and logs a masked `[config]` summary; see [`backend/src/config/env.ts`](backend/src/config/env.ts). Deploy runs [`scripts/verify-deploy-env.sh`](scripts/verify-deploy-env.sh) on the host before Compose. **AgDR** — [`docs/agdr/AgDR-0018-github-actions-ec2-deploy.md`](docs/agdr/AgDR-0018-github-actions-ec2-deploy.md).
 
 ## [0.1.0] — 2026-04-24
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ AI-guided wizard for producing fully-structured blog posts — step by step, wit
 | Database | Supabase (hosted PostgreSQL + JS client) |
 | AI | Anthropic Claude API |
 | Container | Docker Compose (backend + frontend) |
+| CI/CD | GitHub Actions — deploy to EC2 on push to `main` ([docs/deployment.md](docs/deployment.md)) |
 | Testing | Vitest (unit/integration) + Playwright (E2E) |
 
 **Versioning** — the product semver lives in the root `package.json`. Sync workspaces with `npm run version:sync`, then commit; release process and SDLC map are in [docs/releases.md](docs/releases.md) and [CHANGELOG.md](CHANGELOG.md).
@@ -113,6 +114,16 @@ docker compose down
 ```
 
 > **Note:** The database is Supabase cloud — Docker Compose runs only the backend and frontend containers.
+
+---
+
+## Production deploy (GitHub Actions → EC2)
+
+Merges to **`main`** run [.github/workflows/deploy-ec2.yml](.github/workflows/deploy-ec2.yml), which SSHs into the server, syncs the repo to `origin/main`, runs [scripts/verify-deploy-env.sh](scripts/verify-deploy-env.sh) (format checks, no secret values in logs), and rebuilds containers with Docker Compose.
+
+- **Secrets** (`SSH_HOST`, `SSH_USER`, `SSH_PRIVATE_KEY`, optional `DEPLOY_PATH`) — see [docs/deployment.md](docs/deployment.md).
+- **Server setup** — git clone, `backend/.env`, Docker, and `git fetch` access to GitHub are required on the instance.
+- **Runtime** — the API logs a masked `[config]` summary at startup when environment validation passes ([docs/environment-configuration.md](docs/environment-configuration.md)).
 
 ---
 
@@ -278,11 +289,13 @@ blog-generator/
 │       │   └── ScrapeStatusIndicator.tsx
 │       ├── App.tsx
 │       └── main.tsx
-├── docs/agdr/
-│   ├── AgDR-0001-project-structure.md
-│   ├── AgDR-0002-url-scraping-approach.md
-│   ├── AgDR-0003-supabase-database-client.md
-│   └── AgDR-0004-docker-containerisation.md
+├── docs/
+│   ├── deployment.md              # EC2 + GitHub Actions production deploy
+│   └── agdr/
+│       ├── AgDR-0001-project-structure.md
+│       ├── AgDR-0002-url-scraping-approach.md
+│       ├── AgDR-0003-supabase-database-client.md
+│       └── AgDR-0004-docker-containerisation.md
 ├── docker-compose.yml
 ├── .dockerignore
 ├── .env.example

--- a/backend/src/config/__tests__/env.test.ts
+++ b/backend/src/config/__tests__/env.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const validEnv = () => ({
+  NODE_ENV: 'development',
+  PORT: '3000',
+  SUPABASE_URL: 'https://abc123.supabase.co',
+  SUPABASE_SERVICE_ROLE_KEY: `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.${'x'.repeat(120)}`,
+  SUPABASE_ANON_KEY: `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.${'y'.repeat(120)}`,
+  ANTHROPIC_API_KEY: 'sk-ant-api03-test-key-xxxxxxxxxxxxxxxx',
+  JWT_SECRET: '0123456789abcdef0123456789abcdef',
+  FRONTEND_URL: 'http://localhost:5173',
+});
+
+describe('validateAndLogRuntimeEnv', () => {
+  const original = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...original };
+  });
+
+  afterEach(() => {
+    process.env = original;
+  });
+
+  async function loadValidate() {
+    const { validateAndLogRuntimeEnv } = await import('../env.js');
+    return validateAndLogRuntimeEnv;
+  }
+
+  it('passes with valid development env', async () => {
+    Object.assign(process.env, validEnv());
+    const validate = await loadValidate();
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const cfg = validate();
+    expect(cfg.port).toBe(3000);
+    expect(cfg.frontendUrl).toBe('http://localhost:5173');
+    expect(cfg.nodeEnv).toBe('development');
+    expect(log.mock.calls.some((c) => String(c[0]).includes('Environment OK'))).toBe(true);
+    log.mockRestore();
+  });
+
+  it('rejects placeholder Supabase URL', async () => {
+    Object.assign(process.env, validEnv(), {
+      SUPABASE_URL: 'https://your-project-ref.supabase.co',
+    });
+    const validate = await loadValidate();
+    expect(() => validate()).toThrow(/placeholder|your-project-ref/i);
+  });
+
+  it('rejects invalid PORT', async () => {
+    Object.assign(process.env, validEnv(), { PORT: '99999' });
+    const validate = await loadValidate();
+    expect(() => validate()).toThrow(/PORT/);
+  });
+
+  it('rejects short JWT_SECRET', async () => {
+    Object.assign(process.env, validEnv(), { JWT_SECRET: 'short' });
+    const validate = await loadValidate();
+    expect(() => validate()).toThrow(/32/);
+  });
+
+  it('requires sk-ant- prefix for Anthropic key in production', async () => {
+    Object.assign(process.env, validEnv(), {
+      NODE_ENV: 'production',
+      ANTHROPIC_API_KEY: 'not-a-real-anthropic-key-xxxxxxxx',
+    });
+    const validate = await loadValidate();
+    expect(() => validate()).toThrow(/sk-ant-/);
+  });
+
+  it('rejects invalid SCRAPE_TIMEOUT_MS', async () => {
+    Object.assign(process.env, validEnv(), { SCRAPE_TIMEOUT_MS: '50' });
+    const validate = await loadValidate();
+    expect(() => validate()).toThrow(/SCRAPE_TIMEOUT_MS/);
+  });
+
+  it('warns when SUPABASE_ANON_KEY is missing in development', async () => {
+    const base = { ...validEnv() };
+    delete base['SUPABASE_ANON_KEY'];
+    Object.assign(process.env, base, { NODE_ENV: 'development' });
+    const validate = await loadValidate();
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    validate();
+    expect(warn.mock.calls.some((c) => String(c[0]).includes('SUPABASE_ANON_KEY'))).toBe(true);
+    log.mockRestore();
+    warn.mockRestore();
+  });
+
+  it('rejects missing SUPABASE_ANON_KEY in production', async () => {
+    const base = { ...validEnv() };
+    delete base['SUPABASE_ANON_KEY'];
+    Object.assign(process.env, base, { NODE_ENV: 'production' });
+    const validate = await loadValidate();
+    expect(() => validate()).toThrow(/SUPABASE_ANON_KEY/);
+  });
+});

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -1,0 +1,257 @@
+/**
+ * Validates process env at API startup and logs a non-secret summary.
+ * Fails fast with clear errors when values are missing or look like placeholders.
+ */
+
+const LOG_PREFIX = '[config]';
+
+const EXAMPLE_JWT_SECRET = 'a-long-random-secret-min-32-chars';
+
+function looksLikePlaceholder(name: string, raw: string): string | null {
+  const v = raw.trim();
+  const lower = v.toLowerCase();
+  if (v.length === 0) return `${name} is empty`;
+  if (lower.includes('your-key-here')) return `${name} still contains example text (your-key-here)`;
+  if (lower.includes('your-service-role-key')) return `${name} still contains example text`;
+  if (lower.includes('your-anon-key')) return `${name} still contains example text`;
+  if (lower.includes('your-project-ref')) return `${name} still contains example text (your-project-ref)`;
+  if (v === EXAMPLE_JWT_SECRET) return `${name} must not use the example JWT_SECRET from .env.example`;
+  if (lower === 'sk-ant-your-key-here') return `${name} must not use the example Anthropic key`;
+  return null;
+}
+
+function maskSecret(value: string, visibleStart = 8, visibleEnd = 4): string {
+  const t = value.trim();
+  if (t.length <= visibleStart + visibleEnd) return '(set)';
+  return `${t.slice(0, visibleStart)}…${t.slice(-visibleEnd)} (${t.length} chars)`;
+}
+
+function parsePort(raw: string | undefined): { port: number; error?: string } {
+  if (raw === undefined || raw.trim() === '') return { port: 3000 };
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isInteger(n) || n < 1 || n > 65535) {
+    return { port: NaN, error: `PORT must be an integer 1–65535, got ${JSON.stringify(raw)}` };
+  }
+  return { port: n };
+}
+
+function parseHttpUrl(raw: string | undefined, name: string, allowHttpLocalhost: boolean): { url: string; error?: string } {
+  if (!raw?.trim()) return { url: '', error: `${name} is required` };
+  const v = raw.trim();
+  const ph = looksLikePlaceholder(name, v);
+  if (ph) return { url: '', error: ph };
+  let u: URL;
+  try {
+    u = new URL(v);
+  } catch {
+    return { url: '', error: `${name} must be a valid URL, got ${JSON.stringify(v.slice(0, 80))}` };
+  }
+  const okHttps = u.protocol === 'https:';
+  const okLocalHttp =
+    allowHttpLocalhost &&
+    u.protocol === 'http:' &&
+    (u.hostname === 'localhost' || u.hostname === '127.0.0.1' || u.hostname === '[::1]');
+  if (!okHttps && !okLocalHttp) {
+    return {
+      url: '',
+      error: `${name} must use https:// (or http:// for localhost only), got protocol ${u.protocol}`,
+    };
+  }
+  return { url: v };
+}
+
+function validateAnthropicKey(raw: string | undefined, nodeEnv: string): { error?: string } {
+  if (!raw?.trim()) return { error: 'ANTHROPIC_API_KEY is required' };
+  const v = raw.trim();
+  const ph = looksLikePlaceholder('ANTHROPIC_API_KEY', v);
+  if (ph) return { error: ph };
+  if (nodeEnv === 'production' && !v.startsWith('sk-ant-')) {
+    return { error: 'ANTHROPIC_API_KEY must start with sk-ant- in production' };
+  }
+  if (v.length < 10) return { error: 'ANTHROPIC_API_KEY is too short' };
+  return {};
+}
+
+function validateJwtSecret(raw: string | undefined): { error?: string } {
+  if (!raw?.trim()) return { error: 'JWT_SECRET is required' };
+  const v = raw.trim();
+  const ph = looksLikePlaceholder('JWT_SECRET', v);
+  if (ph) return { error: ph };
+  if (v.length < 32) return { error: 'JWT_SECRET must be at least 32 characters' };
+  return {};
+}
+
+function validateSupabaseServiceKey(raw: string | undefined): { error?: string } {
+  if (!raw?.trim()) return { error: 'SUPABASE_SERVICE_ROLE_KEY is required' };
+  const v = raw.trim();
+  const ph = looksLikePlaceholder('SUPABASE_SERVICE_ROLE_KEY', v);
+  if (ph) return { error: ph };
+  if (!v.startsWith('eyJ')) {
+    return { error: 'SUPABASE_SERVICE_ROLE_KEY should be a JWT (starts with eyJ)' };
+  }
+  if (v.length < 80) return { error: 'SUPABASE_SERVICE_ROLE_KEY looks too short' };
+  return {};
+}
+
+function validateSupabaseAnonKey(
+  raw: string | undefined,
+  nodeEnv: string,
+): { error?: string; warn?: string } {
+  if (!raw?.trim()) {
+    if (nodeEnv === 'production') {
+      return {
+        error:
+          'SUPABASE_ANON_KEY is required in production (and in backend/.env for Docker Compose frontend build args)',
+      };
+    }
+    return {
+      warn: 'SUPABASE_ANON_KEY is unset — add it before Docker Compose builds; required in production',
+    };
+  }
+  const v = raw.trim();
+  const ph = looksLikePlaceholder('SUPABASE_ANON_KEY', v);
+  if (ph) return { error: ph };
+  if (!v.startsWith('eyJ')) {
+    return { error: 'SUPABASE_ANON_KEY should be a JWT (starts with eyJ)' };
+  }
+  if (v.length < 80) return { error: 'SUPABASE_ANON_KEY looks too short' };
+  return {};
+}
+
+function validateDbUrl(raw: string | undefined): { error?: string } {
+  if (raw === undefined || raw.trim() === '') return {};
+  const v = raw.trim();
+  const ph = looksLikePlaceholder('SUPABASE_DB_URL', v);
+  if (ph) return { error: ph };
+  if (!/^postgres(ql)?:\/\//i.test(v)) {
+    return { error: 'SUPABASE_DB_URL must start with postgresql:// or postgres://' };
+  }
+  return {};
+}
+
+function validateScrapeTimeout(raw: string | undefined): { error?: string } {
+  if (raw === undefined || raw.trim() === '') return {};
+  const n = Number.parseInt(raw.trim(), 10);
+  if (!Number.isInteger(n) || n < 1_000 || n > 120_000) {
+    return { error: 'SCRAPE_TIMEOUT_MS must be an integer between 1000 and 120000 when set' };
+  }
+  return {};
+}
+
+function validateAnthropicModel(raw: string | undefined): { error?: string } {
+  if (raw === undefined || raw.trim() === '') return {};
+  const v = raw.trim();
+  if (/[\r\n]/.test(v)) return { error: 'ANTHROPIC_MODEL must be a single line' };
+  if (v.length > 120) return { error: 'ANTHROPIC_MODEL is too long' };
+  return {};
+}
+
+export interface ValidatedPublicConfig {
+  port: number;
+  frontendUrl: string;
+  nodeEnv: string;
+}
+
+/**
+ * Validates environment, logs masked summary to stdout, returns public config for Express.
+ * @throws Error if validation fails
+ */
+export function validateAndLogRuntimeEnv(): ValidatedPublicConfig {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  const nodeEnv = (process.env['NODE_ENV'] ?? 'development').trim() || 'development';
+
+  const { port, error: portErr } = parsePort(process.env['PORT']);
+  if (portErr) errors.push(portErr);
+
+  const { url: supabaseUrl, error: supabaseUrlErr } = parseHttpUrl(
+    process.env['SUPABASE_URL'],
+    'SUPABASE_URL',
+    true,
+  );
+  if (supabaseUrlErr) errors.push(supabaseUrlErr);
+
+  errors.push(
+    ...[validateSupabaseServiceKey(process.env['SUPABASE_SERVICE_ROLE_KEY'])]
+      .map((r) => r.error)
+      .filter((e): e is string => Boolean(e)),
+  );
+
+  const anonResult = validateSupabaseAnonKey(process.env['SUPABASE_ANON_KEY'], nodeEnv);
+  if (anonResult.error) errors.push(anonResult.error);
+  if (anonResult.warn) warnings.push(anonResult.warn);
+
+  errors.push(
+    ...[validateAnthropicKey(process.env['ANTHROPIC_API_KEY'], nodeEnv)]
+      .map((r) => r.error)
+      .filter((e): e is string => Boolean(e)),
+  );
+
+  errors.push(
+    ...[validateJwtSecret(process.env['JWT_SECRET'])]
+      .map((r) => r.error)
+      .filter((e): e is string => Boolean(e)),
+  );
+
+  errors.push(
+    ...[validateDbUrl(process.env['SUPABASE_DB_URL'])]
+      .map((r) => r.error)
+      .filter((e): e is string => Boolean(e)),
+  );
+
+  errors.push(
+    ...[validateScrapeTimeout(process.env['SCRAPE_TIMEOUT_MS'])]
+      .map((r) => r.error)
+      .filter((e): e is string => Boolean(e)),
+  );
+
+  errors.push(
+    ...[validateAnthropicModel(process.env['ANTHROPIC_MODEL'])]
+      .map((r) => r.error)
+      .filter((e): e is string => Boolean(e)),
+  );
+
+  const frontendDefault = 'http://localhost:5173';
+  const frontendRaw = process.env['FRONTEND_URL']?.trim() || frontendDefault;
+  const { url: frontendUrl, error: feErr } = parseHttpUrl(frontendRaw, 'FRONTEND_URL', true);
+  if (feErr) errors.push(feErr);
+
+  if (errors.length > 0) {
+    console.error(`${LOG_PREFIX} Environment validation failed:`);
+    for (const e of errors) console.error(`${LOG_PREFIX}   - ${e}`);
+    throw new Error(
+      `Invalid environment (${errors.length}): ${errors.join('; ')} — fix backend/.env or container env`,
+    );
+  }
+
+  for (const w of warnings) console.warn(`${LOG_PREFIX} Warning: ${w}`);
+
+  const sk = process.env['SUPABASE_SERVICE_ROLE_KEY']!.trim();
+  const ak = process.env['ANTHROPIC_API_KEY']!.trim();
+  const jwt = process.env['JWT_SECRET']!.trim();
+  const anonKey = process.env['SUPABASE_ANON_KEY']?.trim();
+
+  console.log(`${LOG_PREFIX} Environment OK (summary — secrets masked)`);
+  console.log(`${LOG_PREFIX}   NODE_ENV=${nodeEnv}`);
+  console.log(`${LOG_PREFIX}   PORT=${port}`);
+  console.log(`${LOG_PREFIX}   FRONTEND_URL=${frontendUrl}`);
+  try {
+    const u = new URL(supabaseUrl);
+    console.log(`${LOG_PREFIX}   SUPABASE_URL host=${u.host} scheme=${u.protocol.replace(':', '')}`);
+  } catch {
+    console.log(`${LOG_PREFIX}   SUPABASE_URL=(set)`);
+  }
+  console.log(`${LOG_PREFIX}   SUPABASE_SERVICE_ROLE_KEY=${maskSecret(sk)}`);
+  if (anonKey) console.log(`${LOG_PREFIX}   SUPABASE_ANON_KEY=${maskSecret(anonKey)}`);
+  console.log(`${LOG_PREFIX}   ANTHROPIC_API_KEY=${ak.startsWith('sk-ant-') ? maskSecret(ak, 12, 4) : maskSecret(ak)}`);
+  const model = process.env['ANTHROPIC_MODEL']?.trim();
+  if (model) console.log(`${LOG_PREFIX}   ANTHROPIC_MODEL=${model}`);
+  console.log(`${LOG_PREFIX}   JWT_SECRET length=${jwt.length} (ok)`);
+  const dbUrl = process.env['SUPABASE_DB_URL']?.trim();
+  if (dbUrl) console.log(`${LOG_PREFIX}   SUPABASE_DB_URL set (migrate CLI)`);
+  const scrapeMs = process.env['SCRAPE_TIMEOUT_MS']?.trim();
+  if (scrapeMs) console.log(`${LOG_PREFIX}   SCRAPE_TIMEOUT_MS=${scrapeMs}`);
+
+  return { port, frontendUrl, nodeEnv };
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -4,11 +4,13 @@ import cors from 'cors';
 import blogRoutes from './routes/blog-routes.js';
 import { errorHandler } from './middleware/error-handler.js';
 import { getAppVersion, getGitSha } from './version.js';
+import { validateAndLogRuntimeEnv } from './config/env.js';
+
+const { port, frontendUrl } = validateAndLogRuntimeEnv();
 
 const app = express();
-const port = process.env['PORT'] ?? 3000;
 
-app.use(cors({ origin: process.env['FRONTEND_URL'] ?? 'http://localhost:5173' }));
+app.use(cors({ origin: frontendUrl }));
 app.use(express.json());
 
 app.get('/health', (_req, res) =>
@@ -22,7 +24,7 @@ app.use('/api/blogs', blogRoutes);
 app.use(errorHandler);
 
 app.listen(port, () => {
-  console.log(`Blog Generator API running on port ${port}`);
+  console.log(`[config] Blog Generator API listening on port ${port}`);
 });
 
 export default app;

--- a/docs/agdr/AgDR-0018-github-actions-ec2-deploy.md
+++ b/docs/agdr/AgDR-0018-github-actions-ec2-deploy.md
@@ -1,0 +1,28 @@
+# AgDR-0018 — GitHub Actions deploy to EC2 (SSH + Docker Compose)
+
+## Status
+
+Accepted — implements [GH-59](https://github.com/mohamednaseramein/blog-generator/issues/59).
+
+## Context
+
+We need production updates on merge to `main` without manual SSH steps. The stack already runs under Docker Compose on a single EC2 instance (`docs/deployment.md`).
+
+## Decision
+
+1. **CI/CD** — Use **GitHub Actions** (`ubuntu-latest`) with **`appleboy/ssh-action`** (pinned `v1.2.3`) to run commands on the app host over SSH using repository secrets (`SSH_HOST`, `SSH_USER`, `SSH_PRIVATE_KEY`, optional `DEPLOY_PATH`).
+2. **Deploy steps** — After `git fetch` / `checkout -B main origin/main`, run **`scripts/verify-deploy-env.sh`** (presence and shape checks, no secret logging), export `APP_VERSION` / `GIT_SHA`, then `docker compose --env-file backend/.env` **down → build --no-cache → up -d → ps** (or `docker-compose` v1 if present).
+3. **Runtime validation** — The backend **must** call **`validateAndLogRuntimeEnv()`** at process start (`backend/src/config/env.ts`) so misconfigured containers fail fast with masked `[config]` logs.
+
+## Consequences
+
+- **Secrets** live only in GitHub Actions and on the server (`backend/.env`); nothing committed.
+- **Trust** — SSH host key pinning is optional hardening (documented in `docs/deployment.md`); default relies on operator/network posture.
+- **Alternatives considered** — Self-hosted runner on AWS (more setup); **AWS CodeDeploy / ECS** (heavier than current single-host Compose model).
+
+## References
+
+- [docs/deployment.md](../deployment.md)
+- [environment-configuration.md](../environment-configuration.md)
+- [AgDR-0004 — Docker containerisation](./AgDR-0004-docker-containerisation.md)
+- [AgDR-0017 — Backend `.env` colocation](./AgDR-0017-backend-env-colocation.md)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -65,5 +65,6 @@ If only `docker-compose` (v1) is installed, substitute `docker-compose` for `doc
 
 ## Related documents
 
+- [AgDR-0018 — GitHub Actions EC2 deploy](./agdr/AgDR-0018-github-actions-ec2-deploy.md) — architecture decision for this pipeline.
 - [environment-configuration.md](./environment-configuration.md) — `.env` layout and Compose `--env-file`.
 - [releases.md](./releases.md) — Versioning and release checklist (includes deploy verification).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,69 @@
+# Production deployment (EC2 + GitHub Actions)
+
+This document describes how **merges to `main`** trigger an **SSH deploy** to a single EC2 host running Docker Compose. It implements [GH-59](https://github.com/mohamednaseramein/blog-generator/issues/59).
+
+## Overview
+
+| Item | Detail |
+|------|--------|
+| Workflow | [.github/workflows/deploy-ec2.yml](../.github/workflows/deploy-ec2.yml) |
+| Trigger | `push` to `main` |
+| Target | Linux host with Docker and Docker Compose (v1 `docker-compose` or v2 `docker compose`) |
+| Remote path | Defaults to `$HOME/blog-generator`; override with `DEPLOY_PATH` secret |
+
+On the server, the job:
+
+1. Fetches and resets the repo to `origin/main`.
+2. Runs [`scripts/verify-deploy-env.sh`](../scripts/verify-deploy-env.sh) to confirm `package.json`, `backend/.env`, and required keys exist with **non-placeholder** values and plausible formats (without printing secrets).
+3. Exports `APP_VERSION` (from root `package.json`) and `GIT_SHA` (short) for image build args.
+4. Runs `docker compose --env-file backend/.env down`, `build --no-cache`, `up -d`, and `ps` (or the `docker-compose` equivalent if v1 is installed), with `[deploy]` log lines around each step.
+
+The backend container then performs its own **[config] environment check** at startup (see [environment-configuration.md](./environment-configuration.md)).
+
+## GitHub Actions secrets
+
+Configure these in the repository: **Settings → Secrets and variables → Actions**.
+
+| Secret | Required | Description |
+|--------|----------|-------------|
+| `SSH_HOST` | Yes | Public DNS or IP of the EC2 instance (e.g. `ec2-….compute.amazonaws.com`). |
+| `SSH_USER` | Yes | SSH login (e.g. `ec2-user` on Amazon Linux). |
+| `SSH_PRIVATE_KEY` | Yes | PEM private key that matches the instance key pair (full key, `-----BEGIN … PRIVATE KEY-----` through `-----END …`). |
+| `DEPLOY_PATH` | No | Absolute path to the repo on the server. If unset, the workflow uses `$HOME/blog-generator` (expanded on the server for `SSH_USER`). |
+
+Do **not** commit keys or hostnames if you can avoid it; keep them in secrets and internal runbooks only.
+
+### Optional hardening
+
+- **Host key verification** — The deploy action performs SSH from GitHub-hosted runners. To pin the server host key, see [appleboy/ssh-action](https://github.com/appleboy/ssh-action) (`fingerprint` / host key options) and update the workflow if your security policy requires it.
+- **Inbound SSH** — Restrict the instance security group to trusted IPs or use a self-hosted runner / Session Manager pattern if you cannot rely on broad GitHub runner IP ranges.
+
+## EC2 prerequisites
+
+1. **Git clone** — The deploy path must be a clone of this repo with `origin` pointing at GitHub and credentials that allow **`git fetch`** (e.g. deploy key with read access, or HTTPS with a credential helper). The workflow runs as `SSH_USER` and expects to update `main` from `origin`.
+2. **`backend/.env`** — Present on the server (gitignored). Compose needs it for runtime and for compose-level variable substitution; see [environment-configuration.md](./environment-configuration.md).
+3. **Docker** — Docker Engine and Compose v1 or v2; `ec2-user` must be able to run `docker` (e.g. member of `docker` group).
+4. **Resources** — `build --no-cache` is CPU/network heavy; size the instance accordingly. The workflow allows up to **45 minutes** for the remote script.
+
+## Manual deploy (same commands as CI)
+
+From the repo root on the server:
+
+```bash
+cd ~/blog-generator   # or your DEPLOY_PATH
+git fetch origin main
+git checkout -B main origin/main
+export APP_VERSION="$(grep -m1 '"version"' package.json | sed 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')"
+export GIT_SHA="$(git rev-parse --short HEAD 2>/dev/null || echo "")"
+docker compose --env-file backend/.env down
+docker compose --env-file backend/.env build --no-cache
+docker compose --env-file backend/.env up -d
+docker compose --env-file backend/.env ps
+```
+
+If only `docker-compose` (v1) is installed, substitute `docker-compose` for `docker compose`.
+
+## Related documents
+
+- [environment-configuration.md](./environment-configuration.md) — `.env` layout and Compose `--env-file`.
+- [releases.md](./releases.md) — Versioning and release checklist (includes deploy verification).

--- a/docs/environment-configuration.md
+++ b/docs/environment-configuration.md
@@ -43,8 +43,15 @@ frontend build args:
 docker compose --env-file backend/.env up --build
 ```
 
+## Startup validation (backend)
+
+When the API process starts (`npm run dev`, `node dist/index.js`, or the backend container), it runs **`validateAndLogRuntimeEnv()`** in [`backend/src/config/env.ts`](../backend/src/config/env.ts): required variables must be present, match expected shapes (URLs, JWT-style Supabase keys, `sk-ant-` Anthropic key in **production**, JWT length ≥ 32), and must not contain obvious placeholder text. **`SUPABASE_ANON_KEY`** is optional in **development** (warning only); it is **required in production** (including the Docker backend image, where `NODE_ENV=production`). On success it logs a **masked** summary to stdout (`[config] …`); it never prints full secrets.
+
+For **CI deploy** to EC2, [`scripts/verify-deploy-env.sh`](../scripts/verify-deploy-env.sh) performs similar checks on the server **before** `docker compose` runs (no secret values in logs).
+
 ## Related documents
 
+- [deployment.md](./deployment.md) — production host: ensure `backend/.env` exists on EC2 before CI deploy runs Compose.
 - [AgDR-0017 — Move .env to backend/](./agdr/AgDR-0017-backend-env-colocation.md)
 - [AgDR-0010 — Single root `.env` (superseded)](./agdr/AgDR-0010-single-root-env-configuration.md)
 - [AgDR-0004 — Docker containerisation](./agdr/AgDR-0004-docker-containerisation.md)

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -10,8 +10,8 @@ This app uses **one semver** for the product: the **`version` field in the root 
 | **Implement** | Add a one-line entry under `## [Unreleased]` in `CHANGELOG.md` if the change is user-visible. |
 | **Review** | PR description should mention impact for operators/users (Helps with release notes). |
 | **Test** | `npm test`, `npm run build`; after deploy, hit `GET /version` and confirm the UI footer. |
-| **Release** | Bump semver, tag `vX.Y.Z`, copy `[Unreleased]` into a dated `## [X.Y.Z]` section, deploy. |
-| **Hotfix** | `npm version patch` (or `minor` / `major`), tag, deploy; note in `CHANGELOG.md`. |
+| **Release** | Bump semver, tag `vX.Y.Z`, copy `[Unreleased]` into a dated `## [X.Y.Z]` section, merge to `main` (triggers [deploy workflow](../.github/workflows/deploy-ec2.yml)) or deploy manually per [deployment.md](./deployment.md). |
+| **Hotfix** | `npm version patch` (or `minor` / `major`), tag, merge to `main` / deploy; note in `CHANGELOG.md`. |
 
 ## How to release
 
@@ -50,3 +50,4 @@ This app uses **one semver** for the product: the **`version` field in the root 
 - [docker-compose.yml](../docker-compose.yml) — `APP_VERSION` / `GIT_SHA` build args
 - [scripts/build-env.sh](../scripts/build-env.sh) — load version + git from the repo for Docker builds
 - [scripts/sync-version.mjs](../scripts/sync-version.mjs) — copy root `version` to workspaces
+- [deployment.md](./deployment.md) — production EC2 deploy and GitHub Actions secrets

--- a/scripts/verify-deploy-env.sh
+++ b/scripts/verify-deploy-env.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Run on the deploy host before docker compose (paths relative to repo root).
+# Does not print secret values — only presence and obvious placeholder patterns.
+set -euo pipefail
+
+ROOT="${1:-.}"
+cd "$ROOT"
+
+echo "[deploy] Repo root: $(pwd)"
+
+if [[ ! -f package.json ]]; then
+  echo "[deploy] ERROR: package.json not found — is this the blog-generator repo?" >&2
+  exit 1
+fi
+
+ver_line="$(grep -m1 '"version"' package.json || true)"
+if [[ -z "$ver_line" ]]; then
+  echo "[deploy] ERROR: could not read version from package.json" >&2
+  exit 1
+fi
+echo "[deploy] package.json version line OK (semver present)"
+
+if [[ ! -f backend/.env ]]; then
+  echo "[deploy] ERROR: backend/.env missing — create it on the server (see docs/environment-configuration.md)" >&2
+  exit 1
+fi
+
+env_bytes="$(wc -c < backend/.env | tr -d ' ')"
+echo "[deploy] backend/.env present (${env_bytes} bytes)"
+
+required_keys=(
+  SUPABASE_URL
+  SUPABASE_SERVICE_ROLE_KEY
+  SUPABASE_ANON_KEY
+  ANTHROPIC_API_KEY
+  JWT_SECRET
+)
+
+for key in "${required_keys[@]}"; do
+  line="$(grep -E "^${key}=" backend/.env 2>/dev/null | tail -n1 || true)"
+  if [[ -z "$line" ]]; then
+    echo "[deploy] ERROR: ${key} is not set in backend/.env" >&2
+    exit 1
+  fi
+  val="${line#*=}"
+  val="${val%$'\r'}"
+  if [[ -z "$val" ]]; then
+    echo "[deploy] ERROR: ${key} is empty in backend/.env" >&2
+    exit 1
+  fi
+  lower="$(printf '%s' "$val" | tr '[:upper:]' '[:lower:]')"
+  case "$lower" in
+    *your-key-here* | *your-service-role-key* | *your-anon-key* | *your-project-ref*)
+      echo "[deploy] ERROR: ${key} still looks like a placeholder — replace with real credentials" >&2
+      exit 1
+      ;;
+  esac
+  if [[ "$key" == "SUPABASE_URL" ]]; then
+    if [[ ! "$val" =~ ^https?:// ]]; then
+      echo "[deploy] ERROR: SUPABASE_URL must start with http:// or https://" >&2
+      exit 1
+    fi
+  fi
+  if [[ "$key" == "ANTHROPIC_API_KEY" ]]; then
+    if [[ ! "$val" =~ ^sk-ant- ]]; then
+      echo "[deploy] ERROR: ANTHROPIC_API_KEY must start with sk-ant-" >&2
+      exit 1
+    fi
+  fi
+  if [[ "$key" == "JWT_SECRET" ]]; then
+    if [[ "${#val}" -lt 32 ]]; then
+      echo "[deploy] ERROR: JWT_SECRET must be at least 32 characters" >&2
+      exit 1
+    fi
+    if [[ "$val" == "a-long-random-secret-min-32-chars" ]]; then
+      echo "[deploy] ERROR: JWT_SECRET must not use the example value from .env.example" >&2
+      exit 1
+    fi
+  fi
+  if [[ "$key" == SUPABASE_SERVICE_ROLE_KEY || "$key" == SUPABASE_ANON_KEY ]]; then
+    if [[ ! "$val" =~ ^eyJ ]]; then
+      echo "[deploy] ERROR: ${key} should be a Supabase JWT (starts with eyJ)" >&2
+      exit 1
+    fi
+    if [[ "${#val}" -lt 80 ]]; then
+      echo "[deploy] ERROR: ${key} looks too short for a Supabase key" >&2
+      exit 1
+    fi
+  fi
+done
+
+echo "[deploy] backend/.env keys validated (formats and non-placeholder)"


### PR DESCRIPTION
## Summary
Implements [GH-59](https://github.com/mohamednaseramein/blog-generator/issues/59): post-merge deploy to EC2, server-side env verification, and backend startup validation with masked logs.

## Changes
- **GitHub Actions** — `.github/workflows/deploy-ec2.yml`: SSH deploy on push to `main`; runs `scripts/verify-deploy-env.sh` before Docker Compose; `[deploy]` log lines.
- **Backend** — `validateAndLogRuntimeEnv()` in `backend/src/config/env.ts`; wired from `index.ts`; tests in `backend/src/config/__tests__/env.test.ts`.
- **Script** — `scripts/verify-deploy-env.sh`: required keys and format checks (no secret values printed).
- **Docs** — `docs/deployment.md`, README, releases, environment-configuration, CHANGELOG.

## Pre-merge checklist
- [ ] Actions secrets: `SSH_HOST`, `SSH_USER`, `SSH_PRIVATE_KEY`, optional `DEPLOY_PATH`.
- [ ] EC2: `backend/.env` complete (including `SUPABASE_ANON_KEY`), Docker, git fetch to GitHub.

## Testing
- `npm run test --workspace=backend`
- `npm run typecheck --workspace=backend`

## Glossary
| Term | Definition |
|------|------------|
| **EC2 deploy** | GitHub-hosted runner opens SSH to the app host and runs git sync + Docker Compose. |
| **verify-deploy-env.sh** | Bash checks on the server that `backend/.env` defines required variables with plausible formats (no logging of values). |
| **validateAndLogRuntimeEnv** | Node startup guard: URLs, JWT-shaped Supabase keys, Anthropic `sk-ant-` in production, JWT length; logs a masked `[config]` summary. |
| **Masked summary** | Logs prefix/length of secrets only, not full tokens. |

Made with [Cursor](https://cursor.com)