### PR TITLE
fix(#59): deploy workflow — remove script_stop, fix DEPLOY_PATH cd

### DIFF
--- a/.github/workflows/deploy-ec2.yml
+++ b/.github/workflows/deploy-ec2.yml
@@ -22,16 +22,31 @@ jobs:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          script_stop: true
           command_timeout: 45m
           script: |
             set -e
             DEPLOY_PATH="${{ secrets.DEPLOY_PATH }}"
-            if [ -z "$DEPLOY_PATH" ]; then
-              DEPLOY_PATH="${HOME}/blog-generator"
+            _home="${HOME:-}"
+            if [ -z "${_home}" ] && command -v getent >/dev/null 2>&1; then
+              _home="$(getent passwd "$(id -un)" 2>/dev/null | cut -d: -f6)" || true
             fi
-            echo "[deploy] Using DEPLOY_PATH=${DEPLOY_PATH}"
-            cd "$DEPLOY_PATH"
+            if [ -z "${_home}" ]; then
+              _home="/home/$(id -un)"
+            fi
+            export HOME="${_home}"
+            if [ -z "${DEPLOY_PATH}" ]; then
+              DEPLOY_PATH="${_home}/blog-generator"
+            fi
+            case "${DEPLOY_PATH}" in
+              '~') DEPLOY_PATH="${_home}" ;;
+              ~/*) DEPLOY_PATH="${_home}/${DEPLOY_PATH#~/}" ;;
+            esac
+            echo "[deploy] Resolved deploy directory (HOME=${_home})"
+            if [ ! -d "${DEPLOY_PATH}" ]; then
+              echo "[deploy] ERROR: directory does not exist. Clone the repo here or set DEPLOY_PATH to the repo root (use an absolute path, not ~/... in secrets unless HOME is set)." >&2
+              exit 1
+            fi
+            cd "${DEPLOY_PATH}"
             echo "[deploy] Syncing git to origin/main"
             git fetch origin main
             git checkout -B main origin/main

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -29,7 +29,7 @@ Configure these in the repository: **Settings → Secrets and variables → Acti
 | `SSH_HOST` | Yes | Public DNS or IP of the EC2 instance (e.g. `ec2-….compute.amazonaws.com`). |
 | `SSH_USER` | Yes | SSH login (e.g. `ec2-user` on Amazon Linux). |
 | `SSH_PRIVATE_KEY` | Yes | PEM private key that matches the instance key pair (full key, `-----BEGIN … PRIVATE KEY-----` through `-----END …`). |
-| `DEPLOY_PATH` | No | Absolute path to the repo on the server. If unset, the workflow uses `$HOME/blog-generator` (expanded on the server for `SSH_USER`). |
+| `DEPLOY_PATH` | No | **Absolute** path to the repo root on the server (e.g. `/home/ec2-user/blog-generator`). If unset, the workflow uses `/home/<ssh-user>/blog-generator` after resolving `HOME` (non-interactive SSH often omits `HOME`; the workflow fixes that). If you use `~/...` in this secret, it is expanded the same way. The directory **must already exist** (clone the repo there once). |
 
 Do **not** commit keys or hostnames if you can avoid it; keep them in secrets and internal runbooks only.
 


### PR DESCRIPTION
## Summary
Fixes failed **Deploy to EC2** runs: invalid `script_stop` input for `appleboy/ssh-action@v1.2.3`, and `cd` failing when `HOME` is unset or `DEPLOY_PATH` uses `~/` without expansion.

## Changes
- Drop `script_stop` (not in action input list; `set -e` already stops on errors).
- Resolve home via `HOME`, `getent passwd`, or `/home/<user>`; expand `~/` in `DEPLOY_PATH`.
- Clear error if the deploy directory does not exist.
- Docs: `DEPLOY_PATH` guidance.

## Glossary
| Term | Definition |
|------|------------|
| **script_stop** | Former drone-ssh option not exposed by ssh-action v1.2.3; caused GitHub `Unexpected input` warning. |
| **DEPLOY_PATH** | Repo root on EC2; must exist. Defaults to `/home/<ssh-user>/blog-generator` when secret unset. |

Made with [Cursor](https://cursor.com)