### PR TITLE
feat(GH-63): ban U+2014 in AI output, harmonize UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented in this file. The format is b
 
 ## [Unreleased]
 
+### Added
+
+- **Content style:** Ban Unicode em dash (U+2014) in AI output and harmonized UI: [`backend/src/lib/copy-style.ts`](backend/src/lib/copy-style.ts), prompt instruction `PROMPT_EMDASH_BAN`, stripping in draft/outline/alignment/reference-extraction services and key API read paths. Documented in [`docs/content-style-sdlc.md`](docs/content-style-sdlc.md) and task [`docs/tasks/feat-no-em-dash-content-style.md`](docs/tasks/feat-no-em-dash-content-style.md).
+
 ### Changed
 
 - **CI/CD** — EC2 deploy uses [`scripts/deploy-ec2.sh`](scripts/deploy-ec2.sh) (no `docker compose down` on the happy path; optional `up --wait` with Compose 2.29+; optional `DOWN_BEFORE_DEPLOY=1` / `DEPLOY_BUILD_NO_CACHE=0` on the host). Documented in [`docs/zero-downtime-sdlc.md`](docs/zero-downtime-sdlc.md) and [`docs/deployment.md`](docs/deployment.md).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Blog Generator
 
-AI-guided wizard for producing fully-structured blog posts — step by step, with the human in control throughout.
+AI-guided wizard for producing fully-structured blog posts, step by step, with the human in control throughout.
 
 ## Stack
 
@@ -11,10 +11,10 @@ AI-guided wizard for producing fully-structured blog posts — step by step, wit
 | Database | Supabase (hosted PostgreSQL + JS client) |
 | AI | Anthropic Claude API |
 | Container | Docker Compose (backend + frontend) |
-| CI/CD | GitHub Actions — deploy to EC2 on push to `main` ([docs/deployment.md](docs/deployment.md)) |
+| CI/CD | GitHub Actions: deploy to EC2 on push to `main` ([docs/deployment.md](docs/deployment.md)) |
 | Testing | Vitest (unit/integration) + Playwright (E2E) |
 
-**Versioning** — the product semver lives in the root `package.json`. Sync workspaces with `npm run version:sync`, then commit; release process and SDLC map are in [docs/releases.md](docs/releases.md) and [CHANGELOG.md](CHANGELOG.md).
+**Versioning:** the product semver lives in the root `package.json`. Sync workspaces with `npm run version:sync`, then commit; release process and SDLC map are in [docs/releases.md](docs/releases.md) and [CHANGELOG.md](CHANGELOG.md). **Copy style** (no em dashes in generated or user-facing product text): [docs/content-style-sdlc.md](docs/content-style-sdlc.md).
 
 ---
 
@@ -291,6 +291,7 @@ blog-generator/
 │       └── main.tsx
 ├── docs/
 │   ├── deployment.md              # EC2 + GitHub Actions production deploy
+│   ├── content-style-sdlc.md      # No U+2014 in AI / product copy (SDLC)
 │   └── agdr/
 │       ├── AgDR-0001-project-structure.md
 │       ├── AgDR-0002-url-scraping-approach.md

--- a/backend/src/handlers/blog-alignment-handler.ts
+++ b/backend/src/handlers/blog-alignment-handler.ts
@@ -25,7 +25,7 @@ export async function handleGenerateAlignment(
     if (!blog) throw new AppError(404, 'NOT_FOUND', 'Blog not found');
 
     const brief = await getBriefByBlogId(blogId);
-    if (!brief) throw new AppError(404, 'NOT_FOUND', 'Brief not found — submit the brief first');
+    if (!brief) throw new AppError(404, 'NOT_FOUND', 'Brief not found - submit the brief first');
 
     const references = await getReferencesByBlogId(blogId);
     const result = await generateAlignmentSummary(brief, feedbackText, references);

--- a/backend/src/handlers/blog-draft-handler.ts
+++ b/backend/src/handlers/blog-draft-handler.ts
@@ -9,6 +9,7 @@ import {
 } from '../repositories/blog-draft-repository.js';
 import { generateBlogDraft, generateMetaAndSlug } from '../services/draft-service.js';
 import type { AlignmentSummary } from '../services/alignment-service.js';
+import { stripEmDashes, stripEmDashesDeep } from '../lib/copy-style.js';
 import { parseStoredOutlineJson } from '../services/outline-service.js';
 import { AppError } from '../middleware/error-handler.js';
 import { getUserId } from '../middleware/auth.js';
@@ -28,20 +29,20 @@ export async function handleGenerateDraft(
     if (!blog) throw new AppError(404, 'NOT_FOUND', 'Blog not found');
 
     const brief = await getBriefByBlogId(blogId);
-    if (!brief) throw new AppError(404, 'NOT_FOUND', 'Brief not found — submit the brief first');
+    if (!brief) throw new AppError(404, 'NOT_FOUND', 'Brief not found - submit the brief first');
     if (!brief.alignmentConfirmed || !brief.alignmentSummary) {
       throw new AppError(400, 'BAD_REQUEST', 'Confirm alignment before generating a draft');
     }
 
     let alignment: AlignmentSummary;
     try {
-      alignment = JSON.parse(brief.alignmentSummary) as AlignmentSummary;
+      alignment = stripEmDashesDeep(JSON.parse(brief.alignmentSummary) as AlignmentSummary);
     } catch {
       throw new AppError(500, 'INTERNAL', 'Stored alignment summary is malformed');
     }
 
     const outlineRow = await getOutlineByBlogId(blogId);
-    if (!outlineRow) throw new AppError(404, 'NOT_FOUND', 'Outline not found — generate an outline first');
+    if (!outlineRow) throw new AppError(404, 'NOT_FOUND', 'Outline not found - generate an outline first');
     if (!outlineRow.outlineConfirmed) {
       throw new AppError(400, 'BAD_REQUEST', 'Confirm the outline before generating a draft');
     }
@@ -130,12 +131,13 @@ export async function handleGetDraft(
 
     res.json({
       draft: {
-        markdown: draft.draftMarkdown,
+        markdown: stripEmDashes(draft.draftMarkdown),
         draftConfirmed: draft.draftConfirmed,
         draftIterations: draft.draftIterations,
-        metaDescription: draft.metaDescription,
-        suggestedSlug: draft.suggestedSlug,
-        seoTitle: draft.seoTitle,
+        metaDescription:
+          draft.metaDescription != null ? stripEmDashes(draft.metaDescription) : draft.metaDescription,
+        suggestedSlug: draft.suggestedSlug != null ? stripEmDashes(draft.suggestedSlug) : draft.suggestedSlug,
+        seoTitle: draft.seoTitle != null ? stripEmDashes(draft.seoTitle) : draft.seoTitle,
       },
     });
   } catch (err) {

--- a/backend/src/handlers/blog-outline-handler.ts
+++ b/backend/src/handlers/blog-outline-handler.ts
@@ -7,6 +7,7 @@ import {
   confirmOutline,
 } from '../repositories/blog-outline-repository.js';
 import { generateBlogOutline, parseStoredOutlineJson } from '../services/outline-service.js';
+import { stripEmDashesDeep } from '../lib/copy-style.js';
 import type { AlignmentSummary } from '../services/alignment-service.js';
 import { AppError } from '../middleware/error-handler.js';
 import { getUserId } from '../middleware/auth.js';
@@ -26,14 +27,14 @@ export async function handleGenerateOutline(
     if (!blog) throw new AppError(404, 'NOT_FOUND', 'Blog not found');
 
     const brief = await getBriefByBlogId(blogId);
-    if (!brief) throw new AppError(404, 'NOT_FOUND', 'Brief not found — submit the brief first');
+    if (!brief) throw new AppError(404, 'NOT_FOUND', 'Brief not found - submit the brief first');
     if (!brief.alignmentConfirmed || !brief.alignmentSummary) {
       throw new AppError(400, 'BAD_REQUEST', 'Confirm alignment before generating an outline');
     }
 
     let alignment: AlignmentSummary;
     try {
-      alignment = JSON.parse(brief.alignmentSummary) as AlignmentSummary;
+      alignment = stripEmDashesDeep(JSON.parse(brief.alignmentSummary) as AlignmentSummary);
     } catch {
       throw new AppError(500, 'INTERNAL', 'Stored alignment summary is malformed');
     }
@@ -97,7 +98,13 @@ export async function handleGetOutline(
     }
 
     res.json({
-      outline: { ...parsed, raw: row.outlineJson },
+      outline: {
+        ...parsed,
+        raw: JSON.stringify({
+          sections: parsed.sections,
+          totalEstimatedWords: parsed.totalEstimatedWords,
+        }),
+      },
       outlineConfirmed: row.outlineConfirmed,
       outlineIterations: row.outlineIterations,
     });

--- a/backend/src/lib/__tests__/copy-style.test.ts
+++ b/backend/src/lib/__tests__/copy-style.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { stripEmDashes, stripEmDashesDeep } from '../copy-style.js';
+
+describe('stripEmDashes', () => {
+  it('replaces U+2014 with spaced hyphen (may double adjacent spaces)', () => {
+    const inStr = 'foo \u2014 bar';
+    expect(stripEmDashes(inStr)).toBe('foo  -  bar');
+  });
+
+  it('is a no-op when no em dash', () => {
+    expect(stripEmDashes('a–b')).toBe('a–b');
+  });
+});
+
+describe('stripEmDashesDeep', () => {
+  it('strips in nested object strings', () => {
+    const o = { a: 'x \u2014 y', b: { c: 'z \u2014 w' } };
+    const out = stripEmDashesDeep(o);
+    expect(out.a).toBe('x  -  y');
+    expect(out.b.c).toBe('z  -  w');
+  });
+});

--- a/backend/src/lib/copy-style.ts
+++ b/backend/src/lib/copy-style.ts
@@ -1,0 +1,38 @@
+/**
+ * House style: the Unicode em dash (U+2014) is not used in product copy or in AI
+ * output. Replace with a spaced hyphen so breaks stay readable in Markdown and JSON.
+ */
+const EM_DASH = '\u2014';
+
+/** Instruction fragment for LLM user prompts. Do not use U+2014 in this string. */
+export const PROMPT_EMDASH_BAN = `Never use the Unicode em dash character (U+2014) in your output. If you need a break or aside, use a spaced hyphen: space, hyphen, space, like " - " instead.`;
+
+/**
+ * Replaces every U+2014 (em dash) with ` - ` (spaced hyphen). Does not change en dashes.
+ */
+export function stripEmDashes(text: string): string {
+  if (!text.includes(EM_DASH)) return text;
+  return text.replaceAll(EM_DASH, ' - ');
+}
+
+/**
+ * Recursively strips em dashes from all string values (objects and arrays). Used
+ * for JSON shapes returned by the model before persistence or response.
+ */
+export function stripEmDashesDeep<T>(value: T): T {
+  if (typeof value === 'string') {
+    return stripEmDashes(value) as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map((v) => stripEmDashesDeep(v)) as T;
+  }
+  if (value && typeof value === 'object') {
+    const o = value as Record<string, unknown>;
+    const next: Record<string, unknown> = {};
+    for (const k of Object.keys(o)) {
+      next[k] = stripEmDashesDeep(o[k]);
+    }
+    return next as T;
+  }
+  return value;
+}

--- a/backend/src/routes/blog-routes.ts
+++ b/backend/src/routes/blog-routes.ts
@@ -48,7 +48,7 @@ router.get('/:id/draft', requireAuth, handleGetDraft);
 
 router.post('/:id/events', requireAuth, handleRecordEvent);
 
-// Reference URLs (multi-URL support — EP-05 / US-09)
+// Reference URLs (multi-URL support, EP-05 / US-09)
 router.post('/:id/references', requireAuth, handleAddReference);
 router.get('/:id/references', requireAuth, handleListReferences);
 router.get('/:id/references/:refId/status', requireAuth, handleGetReferenceStatus);

--- a/backend/src/services/alignment-service.ts
+++ b/backend/src/services/alignment-service.ts
@@ -1,5 +1,6 @@
 import Anthropic from '@anthropic-ai/sdk';
 import type { BlogBrief, BlogReference } from '../domain/types.js';
+import { PROMPT_EMDASH_BAN, stripEmDashesDeep } from '../lib/copy-style.js';
 
 /** Default matches previous hardcoded model; unset env keeps prod behaviour. Override in dev, e.g. Haiku, via ANTHROPIC_MODEL. */
 export const DEFAULT_ALIGNMENT_ANTHROPIC_MODEL = 'claude-sonnet-4-6';
@@ -87,7 +88,8 @@ async function fetchAlignmentJson(prompt: string): Promise<{ raw: string; parsed
     throw new Error('AI returned an unexpected response format. Please try again.');
   }
 
-  return { raw: text, parsed };
+  const cleaned = stripEmDashesDeep(parsed);
+  return { raw: JSON.stringify(cleaned), parsed: cleaned };
 }
 
 function briefBlock(brief: BlogBrief): string {
@@ -130,11 +132,12 @@ export async function generateAlignmentSummary(
 
 ${briefBlock(brief)}
 
-## Reference insights (from automated extraction — structured, not raw page dumps)
+## Reference insights (from automated extraction - structured, not raw page dumps)
 ${snippets}
 ${feedbackNote}
 
-Respond with ONLY valid JSON — no markdown fences, no extra keys.
+${PROMPT_EMDASH_BAN}
+Respond with ONLY valid JSON. No markdown fences, no extra keys.
 The response MUST include a sixth field "differentiationAngle" because structured reference insights were provided. Do NOT include "referenceUnderstanding".
 
 Required JSON shape:
@@ -173,7 +176,8 @@ Required JSON shape:
 ${briefBlock(brief)}
 ${feedbackNote}
 
-Respond with ONLY valid JSON — no markdown fences, no extra keys. Use exactly five string fields (no reference-specific fields).
+${PROMPT_EMDASH_BAN}
+Respond with ONLY valid JSON. No markdown fences, no extra keys. Use exactly five string fields (no reference-specific fields).
 
 Required JSON shape:
 {
@@ -187,14 +191,14 @@ Required JSON shape:
     const { raw, parsed } = await fetchAlignmentJson(prompt);
     validateCoreFields(parsed);
 
-    const withMeta = {
+    const withMeta = stripEmDashesDeep({
       blogGoal: parsed['blogGoal'] as string,
       targetAudience: parsed['targetAudience'] as string,
       seoIntent: parsed['seoIntent'] as string,
       tone: parsed['tone'] as string,
       scope: parsed['scope'] as string,
       referencesAnalysis: 'none_usable' as const,
-    };
+    });
 
     return { ...withMeta, raw: JSON.stringify(withMeta) };
   }
@@ -217,7 +221,8 @@ Required JSON shape:
 ${briefBlock(brief)}
 ${scrapedNote}${feedbackNote}
 
-Respond with ONLY valid JSON — no markdown fences, no extra keys.
+${PROMPT_EMDASH_BAN}
+Respond with ONLY valid JSON. No markdown fences, no extra keys.
 The response MUST include a sixth field "referenceUnderstanding" because reference page text (or a scrape in progress pipeline) was included.
 
 Required JSON shape:
@@ -254,7 +259,8 @@ Required JSON shape:
 
 ${briefBlock(brief)}${feedbackNote}
 
-Respond with ONLY valid JSON — no markdown fences, no extra keys.
+${PROMPT_EMDASH_BAN}
+Respond with ONLY valid JSON. No markdown fences, no extra keys.
 
 Required JSON shape:
 {

--- a/backend/src/services/draft-service.ts
+++ b/backend/src/services/draft-service.ts
@@ -1,5 +1,6 @@
 import Anthropic from '@anthropic-ai/sdk';
 import type { BlogBrief } from '../domain/types.js';
+import { PROMPT_EMDASH_BAN, stripEmDashes } from '../lib/copy-style.js';
 import type { AlignmentSummary } from './alignment-service.js';
 import type { OutlineSection } from './outline-service.js';
 import { resolveAlignmentAnthropicModel } from './alignment-service.js';
@@ -62,7 +63,8 @@ export async function generateBlogDraft(
 ${outlineToPrompt(sections)}${feedbackNote}
 
 ## Output rules
-- Start with a compelling introduction (no H1; use the title only as plain context — first heading should be ##).
+- ${PROMPT_EMDASH_BAN}
+- Start with a compelling introduction (no H1; use the title only as plain context. The first heading should be ##).
 - Use ## for each main section matching the outline order and titles (you may slightly refine titles for flow).
 - Use ### for sub-points where the outline had H3 items.
 - Work the primary keyword naturally into the intro and several headings.
@@ -81,8 +83,10 @@ ${outlineToPrompt(sections)}${feedbackNote}
     throw new Error('AI returned an empty draft. Please try again.');
   }
 
-  const markdown = raw.replace(/^```(?:markdown|md)?\s*/i, '').replace(/\s*```\s*$/m, '').trim();
-  return { markdown, raw };
+  const markdown = stripEmDashes(
+    raw.replace(/^```(?:markdown|md)?\s*/i, '').replace(/\s*```\s*$/m, '').trim(),
+  );
+  return { markdown, raw: stripEmDashes(raw) };
 }
 
 export async function generateMetaAndSlug(
@@ -92,6 +96,7 @@ export async function generateMetaAndSlug(
 ): Promise<MetaAndSlug> {
   const excerpt = markdown.slice(0, 1500);
   const prompt = `Given the following blog post title, primary keyword, and opening content, generate:
+${PROMPT_EMDASH_BAN}
 1. An SEO title: ≤60 characters, starts with or contains the primary keyword near the front, compelling for search results.
 2. A meta description: at most 155 characters, includes the primary keyword, entices clicks.
 3. A URL slug: lowercase, kebab-case, at most 60 characters, keyword-rich.
@@ -121,8 +126,8 @@ Respond with valid JSON only, no markdown fences:
   }
 
   return {
-    seoTitle: parsed.seoTitle?.trim() ? parsed.seoTitle.trim().slice(0, 60) : null,
-    metaDescription: (parsed.metaDescription ?? '').slice(0, 155),
-    suggestedSlug: (parsed.suggestedSlug ?? '').slice(0, 60),
+    seoTitle: parsed.seoTitle?.trim() ? stripEmDashes(parsed.seoTitle.trim().slice(0, 60)) : null,
+    metaDescription: stripEmDashes((parsed.metaDescription ?? '').slice(0, 155)),
+    suggestedSlug: stripEmDashes((parsed.suggestedSlug ?? '').slice(0, 60)),
   };
 }

--- a/backend/src/services/outline-service.ts
+++ b/backend/src/services/outline-service.ts
@@ -1,5 +1,6 @@
 import Anthropic from '@anthropic-ai/sdk';
 import type { BlogBrief } from '../domain/types.js';
+import { PROMPT_EMDASH_BAN, stripEmDashesDeep } from '../lib/copy-style.js';
 import type { AlignmentSummary } from './alignment-service.js';
 
 const client = new Anthropic({ apiKey: process.env['ANTHROPIC_API_KEY'] });
@@ -52,9 +53,10 @@ export async function generateBlogOutline(
 - Tone: ${brief.toneOfVoice}
 - Word count target: ~${wordTarget} words (range: ${brief.wordCountMin}–${brief.wordCountMax})${feedbackNote}
 
-Generate a structured outline. Respond with ONLY valid JSON — no markdown fences, no extra keys.
+Generate a structured outline. Respond with ONLY valid JSON. No markdown fences, no extra keys.
 
 Rules:
+- ${PROMPT_EMDASH_BAN}
 - Include 4–7 H2 sections (never fewer than 4, never more than 7)
 - Each section must have a clear, keyword-relevant title and 2–4 H3 subsections
 - Distribute estimatedWords across sections so they sum to approximately ${wordTarget}
@@ -96,7 +98,9 @@ Required JSON shape:
     throw new Error('AI returned an unexpected response format. Please try again.');
   }
 
-  for (const section of parsed.sections) {
+  const cleaned = stripEmDashesDeep(parsed);
+
+  for (const section of cleaned.sections) {
     if (
       typeof section.title !== 'string' ||
       typeof section.description !== 'string' ||
@@ -108,7 +112,11 @@ Required JSON shape:
     }
   }
 
-  return { sections: parsed.sections, totalEstimatedWords: parsed.totalEstimatedWords, raw: text };
+  return {
+    sections: cleaned.sections,
+    totalEstimatedWords: cleaned.totalEstimatedWords,
+    raw: JSON.stringify(cleaned),
+  };
 }
 
 /** Parse persisted `blog_outlines.outline_json` (same shape as AI outline JSON). */
@@ -130,9 +138,10 @@ export function parseStoredOutlineJson(text: string): {
       throw new Error('Invalid outline section shape');
     }
   }
-  return {
+  const base = {
     sections: parsed.sections,
     totalEstimatedWords:
       typeof parsed.totalEstimatedWords === 'number' ? parsed.totalEstimatedWords : 0,
   };
+  return stripEmDashesDeep(base);
 }

--- a/backend/src/services/reference-extraction-service.ts
+++ b/backend/src/services/reference-extraction-service.ts
@@ -1,5 +1,6 @@
 import Anthropic from '@anthropic-ai/sdk';
 import type { BlogBrief } from '../domain/types.js';
+import { PROMPT_EMDASH_BAN, stripEmDashes } from '../lib/copy-style.js';
 import { resolveAlignmentAnthropicModel } from './alignment-service.js';
 
 const client = new Anthropic({ apiKey: process.env['ANTHROPIC_API_KEY'] });
@@ -67,6 +68,7 @@ export async function generateReferenceExtraction(
 
   const userContent = `You are an editorial assistant. The user is writing a blog post and added a reference URL whose text was scraped.
 
+${PROMPT_EMDASH_BAN}
 ## User's blog brief (for relevance)
 - Title: ${brief.title}
 - Primary keyword: ${brief.primaryKeyword}
@@ -81,10 +83,10 @@ ${url}
 ${slice}
 
 Return one JSON object with exactly these keys and types (no other keys):
-- "relevance": one of the strings "high", "medium", or "low" — how useful this page is for the user's specific brief
-- "summary": string — one sentence: what this page covers in relation to the brief
-- "keyAngle": string — one sentence: what angle, evidence, or gap vs typical coverage this source suggests
-- "irrelevantToBrief": boolean — true if the page is unrelated to the brief or offers no usable angle; false otherwise`;
+- "relevance": one of the strings "high", "medium", or "low" - how useful this page is for the user's specific brief
+- "summary": string - one sentence: what this page covers in relation to the brief
+- "keyAngle": string - one sentence: what angle, evidence, or gap vs typical coverage this source suggests
+- "irrelevantToBrief": boolean - true if the page is unrelated to the brief or offers no usable angle; false otherwise`;
 
   const message = await client.messages.create({
     model: resolveAlignmentAnthropicModel(),
@@ -120,5 +122,10 @@ Return one JSON object with exactly these keys and types (no other keys):
     throw new Error('AI returned an unexpected response format. Please try again.');
   }
 
-  return { ...parsed, raw: jsonText };
+  return {
+    ...parsed,
+    summary: stripEmDashes(parsed.summary),
+    keyAngle: stripEmDashes(parsed.keyAngle),
+    raw: stripEmDashes(jsonText),
+  };
 }

--- a/backend/src/services/url-scraper-service.ts
+++ b/backend/src/services/url-scraper-service.ts
@@ -74,13 +74,13 @@ async function scrapeReference(referenceId: string, url: string): Promise<void> 
 
     if (error.code === 'ECONNABORTED' || error.message?.includes('timeout')) {
       status = 'timeout';
-      message = `Request timed out after ${timeoutMs / 1000}s — the URL may be slow or unreachable.`;
+      message = `Request timed out after ${timeoutMs / 1000}s - the URL may be slow or unreachable.`;
     } else if (error.response?.status === 401 || error.response?.status === 403) {
       message = 'This URL is private or requires login. Copy the relevant content and paste it into your Blog Brief instead.';
     } else if (error.response?.status === 404) {
-      message = 'This URL returned a 404 — the page was not found.';
+      message = 'This URL returned a 404 - the page was not found.';
     } else if (error.code === 'ENOTFOUND' || error.code === 'EAI_AGAIN') {
-      message = 'Could not reach this URL — check it is publicly accessible.';
+      message = 'Could not reach this URL - check it is publicly accessible.';
     }
 
     await updateReferenceScrapeResult(referenceId, status, null, message);

--- a/docs/content-style-sdlc.md
+++ b/docs/content-style-sdlc.md
@@ -1,0 +1,26 @@
+# Content style: no em dashes (SDLC)
+
+This document records a **house rule** for Blog Generator: **do not use the Unicode em dash (U+2014)** in AI-generated copy, stored blog content, or user-facing product strings. Use a **spaced hyphen** (` ` + `-` + ` `) or rephrase with a period or colon when a break reads more clearly.
+
+## Why
+
+Alignment between model output, Markdown posts, SEO fields, and UI copy is easier when one punctuation rule applies everywhere. The em dash is easy for models to emit; we normalize it so published text stays consistent.
+
+## SDLC mapping
+
+| Phase | Responsibility |
+|--------|----------------|
+| **Requirements** | Ban U+2014 in generated and user-visible text; allow en dashes in numeric ranges where already used (e.g. word ranges) unless product later extends the rule. |
+| **Design** | Prompts include `PROMPT_EMDASH_BAN` from `backend/src/lib/copy-style.ts`. |
+| **Implementation** | `stripEmDashes` on single strings; `stripEmDashesDeep` on JSON-shaped model output before save; read paths strip legacy stored text when serving. |
+| **Verification** | Unit tests in `backend/src/lib/__tests__/copy-style.test.ts`; manual spot-check of outline, alignment, draft, and publish export. |
+| **Operation** | If a new LLM call path is added, import the same helpers and prompt line. |
+
+## Technical reference
+
+- **Source of truth:** `backend/src/lib/copy-style.ts` (`PROMPT_EMDASH_BAN`, `stripEmDashes`, `stripEmDashesDeep`).
+- **Not in scope for this rule:** Log lines, developer-only comments, and non-UI server diagnostics (may still be cleaned over time for consistency).
+
+## Related
+
+- Task: [feat-no-em-dash-content-style.md](./tasks/feat-no-em-dash-content-style.md)

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -9,7 +9,7 @@ This app uses **one semver** for the product: the **`version` field in the root 
 | **Plan** | Optional: name a target version or GitHub milestone. |
 | **Implement** | Add a one-line entry under `## [Unreleased]` in `CHANGELOG.md` if the change is user-visible. |
 | **Review** | PR description should mention impact for operators/users (Helps with release notes). |
-| **Test** | `npm test`, `npm run build`; after deploy, hit `GET /version` and confirm the UI footer. |
+| **Test** | `npm test`, `npm run build`; after deploy, hit `GET /version` and confirm the UI footer. For copy changes, see [content-style-sdlc.md](./content-style-sdlc.md). |
 | **Release** | Bump semver, tag `vX.Y.Z`, copy `[Unreleased]` into a dated `## [X.Y.Z]` section, merge to `main` (triggers [deploy workflow](../.github/workflows/deploy-ec2.yml)) or deploy manually per [deployment.md](./deployment.md). |
 | **Hotfix** | `npm version patch` (or `minor` / `major`), tag, merge to `main` / deploy; note in `CHANGELOG.md`. |
 

--- a/docs/tasks/feat-no-em-dash-content-style.md
+++ b/docs/tasks/feat-no-em-dash-content-style.md
@@ -1,0 +1,28 @@
+# [Feature] Ban em dashes (U+2014) in AI and blog copy
+
+| Field | Value |
+|--------|--------|
+| Type | Feature (content quality) |
+| Priority | P1 |
+
+## User story
+
+As a **content author using Blog Generator**, I want **generated copy and published posts to avoid em dashes** so that **tone and punctuation stay consistent across steps, exports, and the UI**.
+
+## Acceptance criteria
+
+- [x] Every Anthropic prompt that produces user-visible strings includes the shared **no em dash** instruction from `copy-style.ts`.
+- [x] Model output is passed through `stripEmDashes` or `stripEmDashesDeep` before persistence or API response where the content is alignment, outline, draft, reference extraction, or SEO meta.
+- [x] Read paths for stored alignment, outline, and draft apply the same stripping so older rows are harmonized at serve time.
+- [x] Wizard and key user-visible strings in the frontend no longer use U+2014.
+- [x] `docs/content-style-sdlc.md` describes the rule and SDLC ownership.
+
+## Design notes
+
+- Replacement is literal U+2014 to ` - ` (see `stripEmDashes`). En dashes in templates for ranges (e.g. `4–7` sections) are unchanged in this iteration.
+- Future: optional ESLint or CI check for U+2014 in `frontend/src` strings.
+
+## Out of scope
+
+- Third-party or user-typed content in fields we do not control beyond normal validation.
+- wholesale rewrite of non-UI backend log messages.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -124,7 +124,7 @@ export function App() {
           {state.step === 'brief' && (
             <>
               <div className="mb-6">
-                <h2 className="text-lg font-semibold text-slate-800">Step 1 — Blog Brief</h2>
+                <h2 className="text-lg font-semibold text-slate-800">Step 1: Blog Brief</h2>
                 <p className="mt-1 text-sm text-slate-500">
                   Tell us about your post. The more detail you give, the better the output.
                 </p>

--- a/frontend/src/components/AlignmentSummary.tsx
+++ b/frontend/src/components/AlignmentSummary.tsx
@@ -121,7 +121,7 @@ export function AlignmentSummary({ blogId, onEdit, onConfirmed }: Props) {
   return (
     <div className="flex flex-col gap-6">
       <div>
-        <h2 className="text-lg font-semibold text-slate-800">Step 2 — AI Alignment Summary</h2>
+        <h2 className="text-lg font-semibold text-slate-800">Step 2: AI Alignment Summary</h2>
         <p className="mt-1 text-sm text-slate-500">
           Review what the AI has understood. Edit or confirm before generation begins.
         </p>

--- a/frontend/src/components/BlogBriefForm.tsx
+++ b/frontend/src/components/BlogBriefForm.tsx
@@ -49,7 +49,7 @@ const schema = z
 
 type FormValues = z.input<typeof schema>;
 
-/** New blogs have no `blog_briefs` row yet — GET /brief returns 404 with this message. */
+/** New blogs have no `blog_briefs` row yet. GET /brief returns 404 with this message. */
 function isBriefNotFoundError(e: unknown): boolean {
   return e instanceof Error && e.message === 'Brief not found';
 }
@@ -247,7 +247,7 @@ export function BlogBriefForm({ blogId, onSuccess }: Props) {
 
       <Field
         label="Reference URLs"
-        hint="Optional — add up to 5 URLs. We'll scrape each one to inform the content."
+        hint="Optional: add up to 5 URLs. We'll scrape each one to inform the content."
       >
         <ReferenceUrlList blogId={blogId} initialReferences={existingReferences} />
       </Field>

--- a/frontend/src/components/DraftStep.tsx
+++ b/frontend/src/components/DraftStep.tsx
@@ -86,7 +86,7 @@ export function DraftStep({ blogId, onBack, onConfirmed }: Props) {
   return (
     <div className="flex flex-col gap-6">
       <div>
-        <h2 className="text-lg font-semibold text-slate-800">Step 4 — Blog Draft</h2>
+        <h2 className="text-lg font-semibold text-slate-800">Step 4: Blog Draft</h2>
         <p className="mt-1 text-sm text-slate-500">
           Review the AI-generated markdown. Give feedback to revise, or confirm when you are happy.
         </p>

--- a/frontend/src/components/OutlineStep.tsx
+++ b/frontend/src/components/OutlineStep.tsx
@@ -88,7 +88,7 @@ export function OutlineStep({ blogId, onBack, onConfirmed }: Props) {
   return (
     <div className="flex flex-col gap-6">
       <div>
-        <h2 className="text-lg font-semibold text-slate-800">Step 3 — Blog Outline</h2>
+        <h2 className="text-lg font-semibold text-slate-800">Step 3: Blog Outline</h2>
         <p className="mt-1 text-sm text-slate-500">
           Review the AI-generated structure. Provide feedback or confirm to proceed to drafting.
         </p>

--- a/frontend/src/components/PublishStep.tsx
+++ b/frontend/src/components/PublishStep.tsx
@@ -142,7 +142,7 @@ export function PublishStep({ blogId, onBack, onFinish }: Props) {
     try {
       const draftRes = await getDraft(blogId);
       if (!draftRes.draft.draftConfirmed) {
-        setError('Draft is not confirmed — go back to Step 4 and confirm the draft first.');
+        setError('Draft is not confirmed - go back to Step 4 and confirm the draft first.');
         return;
       }
       setMarkdown(draftRes.draft.markdown);
@@ -197,10 +197,10 @@ export function PublishStep({ blogId, onBack, onFinish }: Props) {
   return (
     <div className="flex min-h-0 flex-col gap-6">
       <div>
-        <h2 className="text-lg font-semibold text-slate-800">Step 5 — Publish</h2>
+        <h2 className="text-lg font-semibold text-slate-800">Step 5: Publish</h2>
         <p className="mt-1 text-sm text-slate-500">
           Review your post, then use Export to copy Markdown or HTML for your CMS. Copied full posts
-          include the title, optional slug and meta, and body — matching the preview.
+          include the title, optional slug and meta, and body, matching the preview.
         </p>
       </div>
 
@@ -275,7 +275,7 @@ export function PublishStep({ blogId, onBack, onFinish }: Props) {
             )}
           </div>
 
-          {/* Export — below preview for a single scroll flow */}
+          {/* Export: below preview for a single scroll flow */}
           <div className="min-w-0 w-full">
             <div className="flex flex-col gap-4 rounded-xl border border-slate-200 bg-white p-1 shadow-sm">
               <div className="px-3 pt-3">
@@ -286,7 +286,7 @@ export function PublishStep({ blogId, onBack, onFinish }: Props) {
               <div className="flex flex-col gap-2 border-t border-slate-100 px-3 py-3">
                 <p className="text-xs font-medium text-slate-600">Full post</p>
                 <p className="text-xs text-slate-500">
-                  Title, optional slug and meta, and body — in one paste.
+                  Title, optional slug and meta, and body in one paste.
                 </p>
                 <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:gap-2">
                   <CopyButton
@@ -356,7 +356,7 @@ export function PublishStep({ blogId, onBack, onFinish }: Props) {
                     <span>SEO and social</span>
                     {!seoOpen && (suggestedSlug || metaDescription || seoTitle) && (
                       <p className="mt-0.5 text-xs font-normal text-slate-500">
-                        SEO title, slug, and meta available — expand to view and copy.
+                        SEO title, slug, and meta available. Expand to view and copy.
                       </p>
                     )}
                   </div>
@@ -387,7 +387,7 @@ export function PublishStep({ blogId, onBack, onFinish }: Props) {
                         />
                       </div>
                     ) : (
-                      <p className="text-xs text-slate-400">SEO title not yet generated — confirm the draft to generate.</p>
+                      <p className="text-xs text-slate-400">SEO title not yet generated. Confirm the draft to generate.</p>
                     )}
 
                     {suggestedSlug ? (
@@ -404,7 +404,7 @@ export function PublishStep({ blogId, onBack, onFinish }: Props) {
                         />
                       </div>
                     ) : (
-                      <p className="text-xs text-slate-400">Slug not yet generated — confirm the draft to generate.</p>
+                      <p className="text-xs text-slate-400">Slug not yet generated. Confirm the draft to generate.</p>
                     )}
 
                     {metaDescription ? (
@@ -426,7 +426,7 @@ export function PublishStep({ blogId, onBack, onFinish }: Props) {
                         />
                       </div>
                     ) : (
-                      <p className="text-xs text-slate-400">Meta not yet generated — confirm the draft to generate.</p>
+                      <p className="text-xs text-slate-400">Meta not yet generated. Confirm the draft to generate.</p>
                     )}
 
                     {(seoTitle || metaDescription || suggestedSlug || primaryKeyword) && (

--- a/frontend/src/components/ReferenceUrlCard.tsx
+++ b/frontend/src/components/ReferenceUrlCard.tsx
@@ -79,7 +79,7 @@ function ScrapeLine({ status, error }: { status: ReferenceScrapeStatus; error: s
   if (status === 'timeout') {
     return (
       <span className="text-xs text-amber-600">
-        ⚠ {error ?? 'Request timed out — the URL may be slow or unreachable.'}
+        ⚠ {error ?? 'Request timed out - the URL may be slow or unreachable.'}
       </span>
     );
   }
@@ -120,7 +120,7 @@ function ExtractionLine({
     return (
       <div className="flex flex-col gap-2">
         <p className="text-xs text-amber-800 leading-snug">
-          {errorDetail?.trim() ?? 'Reference analysis failed — alignment can still use the raw page text.'}
+          {errorDetail?.trim() ?? 'Reference analysis failed - alignment can still use the raw page text.'}
         </p>
         <Button
           type="button"

--- a/frontend/src/components/ScrapeStatusIndicator.tsx
+++ b/frontend/src/components/ScrapeStatusIndicator.tsx
@@ -42,7 +42,7 @@ export function ScrapeStatusIndicator({ blogId }: Props) {
   if (status.scrapeStatus === 'success') {
     return (
       <Toast variant="success">
-        Reference URL scraped — {status.scrapedContentLength.toLocaleString()} chars extracted.
+        Reference URL scraped. {status.scrapedContentLength.toLocaleString()} chars extracted.
       </Toast>
     );
   }

--- a/frontend/src/lib/publishContent.ts
+++ b/frontend/src/lib/publishContent.ts
@@ -30,13 +30,13 @@ export interface FullDocumentHtmlOptions {
   bodyMarkdown: string;
 }
 
-/** HTML `<head>` snippet with SEO meta tags — paste into your CMS head section. */
+/** HTML `<head>` snippet with SEO meta tags. Paste into your CMS head section. */
 export function buildSeoMetaSnippet(opts: Pick<FullDocumentHtmlOptions, 'seoTitle' | 'metaDescription' | 'suggestedSlug' | 'primaryKeyword' | 'title'>): string {
   const baseUrl = (import.meta.env['VITE_BASE_URL'] as string | undefined)?.replace(/\/$/, '') || DEFAULT_BASE_URL;
   const displayTitle = opts.seoTitle?.trim() || opts.title.trim();
   const canonicalSlug = opts.suggestedSlug?.trim() ?? '';
   const lines: string[] = [
-    `<!-- SEO meta tags — paste into your CMS <head> section -->`,
+    `<!-- SEO meta tags. Paste into your CMS <head> section -->`,
     `<title>${escapeHtml(displayTitle)}</title>`,
   ];
   if (opts.metaDescription?.trim()) {

--- a/scripts/deploy-ec2.sh
+++ b/scripts/deploy-ec2.sh
@@ -10,7 +10,7 @@ cd "$ROOT"
 if [[ -x scripts/verify-deploy-env.sh ]]; then
   scripts/verify-deploy-env.sh .
 else
-  echo "[deploy] WARN: scripts/verify-deploy-env.sh missing or not executable — skipping env verification" >&2
+  echo "[deploy] WARN: scripts/verify-deploy-env.sh missing or not executable - skipping env verification" >&2
 fi
 
 # shellcheck disable=SC2016
@@ -48,7 +48,7 @@ if dc --env-file backend/.env up -d --help 2>&1 | grep -qE '[[:space:]]--wait[[:
   echo "[deploy] docker compose up -d --wait"
   dc --env-file backend/.env up -d --wait
 else
-  echo "[deploy] NOTE: this Compose has no 'up -d --wait' — consider upgrading to Docker Compose 2.29+"
+  echo "[deploy] NOTE: this Compose has no 'up -d --wait' - consider upgrading to Docker Compose 2.29+"
   echo "[deploy] docker compose up -d"
   dc --env-file backend/.env up -d
 fi


### PR DESCRIPTION
## Summary
- Adds `copy-style.ts` (`PROMPT_EMDASH_BAN`, `stripEmDashes`, `stripEmDashesDeep`) and applies to alignment, draft, outline, reference extraction, and read paths
- Updates wizard and publish strings; `content-style-sdlc.md` and task doc
- `deploy-ec2.sh`: log lines use ASCII hyphens (no U+2014 in script output)

Closes #63

## Glossary
| Term | Definition |
|------|------------|
| **U+2014** | Unicode em dash, banned in generated copy; replaced with spaced hyphen via `stripEmDashes`. |
| **PROMPT_EMDASH_BAN** | Instruction injected into LLM user prompts. |
| **stripEmDashesDeep** | Recursively normalizes em dashes in JSON-shaped model output before persist or response. |

Made with [Cursor](https://cursor.com)