### PR TITLE
chore(#65): conventional-commit version infer and postversion sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project are documented in this file. The format is b
 
 ### Added
 
+- **Versioning** — `scripts/bump-version.mjs` and `npm run version:infer` / `version:bump` infer semver from conventional commits since the release git tag; rules in [`docs/releases.md`](docs/releases.md). Root `postversion` runs `version:sync` and stages workspace `package.json` files after `npm version`.
 - **Content style:** Ban Unicode em dash (U+2014) in AI output and harmonized UI: [`backend/src/lib/copy-style.ts`](backend/src/lib/copy-style.ts), prompt instruction `PROMPT_EMDASH_BAN`, stripping in draft/outline/alignment/reference-extraction services and key API read paths. Documented in [`docs/content-style-sdlc.md`](docs/content-style-sdlc.md) and task [`docs/tasks/feat-no-em-dash-content-style.md`](docs/tasks/feat-no-em-dash-content-style.md).
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ AI-guided wizard for producing fully-structured blog posts, step by step, with t
 | CI/CD | GitHub Actions: deploy to EC2 on push to `main` ([docs/deployment.md](docs/deployment.md)) |
 | Testing | Vitest (unit/integration) + Playwright (E2E) |
 
-**Versioning:** the product semver lives in the root `package.json`. Sync workspaces with `npm run version:sync`, then commit; release process and SDLC map are in [docs/releases.md](docs/releases.md) and [CHANGELOG.md](CHANGELOG.md). **Copy style** (no em dashes in generated or user-facing product text): [docs/content-style-sdlc.md](docs/content-style-sdlc.md).
+**Versioning:** the product semver lives in the root `package.json`. Sync workspaces with `npm run version:sync`, or bump with `npm run version:infer` / `npm run version:bump -- patch|minor|major` (see [docs/releases.md](docs/releases.md)); release notes in [CHANGELOG.md](CHANGELOG.md). **Copy style** (no em dashes in generated or user-facing product text): [docs/content-style-sdlc.md](docs/content-style-sdlc.md).
 
 ---
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -10,7 +10,7 @@ This app uses **one semver** for the product: the **`version` field in the root 
 | **Implement** | Add a one-line entry under `## [Unreleased]` in `CHANGELOG.md` if the change is user-visible. |
 | **Review** | PR description should mention impact for operators/users (Helps with release notes). |
 | **Test** | `npm test`, `npm run build`; after deploy, hit `GET /version` and confirm the UI footer. For copy changes, see [content-style-sdlc.md](./content-style-sdlc.md). |
-| **Release** | Bump semver, tag `vX.Y.Z`, copy `[Unreleased]` into a dated `## [X.Y.Z]` section, merge to `main` (triggers [deploy workflow](../.github/workflows/deploy-ec2.yml)) or deploy manually per [deployment.md](./deployment.md). |
+| **Release** | Bump semver (`npm run version:infer` or `npm run version:bump -- patch|minor|major`), tag `vX.Y.Z`, copy `[Unreleased]` into a dated `## [X.Y.Z]` section, merge to `main` (triggers [deploy workflow](../.github/workflows/deploy-ec2.yml)) or deploy manually per [deployment.md](./deployment.md). |
 | **Hotfix** | `npm version patch` (or `minor` / `major`), tag, merge to `main` / deploy; note in `CHANGELOG.md`. |
 
 ## How to release
@@ -42,6 +42,51 @@ This app uses **one semver** for the product: the **`version` field in the root 
 - **MINOR** — new behaviour, backward compatible.
 - **PATCH** — fixes and internal changes without a public contract change.
 
+## Conventional commits → bump (automation)
+
+Use [**Conventional Commits**](https://www.conventionalcommits.org/) in PR titles / merge commits so tooling can infer the next semver.
+
+### Rules (`npm run version:infer`)
+
+The script inspects **`v<current package.json version>..HEAD`**, or falls back to **`latest v* tag..HEAD`**. If neither anchor exists, it stops and tells you to tag a release or bump manually — so inference never scans the entire project history by accident.
+
+| Commit type (prefix) | Semver impact | Notes |
+| --- | --- | --- |
+| `feat:` / `feature:` | **MINOR** | User-visible capability. |
+| `fix:`, `perf:`, `refactor:`, `revert:` | **PATCH** | Bugs, performance, safe refactors. |
+| `feat!:`, `fix!:`, … or `BREAKING CHANGE:` in body | **MAJOR** | Breaking change for API, schema, or operators. |
+| `docs:`, `chore:`, `style:`, `test:`, `build:`, `ci:` | **none** | Does not bump the product version **if every** commit in range is only these types. |
+| Other / non-conventional | **PATCH** | Conservative default when the prefix is unknown. |
+
+When several commits are in range, the **highest** impact wins (e.g. one `feat` and one `fix` → **minor**).
+
+### Commands
+
+```bash
+# Preview inferred bump (no file changes)
+npm run version:infer:dry
+
+# Apply inferred bump + sync backend/frontend package.json
+npm run version:infer
+
+# Override when you know the level
+npm run version:bump -- patch    # or minor | major
+npm run version:bump -- patch --dry-run
+```
+
+After **`version:infer`** or **`version:bump`**, commit the three `package.json` files, update [CHANGELOG.md](../CHANGELOG.md), and tag **`vX.Y.Z`** (see **How to release** above). **`npm version patch`** (etc.) still works: **`postversion`** runs **`version:sync`** and stages workspace manifests.
+
+### First-time / no tags yet
+
+After the first release line in the changelog, create the anchor tag matching the root version, e.g.:
+
+```bash
+git tag v0.1.0 -m "Release 0.1.0"
+git push origin v0.1.0
+```
+
+Then future `version:infer` runs use `v0.1.0..HEAD` (or the tag that matches `package.json` once you bump).
+
 ## File reference
 
 - Root: `package.json` (`version`)
@@ -50,4 +95,5 @@ This app uses **one semver** for the product: the **`version` field in the root 
 - [docker-compose.yml](../docker-compose.yml) — `APP_VERSION` / `GIT_SHA` build args
 - [scripts/build-env.sh](../scripts/build-env.sh) — load version + git from the repo for Docker builds
 - [scripts/sync-version.mjs](../scripts/sync-version.mjs) — copy root `version` to workspaces
+- [scripts/bump-version.mjs](../scripts/bump-version.mjs) — explicit or `--infer` semver bump + sync
 - [deployment.md](./deployment.md) — production EC2 deploy and GitHub Actions secrets

--- a/package.json
+++ b/package.json
@@ -10,7 +10,11 @@
     "dev": "concurrently \"npm run dev --workspace=backend\" \"npm run dev --workspace=frontend\"",
     "build": "npm run build --workspace=backend && npm run build --workspace=frontend",
     "test": "npm run test --workspace=backend",
-    "version:sync": "node scripts/sync-version.mjs"
+    "version:sync": "node scripts/sync-version.mjs",
+    "version:bump": "node scripts/bump-version.mjs",
+    "version:infer": "node scripts/bump-version.mjs --infer",
+    "version:infer:dry": "node scripts/bump-version.mjs --infer --dry-run",
+    "postversion": "node scripts/sync-version.mjs && git add backend/package.json frontend/package.json"
   },
   "devDependencies": {
     "concurrently": "^9.1.2"

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,0 +1,232 @@
+/**
+ * Bump root semver, then run sync-version.mjs so backend/frontend match.
+ *
+ * Usage:
+ *   node scripts/bump-version.mjs patch|minor|major
+ *   node scripts/bump-version.mjs --infer [--dry-run]
+ *
+ * --infer: inspects git commits since the latest v* tag (or all history if none)
+ * and picks the highest bump per docs/releases.md rules.
+ */
+import { execSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+function readRootVersion() {
+  const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
+  const v = pkg.version;
+  if (typeof v !== 'string' || !/^\d+\.\d+\.\d+/.test(v)) {
+    throw new Error(`Root package.json needs semver "version" (got ${String(v)})`);
+  }
+  return { pkg, version: v };
+}
+
+function parseSemver(v) {
+  const m = v.match(/^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+([0-9A-Za-z.-]+))?$/);
+  if (!m) throw new Error(`Not a simple semver X.Y.Z: ${v}`);
+  return { major: +m[1], minor: +m[2], patch: +m[3], pre: m[4], build: m[5] };
+}
+
+function formatSemver(p, pre, build) {
+  let s = `${p.major}.${p.minor}.${p.patch}`;
+  if (pre) s += `-${pre}`;
+  if (build) s += `+${build}`;
+  return s;
+}
+
+function bumpLevel(parts, level) {
+  const { major, minor, patch, pre, build } = parts;
+  if (pre || build) {
+    throw new Error(`Bump script only supports simple X.Y.Z without pre-release (got ${formatSemver(parts, pre, build)})`);
+  }
+  if (level === 'major') return { major: major + 1, minor: 0, patch: 0 };
+  if (level === 'minor') return { major, minor: minor + 1, patch: 0 };
+  if (level === 'patch') return { major, minor, patch: patch + 1 };
+  throw new Error(`Invalid level: ${level}`);
+}
+
+function runSync() {
+  execSync('node scripts/sync-version.mjs', { cwd: root, stdio: 'inherit' });
+}
+
+function git(args, { allowFail = false } = {}) {
+  try {
+    return execSync(`git ${args}`, {
+      cwd: root,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+  } catch {
+    if (allowFail) return '';
+    throw new Error(`git ${args} failed`);
+  }
+}
+
+/**
+ * @returns {string|null} rev range for git log, e.g. "v0.1.0..HEAD"
+ */
+function getLogRange() {
+  const { version } = readRootVersion();
+  const exact = `v${version}`;
+  if (git(`rev-parse -q --verify "refs/tags/${exact}"`, { allowFail: true })) {
+    return `${exact}..HEAD`;
+  }
+  const latest = git('describe --tags --abbrev=0 --match "v[0-9]*"', { allowFail: true });
+  if (latest) return `${latest}..HEAD`;
+  return null;
+}
+
+/**
+ * @param {string} subject first line of commit message
+ * @param {string} body rest of commit message
+ * @returns {'major'|'minor'|'patch'|'none'}
+ */
+function bumpFromCommit(subject, body) {
+  const text = `${subject}\n${body}`;
+  if (/^BREAKING CHANGE(\s|$)/m.test(body) || /^BREAKING-CHANGE(\s|$)/m.test(body)) {
+    return 'major';
+  }
+  // feat(api)!: or fix!: in subject
+  const header = subject.trim();
+  if (/^[a-z]+(?:\([^)]*\))?!:/i.test(header)) {
+    return 'major';
+  }
+
+  const typeMatch = header.match(/^([a-z]+)(?:\([^)]*\))?:\s/i);
+  if (!typeMatch) return 'none';
+  const type = typeMatch[1].toLowerCase();
+
+  if (type === 'feat' || type === 'feature') return 'minor';
+  if (
+    type === 'fix' ||
+    type === 'perf' ||
+    type === 'refactor' ||
+    type === 'revert'
+  ) {
+    return 'patch';
+  }
+  // Non-user-facing — no product version impact when alone
+  if (
+    type === 'docs' ||
+    type === 'chore' ||
+    type === 'style' ||
+    type === 'test' ||
+    type === 'build' ||
+    type === 'ci'
+  ) {
+    return 'none';
+  }
+  // Unknown types: conservative patch
+  return 'patch';
+}
+
+function rank(b) {
+  if (b === 'major') return 3;
+  if (b === 'minor') return 2;
+  if (b === 'patch') return 1;
+  return 0;
+}
+
+function inferBump() {
+  const range = getLogRange();
+  if (!range) {
+    const { version } = readRootVersion();
+    return {
+      level: null,
+      reason: `No git tag anchor found. Create tag v${version} (or an older v* release tag), push it, then retry — or bump explicitly: node scripts/bump-version.mjs patch|minor|major`,
+    };
+  }
+  let raw;
+  try {
+    raw = git(`log ${range} --pretty=format:%H%x1f%s%x1f%b%x1e`);
+  } catch {
+    return { level: null, reason: 'No commits in range.' };
+  }
+  if (!raw) {
+    return { level: null, reason: `No commits since ${range.replace(/\.\.HEAD$/, '')}.` };
+  }
+
+  const chunks = raw.split('\x1e').filter(Boolean);
+  let best = 0;
+  const counts = { major: 0, minor: 0, patch: 0, none: 0 };
+
+  for (const chunk of chunks) {
+    const [hash, subject, body = ''] = chunk.split('\x1f');
+    if (!hash) continue;
+    const b = bumpFromCommit(subject || '', body || '');
+    counts[b === 'none' ? 'none' : b]++;
+    best = Math.max(best, rank(b));
+  }
+
+  if (best === 0) {
+    return {
+      level: null,
+      reason: `Only non-shipping types (docs/chore/ci/…) in ${range}; no semver bump.`,
+      range,
+      counts,
+    };
+  }
+
+  const level = best === 3 ? 'major' : best === 2 ? 'minor' : 'patch';
+  return { level, reason: `Inferred ${level} from conventional commits (${range}).`, range, counts };
+}
+
+function writeRootVersion(newVersion) {
+  const { pkg } = readRootVersion();
+  pkg.version = newVersion;
+  writeFileSync(join(root, 'package.json'), `${JSON.stringify(pkg, null, 2)}\n`);
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const dryRun = argv.includes('--dry-run');
+  const args = argv.filter((a) => a !== '--dry-run');
+
+  if (args.length === 1 && args[0] === '--infer') {
+    const { level, reason, counts } = inferBump();
+    process.stdout.write(`${reason}\n`);
+    if (counts) process.stdout.write(`Breakdown: ${JSON.stringify(counts)}\n`);
+    if (!level) {
+      process.exit(0);
+    }
+    if (dryRun) {
+      const { version } = readRootVersion();
+      const next = formatSemver(bumpLevel(parseSemver(version), level));
+      process.stdout.write(`Would bump ${version} → ${next}\n`);
+      process.exit(0);
+    }
+    const { version } = readRootVersion();
+    const next = formatSemver(bumpLevel(parseSemver(version), level));
+    writeRootVersion(next);
+    runSync();
+    process.stdout.write(`Bumped ${version} → ${next} (workspace synced)\n`);
+    process.exit(0);
+  }
+
+  if (args.length === 1 && /^(patch|minor|major)$/.test(args[0])) {
+    const level = args[0];
+    const { version } = readRootVersion();
+    const next = formatSemver(bumpLevel(parseSemver(version), level));
+    if (dryRun) {
+      process.stdout.write(`Would bump ${version} → ${next}\n`);
+      process.exit(0);
+    }
+    writeRootVersion(next);
+    runSync();
+    process.stdout.write(`Bumped ${version} → ${next} (workspace synced)\n`);
+    process.exit(0);
+  }
+
+  process.stderr.write(`Usage:
+  node scripts/bump-version.mjs patch|minor|major [--dry-run]
+  node scripts/bump-version.mjs --infer [--dry-run]
+
+Rules for --infer are documented in docs/releases.md (conventional commits → semver).
+`);
+  process.exit(1);
+}
+
+main();

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -5,8 +5,8 @@
  *   node scripts/bump-version.mjs patch|minor|major
  *   node scripts/bump-version.mjs --infer [--dry-run]
  *
- * --infer: inspects git commits since the latest v* tag (or all history if none)
- * and picks the highest bump per docs/releases.md rules.
+ * --infer: inspects git commits in range v<package.json version>..HEAD, else
+ * latest v* tag..HEAD (see docs/releases.md). No tag anchor → exits with guidance.
  */
 import { execSync } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'node:fs';
@@ -86,7 +86,12 @@ function getLogRange() {
  */
 function bumpFromCommit(subject, body) {
   const text = `${subject}\n${body}`;
-  if (/^BREAKING CHANGE(\s|$)/m.test(body) || /^BREAKING-CHANGE(\s|$)/m.test(body)) {
+  if (
+    /^BREAKING CHANGE:/m.test(body) ||
+    /^BREAKING CHANGE(\s|$)/m.test(body) ||
+    /^BREAKING-CHANGE:/m.test(body) ||
+    /^BREAKING-CHANGE(\s|$)/m.test(body)
+  ) {
     return 'major';
   }
   // feat(api)!: or fix!: in subject
@@ -96,7 +101,7 @@ function bumpFromCommit(subject, body) {
   }
 
   const typeMatch = header.match(/^([a-z]+)(?:\([^)]*\))?:\s/i);
-  if (!typeMatch) return 'none';
+  if (!typeMatch) return 'patch';
   const type = typeMatch[1].toLowerCase();
 
   if (type === 'feat' || type === 'feature') return 'minor';


### PR DESCRIPTION
## Summary
Adds automated semver bumping from conventional commits (with explicit override), documents rules, and wires `postversion` to keep workspace `package.json` files aligned.

## Changes
- `scripts/bump-version.mjs` — `patch|minor|major` or `--infer`; anchored to `v<package version>` or latest `v*` tag
- npm: `version:bump`, `version:infer`, `version:infer:dry`, `postversion`
- `docs/releases.md`, README, CHANGELOG

Closes #65

## Glossary
| Term | Definition |
|------|------------|
| Semver | Semantic version **MAJOR.MINOR.PATCH** per semver.org. |
| Conventional commits | Commit subjects like `feat:`, `fix:`, `BREAKING CHANGE:` used to infer bump level. |
| Version anchor | Git tag `vX.Y.Z` matching (or preceding) the root `package.json` `version`; `--infer` diffs from that tag to `HEAD`. |
| postversion | npm lifecycle hook after `npm version`; runs `version:sync` and stages backend/frontend manifests. |

## Commit SHA verification
- [ ] Code Reviewer approved commit: (pending)
- [ ] Current HEAD commit: c104744d232924c60f08871df0891a53adbe9eee
- [ ] Match? (pending review)

## Test plan
- [x] `node scripts/bump-version.mjs patch --dry-run`
- [x] `node scripts/bump-version.mjs --infer --dry-run` without tags → clear message

Made with [Cursor](https://cursor.com)