### PR TITLE
fix(#67): survive transient poll errors in reference card

### DIFF
--- a/frontend/src/components/ReferenceUrlCard.tsx
+++ b/frontend/src/components/ReferenceUrlCard.tsx
@@ -200,11 +200,15 @@ export function ReferenceUrlCard({
     if (scrapeDone && extractionDone) return;
 
     let cancelled = false;
+    let consecutiveErrors = 0;
+    const MAX_CONSECUTIVE_ERRORS = 5;
+
     const timer = setInterval(() => {
       if (cancelled) return;
       getReferenceStatus(blogId, refId)
         .then((s) => {
           if (cancelled) return;
+          consecutiveErrors = 0;
           setScrapeStatus(s.scrapeStatus);
           setScrapeError(s.scrapeError);
           setExtractionStatus(s.extractionStatus);
@@ -224,7 +228,9 @@ export function ReferenceUrlCard({
           if (doneNow) clearInterval(timer);
         })
         .catch(() => {
-          if (!cancelled) clearInterval(timer);
+          if (cancelled) return;
+          consecutiveErrors++;
+          if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) clearInterval(timer);
         });
     }, POLL_INTERVAL_MS);
 


### PR DESCRIPTION
## Summary

- Reference URL cards were freezing permanently at "Analysing reference…" when a single poll request failed (network blip, server restart)
- The `.catch` handler in the polling `useEffect` called `clearInterval` on **any** error, killing the loop forever
- The AI extraction completed on the backend (visible on the Alignment step as "🔗 Reference Understanding"), but the Brief step never picked up the result
- Fix: replace hard `clearInterval` in catch with a consecutive-failure counter; polling only stops after 5 straight failures (~10s of sustained errors), then resets on the next successful response

## Testing

1. Add a reference URL in the Blog Brief step
2. While "Analysing reference…" spins, simulate a network blip (DevTools → Network → Offline for 1–2s → back Online)
3. Verify the spinner recovers and eventually shows the analysis result
4. Verify the card still stops polling and shows results on success (happy path unchanged)

Fixes #67

---

## Glossary

| Term | Definition |
|------|------------|
| `consecutiveErrors` | Counter incremented on each failed poll request; resets to zero on success; polling stops only when it reaches `MAX_CONSECUTIVE_ERRORS` (5) |
| `clearInterval` | Browser API that cancels a repeating timer set by `setInterval` |
| `extractionStatus` | Backend state for the AI reference-analysis job: `pending`, `success`, `failed`, or `irrelevant` |
| Polling | The frontend pattern of repeatedly calling an API endpoint (every 2s here) until a background job settles |
| Transient error | A short-lived network failure (timeout, server blip) that resolves on retry, as opposed to a permanent API failure |