### PR TITLE
fix(#95): EP-04 JWT on API calls, admin demote guard, seed env password

### DIFF
--- a/backend/src/db/migrations/migrate-012-create-users-table.sql
+++ b/backend/src/db/migrations/migrate-012-create-users-table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS users (
+  id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  role VARCHAR(20) NOT NULL DEFAULT 'user',
+  email_verified_at TIMESTAMPTZ,
+  deactivated_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/backend/src/db/migrations/migrate-012-create-users-table.sql
+++ b/backend/src/db/migrations/migrate-012-create-users-table.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS users (
   id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
-  role VARCHAR(20) NOT NULL DEFAULT 'user',
+  role VARCHAR(20) NOT NULL DEFAULT 'user' CHECK (role IN ('admin', 'user')),
   email_verified_at TIMESTAMPTZ,
   deactivated_at TIMESTAMPTZ,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),

--- a/backend/src/db/migrations/migrate-013-auth-sync-triggers.sql
+++ b/backend/src/db/migrations/migrate-013-auth-sync-triggers.sql
@@ -8,6 +8,9 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;
 
+ALTER FUNCTION public.handle_new_user() SET search_path = public;
+REVOKE ALL ON FUNCTION public.handle_new_user() FROM PUBLIC;
+
 DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
 
 CREATE TRIGGER on_auth_user_created
@@ -25,6 +28,9 @@ BEGIN
   RETURN new;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;
+
+ALTER FUNCTION public.handle_auth_user_update() SET search_path = public;
+REVOKE ALL ON FUNCTION public.handle_auth_user_update() FROM PUBLIC;
 
 DROP TRIGGER IF EXISTS on_auth_user_updated ON auth.users;
 

--- a/backend/src/db/migrations/migrate-013-auth-sync-triggers.sql
+++ b/backend/src/db/migrations/migrate-013-auth-sync-triggers.sql
@@ -1,0 +1,35 @@
+-- Function to handle new user insertion
+CREATE OR REPLACE FUNCTION public.handle_new_user() 
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO public.users (id, role, email_verified_at)
+  VALUES (new.id, 'user', new.email_confirmed_at);
+  RETURN new;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
+
+-- Function to handle user update (mirroring email verification)
+CREATE OR REPLACE FUNCTION public.handle_auth_user_update()
+RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE public.users
+  SET email_verified_at = new.email_confirmed_at,
+      updated_at = NOW()
+  WHERE id = new.id;
+  RETURN new;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+DROP TRIGGER IF EXISTS on_auth_user_updated ON auth.users;
+
+CREATE TRIGGER on_auth_user_updated
+  AFTER UPDATE OF email_confirmed_at ON auth.users
+  FOR EACH ROW
+  WHEN (old.email_confirmed_at IS DISTINCT FROM new.email_confirmed_at)
+  EXECUTE FUNCTION public.handle_auth_user_update();

--- a/backend/src/db/migrations/migrate-014-foreign-keys.sql
+++ b/backend/src/db/migrations/migrate-014-foreign-keys.sql
@@ -1,0 +1,5 @@
+ALTER TABLE blogs 
+ADD CONSTRAINT fk_blogs_user_id FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE NOT VALID;
+
+ALTER TABLE author_profiles 
+ADD CONSTRAINT fk_author_profiles_user_id FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE NOT VALID;

--- a/backend/src/handlers/__tests__/profile-handler.test.ts
+++ b/backend/src/handlers/__tests__/profile-handler.test.ts
@@ -28,7 +28,12 @@ const SAMPLE_PROFILE = {
 };
 
 function makeReq(body: unknown = {}, params: Record<string, string> = {}): Request {
-  return { body, params } as unknown as Request;
+  return {
+    body,
+    params,
+    // Handlers call getUserId(), which assumes requireAuth already ran.
+    userId: '00000000-0000-0000-0000-000000000001',
+  } as unknown as Request;
 }
 
 function makeRes(): { res: Response; json: ReturnType<typeof vi.fn>; status: ReturnType<typeof vi.fn> } {

--- a/backend/src/handlers/admin-handler.ts
+++ b/backend/src/handlers/admin-handler.ts
@@ -1,0 +1,187 @@
+import type { Request, Response } from 'express';
+import { getSupabase } from '../db/supabase.js';
+import { getUserId } from '../middleware/auth.js';
+
+/** Express may type params as `string | string[]`; routes here use a single segment. */
+function routeParam(value: string | string[] | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  return Array.isArray(value) ? value[0] : value;
+}
+
+export async function listUsers(req: Request, res: Response) {
+  try {
+    const supabase = getSupabase();
+    
+    // We get auth users via Admin API for email, and join with public.users
+    const { data: authUsers, error: authError } = await supabase.auth.admin.listUsers();
+    if (authError) throw authError;
+
+    const { data: publicUsers, error: dbError } = await supabase
+      .from('users')
+      .select('*');
+    if (dbError) throw dbError;
+
+    const userMap = new Map(publicUsers.map((u: any) => [u.id, u]));
+
+    const users = authUsers.users.map(u => {
+      const p = userMap.get(u.id) || {};
+      return {
+        id: u.id,
+        email: u.email,
+        role: p.role || 'user',
+        email_verified_at: p.email_verified_at || u.email_confirmed_at,
+        deactivated_at: p.deactivated_at || null,
+        created_at: p.created_at || u.created_at,
+        last_sign_in_at: u.last_sign_in_at
+      };
+    });
+
+    res.json(users);
+  } catch (err) {
+    res.status(500).json({ error: (err as Error).message });
+  }
+}
+
+export async function deactivateUser(req: Request, res: Response) {
+  const id = routeParam(req.params.id);
+  if (!id) {
+    res.status(400).json({ error: 'Missing user id' });
+    return;
+  }
+  try {
+    const supabase = getSupabase();
+    
+    // Last-admin protection
+    const { data: userToDeactivate } = await supabase.from('users').select('role').eq('id', id).single();
+    if (userToDeactivate?.role === 'admin') {
+      const { count } = await supabase.from('users').select('*', { count: 'exact' }).eq('role', 'admin').is('deactivated_at', null);
+      if (count && count <= 1) {
+        res.status(409).json({ error: 'LAST_ADMIN', message: 'Cannot deactivate the last admin' });
+        return;
+      }
+    }
+
+    const { error } = await supabase.from('users').update({ deactivated_at: new Date().toISOString() }).eq('id', id);
+    if (error) throw error;
+    res.json({ success: true });
+  } catch (err) {
+    res.status(500).json({ error: (err as Error).message });
+  }
+}
+
+export async function promoteUser(req: Request, res: Response) {
+  const id = routeParam(req.params.id);
+  if (!id) {
+    res.status(400).json({ error: 'Missing user id' });
+    return;
+  }
+  try {
+    const supabase = getSupabase();
+    const { error } = await supabase.from('users').update({ role: 'admin' }).eq('id', id);
+    if (error) throw error;
+    res.json({ success: true });
+  } catch (err) {
+    res.status(500).json({ error: (err as Error).message });
+  }
+}
+
+export async function demoteUser(req: Request, res: Response) {
+  const id = routeParam(req.params.id);
+  if (!id) {
+    res.status(400).json({ error: 'Missing user id' });
+    return;
+  }
+  const currentAdminId = getUserId(req);
+
+  if (id === currentAdminId) {
+    res.status(403).json({ error: 'Cannot demote yourself directly' });
+    return;
+  }
+
+  try {
+    const supabase = getSupabase();
+    
+    // Last-admin protection
+    const { count } = await supabase.from('users').select('*', { count: 'exact' }).eq('role', 'admin').is('deactivated_at', null);
+    if (count && count <= 1) {
+      res.status(409).json({ error: 'LAST_ADMIN', message: 'Cannot demote the last admin' });
+      return;
+    }
+
+    const { error } = await supabase.from('users').update({ role: 'user' }).eq('id', id);
+    if (error) throw error;
+    res.json({ success: true });
+  } catch (err) {
+    res.status(500).json({ error: (err as Error).message });
+  }
+}
+
+export async function forceResetUser(req: Request, res: Response) {
+  const id = routeParam(req.params.id);
+  if (!id) {
+    res.status(400).json({ error: 'Missing user id' });
+    return;
+  }
+  try {
+    const supabase = getSupabase();
+    const { data: user, error: userError } = await supabase.auth.admin.getUserById(id);
+    if (userError) throw userError;
+
+    if (!user.user.email) {
+      res.status(400).json({ error: 'User has no email' });
+      return;
+    }
+
+    const { error } = await supabase.auth.resetPasswordForEmail(user.user.email);
+    if (error) throw error;
+    
+    res.json({ success: true });
+  } catch (err) {
+    res.status(500).json({ error: (err as Error).message });
+  }
+}
+
+export async function listAllBlogs(req: Request, res: Response) {
+  try {
+    const supabase = getSupabase();
+    const { data: blogs, error } = await supabase
+      .from('blogs')
+      .select('*, users(id)'); // In a real scenario we'd join auth.users or mapped email.
+    
+    if (error) throw error;
+
+    // Fetch emails for these users
+    const userIds = [...new Set(blogs.map((b: any) => b.user_id))];
+    const { data: authUsers } = await supabase.auth.admin.listUsers();
+    const emailMap = new Map((authUsers?.users || []).map(u => [u.id, u.email]));
+
+    const enrichedBlogs = blogs.map((b: any) => ({
+      ...b,
+      owner_email: emailMap.get(b.user_id) || 'Unknown'
+    }));
+
+    res.json(enrichedBlogs);
+  } catch (err) {
+    res.status(500).json({ error: (err as Error).message });
+  }
+}
+
+export async function getAnyBlog(req: Request, res: Response) {
+  const id = routeParam(req.params.id);
+  if (!id) {
+    res.status(400).json({ error: 'Missing blog id' });
+    return;
+  }
+  try {
+    const supabase = getSupabase();
+    const { data: blog, error } = await supabase.from('blogs').select('*').eq('id', id).single();
+    if (error) throw error;
+    if (!blog) {
+      res.status(404).json({ error: 'Blog not found' });
+      return;
+    }
+    res.json(blog);
+  } catch (err) {
+    res.status(500).json({ error: (err as Error).message });
+  }
+}

--- a/backend/src/handlers/admin-handler.ts
+++ b/backend/src/handlers/admin-handler.ts
@@ -100,9 +100,24 @@ export async function demoteUser(req: Request, res: Response) {
 
   try {
     const supabase = getSupabase();
-    
-    // Last-admin protection
-    const { count } = await supabase.from('users').select('*', { count: 'exact' }).eq('role', 'admin').is('deactivated_at', null);
+
+    const { data: targetUser, error: targetError } = await supabase
+      .from('users')
+      .select('role')
+      .eq('id', id)
+      .single();
+    if (targetError) throw targetError;
+
+    if (targetUser?.role !== 'admin') {
+      res.json({ success: true });
+      return;
+    }
+
+    const { count } = await supabase
+      .from('users')
+      .select('*', { count: 'exact' })
+      .eq('role', 'admin')
+      .is('deactivated_at', null);
     if (count && count <= 1) {
       res.status(409).json({ error: 'LAST_ADMIN', message: 'Cannot demote the last admin' });
       return;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,6 +3,7 @@ import express from 'express';
 import cors from 'cors';
 import blogRoutes from './routes/blog-routes.js';
 import profileRoutes from './routes/profile-routes.js';
+import { adminRoutes } from './routes/admin-routes.js';
 import { errorHandler } from './middleware/error-handler.js';
 import { getAppVersion, getGitSha } from './version.js';
 import { validateAndLogRuntimeEnv } from './config/env.js';
@@ -22,6 +23,7 @@ app.get('/version', (_req, res) =>
 );
 app.use('/api/blogs', blogRoutes);
 app.use('/api/profiles', profileRoutes);
+app.use('/api/admin', adminRoutes);
 
 app.use(errorHandler);
 

--- a/backend/src/middleware/__tests__/auth-middleware.test.ts
+++ b/backend/src/middleware/__tests__/auth-middleware.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Request, Response, NextFunction } from 'express';
+import { requireAdmin, getUserId } from '../auth.js';
+import { requireVerifiedEmail } from '../verified.js';
+
+function makeRes() {
+  const status = vi.fn().mockReturnThis();
+  const json = vi.fn().mockReturnThis();
+  const res = { status, json } as unknown as Response;
+  return { res, status, json };
+}
+
+const next: NextFunction = vi.fn();
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('getUserId', () => {
+  it('throws when userId is missing', () => {
+    const req = {} as Request;
+    expect(() => getUserId(req)).toThrow(/requireAuth/);
+  });
+
+  it('returns userId when set', () => {
+    const req = { userId: 'u-1' } as Request;
+    expect(getUserId(req)).toBe('u-1');
+  });
+});
+
+describe('requireAdmin', () => {
+  it('returns 401 when unauthenticated', () => {
+    const req = {} as Request;
+    const { res, status } = makeRes();
+    requireAdmin(req, res, next);
+    expect(status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when role is not admin', () => {
+    const req = { user: { role: 'user' } } as unknown as Request;
+    const { res, status } = makeRes();
+    requireAdmin(req, res, next);
+    expect(status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('calls next for admin', () => {
+    const req = { user: { role: 'admin' } } as unknown as Request;
+    const { res } = makeRes();
+    requireAdmin(req, res, next);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('requireVerifiedEmail', () => {
+  it('returns 401 when unauthenticated', () => {
+    const req = {} as Request;
+    const { res, status } = makeRes();
+    requireVerifiedEmail(req, res, next);
+    expect(status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when email is unverified', () => {
+    const req = { user: { email_verified_at: null } } as unknown as Request;
+    const { res, status, json } = makeRes();
+    requireVerifiedEmail(req, res, next);
+    expect(status).toHaveBeenCalledWith(403);
+    expect(json).toHaveBeenCalledWith(expect.objectContaining({ error: 'EMAIL_NOT_VERIFIED' }));
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('calls next when verified', () => {
+    const req = { user: { email_verified_at: '2026-01-01T00:00:00Z' } } as unknown as Request;
+    const { res } = makeRes();
+    requireVerifiedEmail(req, res, next);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});
+

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,15 +1,86 @@
 import type { Request, Response, NextFunction } from 'express';
+import { getSupabase } from '../db/supabase.js';
 
-// Placeholder auth middleware — replaced when EP-04 (Authentication) is implemented.
-// For now injects a fixed userId so EP-01 endpoints can be tested end-to-end.
-const DEV_USER_ID = '00000000-0000-0000-0000-000000000001';
+export interface AuthUser {
+  id: string;
+  role: 'admin' | 'user';
+  email_verified_at: string | null;
+  deactivated_at: string | null;
+}
 
-export function requireAuth(req: Request, _res: Response, next: NextFunction): void {
-  // TODO(EP-04): verify JWT, populate req.userId from token claims
-  (req as Request & { userId: string }).userId = DEV_USER_ID;
+declare global {
+  namespace Express {
+    interface Request {
+      userId?: string;
+      user?: AuthUser;
+    }
+  }
+}
+
+export async function requireAuth(req: Request, res: Response, next: NextFunction): Promise<void> {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    res.status(401).json({ error: 'Missing or invalid Authorization header' });
+    return;
+  }
+
+  const token = authHeader.split(' ')[1];
+  if (!token) {
+    res.status(401).json({ error: 'Token missing' });
+    return;
+  }
+
+  try {
+    const supabase = getSupabase();
+    // getUser validates the JWT and checks if it's revoked
+    const { data: { user }, error } = await supabase.auth.getUser(token);
+
+    if (error || !user) {
+      res.status(401).json({ error: 'Invalid token' });
+      return;
+    }
+
+    const { data: dbUser, error: dbError } = await supabase
+      .from('users')
+      .select('id, role, email_verified_at, deactivated_at')
+      .eq('id', user.id)
+      .single();
+
+    if (dbError || !dbUser) {
+      res.status(401).json({ error: 'User record not found' });
+      return;
+    }
+
+    if (dbUser.deactivated_at) {
+      res.status(401).json({ error: 'This account has been deactivated. Please contact support.' });
+      return;
+    }
+
+    req.userId = user.id;
+    req.user = dbUser;
+    next();
+  } catch (err) {
+    res.status(500).json({ error: 'Internal authentication error' });
+  }
+}
+
+export function requireAdmin(req: Request, res: Response, next: NextFunction): void {
+  if (!req.user) {
+    res.status(401).json({ error: 'Authentication required' });
+    return;
+  }
+
+  if (req.user.role !== 'admin') {
+    res.status(403).json({ error: 'Forbidden: Admin access required' });
+    return;
+  }
+
   next();
 }
 
 export function getUserId(req: Request): string {
-  return (req as Request & { userId?: string }).userId ?? DEV_USER_ID;
+  if (!req.userId) {
+    throw new Error('getUserId called before requireAuth');
+  }
+  return req.userId;
 }

--- a/backend/src/middleware/verified.ts
+++ b/backend/src/middleware/verified.ts
@@ -1,0 +1,15 @@
+import type { Request, Response, NextFunction } from 'express';
+
+export function requireVerifiedEmail(req: Request, res: Response, next: NextFunction): void {
+  if (!req.user) {
+    res.status(401).json({ error: 'Authentication required' });
+    return;
+  }
+
+  if (!req.user.email_verified_at) {
+    res.status(403).json({ error: 'EMAIL_NOT_VERIFIED', message: 'You must verify your email to perform this action' });
+    return;
+  }
+
+  next();
+}

--- a/backend/src/routes/admin-routes.ts
+++ b/backend/src/routes/admin-routes.ts
@@ -1,0 +1,19 @@
+import { Router } from 'express';
+import { requireAuth, requireAdmin } from '../middleware/auth.js';
+import * as adminHandler from '../handlers/admin-handler.js';
+
+const router = Router();
+
+// All admin routes require authentication and admin role
+router.use(requireAuth, requireAdmin);
+
+router.get('/users', adminHandler.listUsers);
+router.post('/users/:id/deactivate', adminHandler.deactivateUser);
+router.post('/users/:id/promote', adminHandler.promoteUser);
+router.post('/users/:id/demote', adminHandler.demoteUser);
+router.post('/users/:id/force-reset', adminHandler.forceResetUser);
+
+router.get('/blogs', adminHandler.listAllBlogs);
+router.get('/blogs/:id', adminHandler.getAnyBlog);
+
+export const adminRoutes = router;

--- a/backend/src/routes/blog-routes.ts
+++ b/backend/src/routes/blog-routes.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { requireAuth } from '../middleware/auth.js';
+import { requireVerifiedEmail } from '../middleware/verified.js';
 import { handleCreateBlog, handleCompleteBlog, handleListBlogs } from '../handlers/blog-handler.js';
 import {
   handleSubmitBrief,
@@ -33,9 +34,9 @@ import { handleGetPrompt } from '../handlers/blog-prompts-handler.js';
 const router = Router();
 
 router.get('/', requireAuth, handleListBlogs);
-router.post('/', requireAuth, handleCreateBlog);
+router.post('/', requireAuth, requireVerifiedEmail, handleCreateBlog);
 router.post('/:id/complete', requireAuth, handleCompleteBlog);
-router.post('/:id/brief', requireAuth, handleSubmitBrief);
+router.post('/:id/brief', requireAuth, requireVerifiedEmail, handleSubmitBrief);
 router.get('/:id/brief', requireAuth, handleGetBrief);
 router.get('/:id/brief/scrape-status', requireAuth, handleGetScrapeStatus);
 router.post('/:id/alignment', requireAuth, handleGenerateAlignment);

--- a/docs/agdr/AgDR-0021-auth-provider-supabase.md
+++ b/docs/agdr/AgDR-0021-auth-provider-supabase.md
@@ -1,0 +1,69 @@
+---
+id: AgDR-0021
+timestamp: 2026-05-04T00:00:00Z
+agent: claude-opus-4-7 (Tech Lead role)
+model: claude-opus-4-7
+session: ep-04-auth-tech-design
+trigger: user-prompt
+status: executed
+---
+
+# AgDR-0021 — Auth Provider: Supabase Auth
+
+> In the context of replacing the placeholder dev-user UUID with real accounts in EP-04, facing the choice between Supabase Auth, Auth0, Clerk, NextAuth, or a custom implementation, I decided to use **Supabase Auth**, to achieve email/password registration, verification, password reset, and JWT issuance with zero new vendor onboarding and a database-native role layer, accepting the tradeoff that we are coupled to Supabase's auth UX, rate limits, and email-template constraints rather than a best-of-breed auth specialist.
+
+## Context
+
+EP-04 ([epic #95](https://github.com/mohamednaseramein/blog-generator/issues/95)) replaces the hardcoded dev-user UUID `00000000-0000-0000-0000-000000000001` with real authenticated accounts. The product needs:
+
+- Email/password registration with verification
+- Login and per-device logout
+- Forgot-password and reset-password flows
+- JWT-based session for the SPA frontend → Express backend
+- A role layer (`admin` | `user`) enforced at the API boundary
+- A clean cutover that adopts existing dev rows under the first admin
+
+The blog-generator already uses Supabase as its database client (see [AgDR-0003 — Supabase Database Client](./AgDR-0003-supabase-database-client.md)). The `@supabase/supabase-js` SDK is already installed in `backend/package.json`, the `auth.users` schema exists in our Supabase project, and the database connection is configured. Adding Supabase Auth means turning on a feature in the same project we already pay for, not onboarding a new vendor.
+
+The PRD ([`prd-auth-ep04.md`](https://github.com/mohamednaseramein/apexyard/blob/main/projects/blog-generator/prd-auth-ep04.md)) sets the constraint that auth provider is pre-decided as Supabase Auth. This AgDR records the trade-off for future reference.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|---|---|---|
+| **Supabase Auth (chosen)** | Already in the stack (`@supabase/supabase-js`, same project); `auth.users` lives in the same Postgres so FKs from our app `users` table are trivial; no new vendor; bcrypt + JWT + email flows handled; free tier covers v1 traffic; RLS-compatible if we want to layer it later | Locked into Supabase's email-template UX and rate-limit knobs; less polished pre-built UI than Clerk; custom flows (e.g. magic-link, MFA) require Supabase support adding them; coupling deepens our exit cost from Supabase |
+| Auth0 | Mature, OWASP-audited, rich admin UI, MFA / SSO ready | Adds a second vendor, second bill (~$25/mo at the lowest meaningful tier), separate user store from our Postgres → either sync nightmare or we treat Auth0 as source-of-truth and lose FK ergonomics; large SDK; over-engineered for an email/password v1 |
+| Clerk | Best-in-class drop-in UI, generous free tier, modern DX, strong session model | Same data-locality problem as Auth0 (user store outside our Postgres); pricing scales with MAU not flat; would force us to use their `<SignIn />` components or rebuild — couples our frontend to their components or back to a thin wrapper anyway |
+| NextAuth.js / Auth.js | Open source, code-only, no vendor lock-in | Requires us to host and operate the email-sending side, manage the password-hashing parameters, write the verification token store, and run the migrations — re-implementing what Supabase Auth already gives us; CSRF and session-fixation are our problem to get right |
+| Custom (own bcrypt + JWT + email) | Maximum control, no vendor at all | All of NextAuth's downsides plus we own every CVE, every reset-token edge case, every rate-limit bug; security-critical greenfield code is the worst place to optimise for control over speed |
+
+## Decision
+
+Chosen: **Supabase Auth**, because:
+
+1. **Zero new vendor onboarding.** The Supabase project, `auth.users` schema, and SDK are already integrated (AgDR-0003).
+2. **Database-local user identity.** `auth.users.id` is a Postgres UUID in the same database as `blogs`, `author_profiles`, etc. Our app `users` table can `REFERENCES auth.users(id)` directly — no cross-system sync.
+3. **Bundled email flows.** Verification, forgot-password, reset, and resend are first-class features; we wire them up rather than build them.
+4. **Reuses the JWT infrastructure** the SPA already understands implicitly via `@supabase/supabase-js`. The backend verifies the JWT per request using Supabase's `jwt.verify` (or the SDK's `auth.getUser(jwt)` admin helper).
+5. **Cutover is straightforward** because the auth user and the app user share a UUID — the seeder script (`scripts/seed-first-admin.ts`) creates the auth user via the Admin API, then references that UUID in the application `users` row and in all reassigned `blogs.user_id` / `author_profiles.user_id` updates.
+
+## Consequences
+
+- **Supabase project configuration required** before implementation (operator action, captured in PRD § Dependencies):
+  - Enable the **Email** auth provider
+  - Configure Custom SMTP (Mailtrap — see [AgDR-0022](./AgDR-0022-email-transport-mailtrap.md))
+  - Set Site URL and redirect allowlist (`http://localhost:5173/*` for dev; production URL is a launch blocker)
+- **Backend** uses `@supabase/supabase-js` for auth flows on the public API and the `service_role` client for admin actions (e.g. seeder script, admin user-management endpoints).
+- **`requireAuth` middleware** (currently a placeholder, see [`technical-design-ep01.md`](https://github.com/mohamednaseramein/apexyard/blob/main/projects/ai-blog-generator/technical-design-ep01.md)) is replaced with a real implementation that calls `supabase.auth.getUser(token)` and attaches `req.user` from the verified JWT.
+- **Application `users` table** is added with FK to `auth.users.id`, plus role / email_verified_at / deactivated_at columns. Cutover migration handles this; see [AgDR-0026 — Cutover by First Admin](./AgDR-0026-cutover-adopt-by-first-admin.md).
+- **Rate limits** default to Supabase's settings (no application-layer overrides in v1) — recorded here rather than as a separate AgDR per the PRD's § Constraints note.
+- **Coupling to Supabase deepens.** Migrating off Supabase later would now mean migrating the database **and** the auth provider together. Acceptable v1 trade-off — the PRD is explicit about not re-litigating this.
+- **MFA, magic-link, OAuth providers** are out of scope for v1 (PRD § Non-Goals). When we add them, Supabase Auth supports all three natively and no AgDR-0021 supersession is required.
+- **Future supersession** would only be triggered by: Supabase pricing change that breaks our economics, a Supabase Auth incident severe enough to lose trust, or a product pivot that makes us need a feature Supabase doesn't ship.
+
+## Artifacts
+
+- Epic ticket: [mohamednaseramein/blog-generator#95](https://github.com/mohamednaseramein/blog-generator/issues/95)
+- PRD: [`projects/blog-generator/prd-auth-ep04.md`](https://github.com/mohamednaseramein/apexyard/blob/main/projects/blog-generator/prd-auth-ep04.md)
+- Related AgDRs: [AgDR-0003](./AgDR-0003-supabase-database-client.md) (database client), [AgDR-0022](./AgDR-0022-email-transport-mailtrap.md) (email transport), [AgDR-0023](./AgDR-0023-session-supabase-js-default.md) (session model), [AgDR-0026](./AgDR-0026-cutover-adopt-by-first-admin.md) (cutover)
+- Tech design: TBD — `projects/blog-generator/technical-design-ep04-auth.md` to be drafted next phase

--- a/docs/agdr/AgDR-0022-email-transport-mailtrap.md
+++ b/docs/agdr/AgDR-0022-email-transport-mailtrap.md
@@ -1,0 +1,80 @@
+---
+id: AgDR-0022
+timestamp: 2026-05-04T00:00:00Z
+agent: claude-opus-4-7 (Tech Lead role)
+model: claude-opus-4-7
+session: ep-04-auth-tech-design
+trigger: user-prompt
+status: executed
+---
+
+# AgDR-0022 — Email Transport: Mailtrap (Sandbox in Dev/Test, Email API in Prod)
+
+> In the context of sending verification, password-reset, and admin-triggered force-reset emails for EP-04, facing the choice between Mailtrap, Resend, SendGrid, AWS SES, Postmark, or Supabase's bundled email, I decided to use **Mailtrap Sandbox in dev/test and Mailtrap Email API in production**, with sender `me@mnaser.me`, to achieve a single vendor across both environments with a virtual inbox for safe dev testing and real delivery in prod, accepting the tradeoff that Mailtrap's deliverability ceiling is lower than SES/Postmark and that we will eventually need to verify SPF/DKIM for `mnaser.me` to keep prod delivery clean.
+
+## Context
+
+EP-04 ([epic #95](https://github.com/mohamednaseramein/blog-generator/issues/95)) sends transactional email at four moments:
+
+1. **Verification email** on registration (24-hour token; US-AUTH-01 / US-AUTH-02)
+2. **Forgot-password email** on user-initiated reset (1-hour token; US-AUTH-04 / US-AUTH-05)
+3. **Resend verification** when the original token expires
+4. **Admin-triggered force-reset** when an admin needs to reset another user's password (US-AUTH-08 AC3)
+
+Supabase Auth handles the *triggering* (which event sends what email) and the *templating* (default templates, customisable in the Supabase dashboard). What it does **not** ship is the SMTP relay — projects must configure their own Custom SMTP. That choice is what this AgDR records.
+
+Two distinct environments matter:
+
+- **Dev / test** — emails must never go to real inboxes. We need a virtual inbox we can inspect to confirm the link is correct, the token expires, and the copy renders.
+- **Production** — emails must reliably reach Gmail / Outlook / Apple Mail with passing SPF/DKIM/DMARC and acceptable deliverability for transactional volume.
+
+The PRD § Constraints pre-decides Mailtrap; this AgDR records the trade-off and the dual-environment configuration.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|---|---|---|
+| **Mailtrap (Sandbox dev/test, Email API prod) — chosen** | Single vendor across both environments; Sandbox virtual inboxes are best-in-class for verifying email content during dev; Email API has reasonable deliverability for transactional v1 volume; one bill, one set of credentials shapes; same template rendering both sides → fewer surprises at cutover | Lower deliverability ceiling than SES/Postmark at scale; less mature reputation-management tooling; if we ever hit a deliverability issue we may need to switch prod transport — losing the "single vendor" benefit |
+| Resend | Modern DX, great DKIM/SPF setup wizard, healthy deliverability, generous free tier | No native dev-inbox concept (would need a separate dev SMTP like MailHog) → two vendors |
+| AWS SES | Cheapest at scale, excellent deliverability once warmed up, AWS-native | Requires sandbox-removal request, region/quota juggling, no virtual-inbox dev story (need MailHog/Mailtrap for that anyway) → still two vendors |
+| Postmark | Industry-leading transactional deliverability, strong analytics | Premium pricing for v1's volume; same dev-vs-prod-split issue as SES/Resend |
+| SendGrid | Massive provider, well-known | Worst-of-both — paid plan needed for decent reputation, complex UI, no compelling reason over Resend or Postmark |
+| Supabase's bundled email (default SMTP) | Zero-config | **Unusable in production** — Supabase explicitly warns it is rate-limited and not for production traffic; no SPF/DKIM control; we'd still need a real provider for prod, so we'd be configuring two anyway |
+| MailHog (dev) + a paid prod provider | MailHog is local-only, zero cost, fast feedback | Local-only means we lose dev-environment-on-CI testing of email; team members on different machines see different state; two vendors (MailHog + e.g. Resend) |
+
+## Decision
+
+Chosen: **Mailtrap end-to-end**, with environment switching driven by env vars:
+
+| Env | Mode | Endpoint |
+|-----|------|----------|
+| Local dev | Mailtrap **Sandbox** SMTP | `sandbox.smtp.mailtrap.io` |
+| CI / staging | Mailtrap **Sandbox** SMTP (separate inbox per environment) | `sandbox.smtp.mailtrap.io` |
+| Production | Mailtrap **Email API** | `smtp.mailtrap.io` (or HTTP API) |
+
+Sender address: **`me@mnaser.me`** (resolved from PRD § Open Questions on 2026-05-04).
+
+The switch is configured in the Supabase dashboard (project → Auth → Email → Custom SMTP). Backend code does not touch SMTP directly — Supabase Auth dispatches all four email types using whatever SMTP we point it at. This means **the env-switching boundary is the Supabase project, not the application code**: dev/test connects to a Supabase project (or branch) configured for Sandbox; prod connects to one configured for Email API.
+
+## Consequences
+
+- **Operator setup work** before any email-sending code can be tested:
+  - Mailtrap account provisioned with two products: Sandbox + Email API
+  - Sandbox inbox created for dev (and a separate one for staging if we add that env)
+  - Email API domain `mnaser.me` added with SPF + DKIM records (DNS — operator action)
+  - DMARC record on `mnaser.me` (recommended — `p=none` initially, raise once we see clean reports)
+  - Custom SMTP configured in the Supabase dashboard for each environment
+- **Sender domain SPF/DKIM** on `mnaser.me` is a launch blocker for production but **not** for dev/test (Sandbox doesn't enforce them — it's a virtual inbox).
+- **Email-template ownership lives in Supabase**, not in our codebase. Editing the verification email body / subject / CTA is a Supabase-dashboard action, not a code change. Template versioning is informal — record changes in the issue tracker or a follow-up AgDR if we start iterating heavily.
+- **No application-side email code.** The backend never imports `nodemailer` or similar — Supabase Auth is the only sender. If we later need transactional email for non-auth events (e.g. blog-published notifications), that's a separate AgDR.
+- **Deliverability monitoring** is initially passive — Mailtrap dashboard shows sends/bounces/opens. If bounce rate exceeds 5% sustained, treat as an incident and re-evaluate transport.
+- **Failure mode:** if Mailtrap is down, registration and password-reset effectively fail. PRD § Edge Cases specifies the user-facing response (generic 202, log internally, "Resend verification" available). We do not retry beyond Mailtrap's own retry — adding our own retry queue is YAGNI for v1.
+- **Cost:** Mailtrap free tier covers Sandbox; Email API has a small monthly fee at v1 volumes. Within budget.
+- **Future supersession** would be triggered by: deliverability incident lasting > 72h, sustained bounce rate > 5%, or v1 email volume exceeding the Email API quota.
+
+## Artifacts
+
+- Epic ticket: [mohamednaseramein/blog-generator#95](https://github.com/mohamednaseramein/blog-generator/issues/95)
+- PRD: [`projects/blog-generator/prd-auth-ep04.md`](https://github.com/mohamednaseramein/apexyard/blob/main/projects/blog-generator/prd-auth-ep04.md)
+- Related AgDRs: [AgDR-0021](./AgDR-0021-auth-provider-supabase.md) (auth provider — Supabase Auth dispatches the emails)
+- DNS records on `mnaser.me`: SPF + DKIM (TBD during operator setup)

--- a/docs/agdr/AgDR-0023-session-supabase-js-default.md
+++ b/docs/agdr/AgDR-0023-session-supabase-js-default.md
@@ -1,0 +1,74 @@
+---
+id: AgDR-0023
+timestamp: 2026-05-04T00:00:00Z
+agent: claude-opus-4-7 (Tech Lead role)
+model: claude-opus-4-7
+session: ep-04-auth-tech-design
+trigger: user-prompt
+status: executed
+---
+
+# AgDR-0023 — Session Model: `@supabase/supabase-js` Default (localStorage + Server JWT Verify)
+
+> In the context of holding the authenticated session between the SPA frontend and the Express backend in EP-04, facing the choice between the Supabase SDK's default localStorage strategy, httpOnly cookies, a custom JWT in a custom store, or a server-side session table, I decided to **use `@supabase/supabase-js`'s default session storage** (token persisted in localStorage, sent as `Authorization: Bearer …`, verified server-side per request via Supabase's JWT helpers) to achieve the lowest implementation cost and full alignment with the rest of the SDK's flows, accepting the tradeoff that localStorage is reachable from JavaScript and therefore exposed to XSS — which we mitigate at the application layer (CSP, framework defaults, output encoding) rather than at the storage layer.
+
+## Context
+
+The product is an SPA (Vite + React) talking to an Express backend over the same origin in dev (`localhost:5173` → `localhost:3000`) and over a TBD production domain. EP-04 needs a session that:
+
+- Survives page reload (so users don't re-login on every refresh)
+- Carries enough identity to authenticate the user on every API call (`req.user.id` available in handlers)
+- Supports per-device logout (US-AUTH-06)
+- Allows global session revocation when an admin force-resets a user (US-AUTH-08 AC3) or when a user resets their own password (US-AUTH-05 AC2)
+- Returns 401 on the next API call when an admin deactivates a user (US-AUTH-03 AC6 / US-AUTH-08 AC2)
+
+Supabase issues a JWT signed with the project's JWT secret. The SDK ships with built-in session storage and refresh-token handling — by default it persists the access token + refresh token in `localStorage` and auto-refreshes on expiry. The PRD § Constraints pre-decides this approach.
+
+The "Remember me" toggle on the login form (US-AUTH-03 AC1) maps to the SDK's `persistSession` option (default true → 30-day refresh token lifetime; false → session-only).
+
+## Options Considered
+
+| Option | Pros | Cons |
+|---|---|---|
+| **`@supabase/supabase-js` default (localStorage + Bearer token, chosen)** | Zero custom code — the SDK already does it; auto-refresh, expiry, multi-tab sync all handled; admin-API revocation works out of the box; "Remember me" maps cleanly to `persistSession`; backend verification is one SDK call (`supabase.auth.getUser(token)`) | localStorage is reachable from any script in the page → XSS yields token exfiltration; mitigation lives at the app layer (CSP, React's default escaping, audit dependencies) |
+| httpOnly cookies (custom-issued) | Token unreachable from JS, mitigates XSS-driven theft | Defeats Supabase SDK's session model — we'd manually issue, sign, store, refresh, and revoke; cross-origin setup (SameSite, CORS credentials) becomes a permanent maintenance burden; we'd lose `supabase.auth.signInWithPassword` ergonomics or be running two parallel session systems |
+| Custom JWT, our own signing, our own store | Full control over claims, expiry, revocation strategy | Re-implements what Supabase Auth already gives us; key rotation, refresh rotation, replay protection all become our problem; "least secure thing the team writes from scratch" risk |
+| Server-side session table (opaque session id) | Easy server-side revocation (just delete the row), no token-in-storage exposure | Adds a DB read on every request; loses Supabase's pre-built integration; v1 has no scaling pressure that justifies this complexity |
+| Hybrid: SDK for auth flows + cookies for transport | Could in theory get the best of both | Two systems to keep in sync; bug surface; nobody on the team has done it; not justified by v1 threat model |
+
+## Decision
+
+Chosen: **`@supabase/supabase-js` default**.
+
+| Concern | Mechanism |
+|---|---|
+| Where the access token lives | `localStorage` (SDK default), key namespaced by Supabase project ref |
+| Where the refresh token lives | Same — SDK manages both |
+| Token transport to backend | `Authorization: Bearer <access_token>` header, set automatically when frontend code uses the SDK's fetch wrapper or manually for our Express endpoints |
+| Backend verification | `supabase.auth.getUser(token)` (or `jwt.verify` against the project's JWT secret if we want to skip a network round-trip — choice is a tech-design detail, not an AgDR-level decision) |
+| Token expiry | 1 hour (Supabase default) — refresh token used silently to mint a new access token |
+| Refresh token expiry | 30 days when `persistSession: true`, ~1 hour when `persistSession: false` (effectively session-only) |
+| "Remember me" toggle | `persistSession: false` when unchecked; default `true` otherwise |
+| Logout (per-device) | `supabase.auth.signOut()` clears localStorage + revokes refresh token at Supabase |
+| Global session revocation | Supabase Admin API: `auth.admin.signOut(userId)` invalidates all refresh tokens; access tokens still valid until expiry — accepted because the role/deactivation check on every request closes the gap (next call returns 401) |
+| Deactivation propagation | Backend reads `users.deactivated_at` per request (already in PRD § Constraints); a still-valid access token from a deactivated user gets 401 on the very next API call, so propagation latency ≤ access-token TTL |
+
+## Consequences
+
+- **XSS is the threat model that matters.** Storing tokens in localStorage means any successful XSS in the SPA leaks the session. Mitigations at the app layer — none of which is part of EP-04's scope but all of which are now mandatory companions to this AgDR:
+  - Content Security Policy with no `unsafe-inline` script src
+  - React's default JSX escaping (no `dangerouslySetInnerHTML` on auth-adjacent surfaces)
+  - Dependency audit on auth pages (existing `/audit-deps` workflow)
+  - Sanitisation of any user content that could land in the DOM (e.g. blog drafts rendered to HTML — already handled by the markdown pipeline, but worth checking under this lens)
+- **No httpOnly cookies anywhere in the auth path.** This is a deliberate, recorded choice — future Tech Leads should not switch transport without superseding this AgDR.
+- **CORS configuration** in production must allow `Authorization` header from the frontend origin and not require `credentials: 'include'` (no cookies → no credentialed CORS needed).
+- **Multi-tab sync** is handled by the SDK — logout in one tab signs out in the others on next interaction.
+- **Stale role after promotion / demotion** is intentionally accepted (PRD § Edge Cases): the JWT carries `user_id` only; `role` is read fresh from the application `users` table per request. Promotion takes effect on next API call. No JWT-claim invalidation needed.
+- **MFA, session-fixation defences, and device-trust signals** are not addressed here. PRD § Non-Goals defers MFA. Session fixation is mitigated by Supabase's refresh-token rotation (a refresh token is single-use; using it issues a new pair).
+- **Future supersession** would be triggered by: an XSS incident in the product, regulated-data requirements (HIPAA, PCI) that mandate httpOnly cookies, or a user-base shift that changes the threat model materially.
+
+## Artifacts
+
+- Epic ticket: [mohamednaseramein/blog-generator#95](https://github.com/mohamednaseramein/blog-generator/issues/95)
+- PRD: [`projects/blog-generator/prd-auth-ep04.md`](https://github.com/mohamednaseramein/apexyard/blob/main/projects/blog-generator/prd-auth-ep04.md)
+- Related AgDRs: [AgDR-0021](./AgDR-0021-auth-provider-supabase.md) (auth provider — supplies the SDK), [AgDR-0024](./AgDR-0024-soft-verification-gate.md) (verification gate — runs after the JWT is verified), [AgDR-0025](./AgDR-0025-role-column-vs-table.md) (role model — read fresh per request)

--- a/docs/agdr/AgDR-0024-soft-verification-gate.md
+++ b/docs/agdr/AgDR-0024-soft-verification-gate.md
@@ -1,0 +1,78 @@
+---
+id: AgDR-0024
+timestamp: 2026-05-04T00:00:00Z
+agent: claude-opus-4-7 (Tech Lead role)
+model: claude-opus-4-7
+session: ep-04-auth-tech-design
+trigger: user-prompt
+status: executed
+---
+
+# AgDR-0024 — Verification Gate: Soft (Login Allowed, Blog Creation Blocked)
+
+> In the context of enforcing email verification in EP-04, facing the choice between a hard gate (block login until verified), a soft gate (login allowed but write actions blocked), or no gate (verification optional), I decided to use a **soft gate** that lets unverified users log in, browse, and view predefined profiles, but blocks `POST /api/blogs` (and the equivalent client-side action) until `users.email_verified_at IS NOT NULL`, to achieve a balance between discouraging drive-by registrations and not punishing genuine users who haven't clicked the link yet, accepting the tradeoff that unverified users still occupy a session and consume a small amount of backend / Supabase quota.
+
+## Context
+
+EP-04 ([epic #95](https://github.com/mohamednaseramein/blog-generator/issues/95)) introduces email verification (US-AUTH-02) which gives us a signal that an email address is real and reachable. The product question is: **what happens between registration and verification?**
+
+Three plausible postures:
+
+1. **Hard gate** — login blocked until the user clicks the verification link
+2. **Soft gate** — login allowed; certain write actions (here, blog creation) blocked until verified
+3. **No gate** — verification is purely informational; nothing is blocked
+
+The PRD § Constraints pre-decides the soft gate. The user stories that depend on this decision:
+
+- **US-AUTH-01 AC4** — registration redirects to a "Check your email" page that explains verification is required *to create blogs*
+- **US-AUTH-03 AC3** — login is allowed for unverified users; dashboard banner explains the gate
+- **US-AUTH-07** — explicitly defines the soft-gate behaviour (banner, client-side block, server-side `403 EMAIL_NOT_VERIFIED`)
+- **US-AUTH-08 AC3** — admin force-reset is independent of verification (admins can reset *any* user)
+
+## Options Considered
+
+| Option | Pros | Cons |
+|---|---|---|
+| **Soft gate (chosen)** | Lets users explore the product before committing; lower friction → higher conversion in registration → first-action funnel; banner + blocked-action message keeps verification top-of-mind without locking the user out; matches what most modern SaaS products do (Linear, Vercel, Notion, Figma) | Unverified accounts persist in the system; possibility of unverified users leaving feedback or hitting other surfaces we haven't considered yet; gate enforcement must be threaded through every "creates content" path going forward (test discipline) |
+| Hard gate (block login until verified) | Strongest signal-validity guarantee; fewer accidentally-spammy accounts; simpler — the gate is a single check at the login boundary | Punishes users with email-delivery delays (~30s in Mailtrap dev, longer in prod with anti-spam pipelines); registration → first-login conversion drops because users hit a wall when they could have explored; no ability to remind the user of the gate inside the app |
+| No gate | Fastest perceived experience; works fine if email verification is purely a "trust score" not a gate | We lose the signal entirely — no protection against typo-emails (`me@gmial.com`), against throwaway addresses being treated as real users, or against future password-reset requests going to addresses that were never confirmed |
+
+## Decision
+
+Chosen: **Soft gate**, scoped narrowly to `POST /api/blogs` (and any subsequent action that materialises persistent content owned by the user — currently just blog creation).
+
+**What is gated:**
+
+- `POST /api/blogs` returns `403 EMAIL_NOT_VERIFIED` when `req.user.email_verified_at IS NULL`. Frontend hides / disables the "New Blog" CTA in the same state and surfaces a `Verify your email to create blogs` banner with a `Resend verification email` action.
+
+**What is NOT gated:**
+
+- Login itself (US-AUTH-03 AC3)
+- Browsing the dashboard
+- Viewing predefined author profiles (US-AUTH-07 AC3 says the user can read these)
+- Reading existing blogs they own (none should exist for an unverified user, but if they do — e.g. through pre-cutover dev data adoption — read access is preserved)
+- Logout, password reset, resend verification — all available regardless
+
+**Where the check lives:**
+
+- Backend: `requireVerifiedEmail` middleware applied to the single route `POST /api/blogs`. Reads `users.email_verified_at` per request (cheap — already loaded for the role check, see [AgDR-0025](./AgDR-0025-role-column-vs-table.md)).
+- Frontend: a `useVerifiedEmail()` hook returns the boolean; the dashboard banner and the disabled state on the "New Blog" button both consume it. The 403 from the backend is the defence-in-depth backstop.
+
+## Consequences
+
+- **The gate is single-route discipline.** Every future "creates user-owned content" endpoint must explicitly attach `requireVerifiedEmail`. This is a known foot-gun — a future engineer adding `POST /api/some-new-thing` without the middleware would let unverified users through. Mitigations:
+  - Tech design for any new write endpoint must call out whether the gate applies
+  - PR review checklist (Code Reviewer agent) adds a "verification gate considered?" item for any new route mutating user data
+  - Future option: invert the model so middleware is applied at the router level and routes opt out — out of scope for v1
+- **Verification status is mutable** — `users.email_verified_at` flips from NULL to a timestamp on first verification and never flips back in v1. Email-change flow is out of scope (PRD § Non-Goals).
+- **No cron job** — we don't expire unverified accounts on a timer. PRD § Non-Goals defers anti-abuse / cleanup of stale unverified accounts; if abuse appears we add a job in a follow-up.
+- **Banner UX persists** every page load until verification — accepted minor friction; the alternative ("dismiss for this session") would let users forget and confuse-loop on their first blog attempt.
+- **Pre-cutover migration interaction:** the cutover migration ([AgDR-0026](./AgDR-0026-cutover-adopt-by-first-admin.md)) sets `email_verified_at = NOW()` for the first admin so existing dev data ends up under a verified account. New users post-cutover follow the standard flow.
+- **Metric implication:** "Email verification rate" target of ≥ 60 % within 7 days (PRD § Success Metrics) is achievable under a soft gate because the user experiences the friction *every time* they try to create a blog — much higher salience than a one-time hard gate at login.
+- **Future supersession** would be triggered by: spam/abuse from unverified accounts exceeding a threshold (then move to hard gate), regulatory requirement for verified email, or product evolution where the read-only experience becomes valuable on its own (then we might *remove* the gate entirely).
+
+## Artifacts
+
+- Epic ticket: [mohamednaseramein/blog-generator#95](https://github.com/mohamednaseramein/blog-generator/issues/95)
+- PRD: [`projects/blog-generator/prd-auth-ep04.md`](https://github.com/mohamednaseramein/apexyard/blob/main/projects/blog-generator/prd-auth-ep04.md) — see US-AUTH-07 specifically
+- Related AgDRs: [AgDR-0021](./AgDR-0021-auth-provider-supabase.md) (auth provider — owns `email_confirmed_at` on `auth.users`), [AgDR-0025](./AgDR-0025-role-column-vs-table.md) (role/verification both read from the same `users` row per request)

--- a/docs/agdr/AgDR-0025-role-column-vs-table.md
+++ b/docs/agdr/AgDR-0025-role-column-vs-table.md
@@ -1,0 +1,85 @@
+---
+id: AgDR-0025
+timestamp: 2026-05-04T00:00:00Z
+agent: claude-opus-4-7 (Tech Lead role)
+model: claude-opus-4-7
+session: ep-04-auth-tech-design
+trigger: user-prompt
+status: executed
+---
+
+# AgDR-0025 — Role Model: Single `role` Column on Application `users` Table
+
+> In the context of enforcing two distinct permission levels (`admin`, `user`) for EP-04, facing the choice between a single `role` column on the application `users` table, a separate `roles` join table, a full RBAC schema, or storing role in `auth.users.app_metadata`, I decided to use a **single `role` column with a CHECK constraint (`'admin' | 'user'`) on the application `users` table**, to achieve the simplest possible enforcement that fits the v1 product (binary operator-vs-customer split with no per-resource permissions), accepting the tradeoff that introducing a third role or any per-resource permission later requires a migration to a different model.
+
+## Context
+
+EP-04 ([epic #95](https://github.com/mohamednaseramein/blog-generator/issues/95)) introduces exactly two roles:
+
+- **`user`** — default role; can manage their own blogs and own author profiles
+- **`admin`** — operator; can manage other users (deactivate, force-reset, promote, demote), edit predefined author profiles, and view all blogs read-only
+
+The user stories that depend on the role model:
+
+- **US-AUTH-08, US-AUTH-09, US-AUTH-10** — admin endpoints gated by role
+- **US-AUTH-11** — promote / demote (writes the role column on another row)
+- **US-AUTH-08 AC5 / US-AUTH-11 AC4** — last-admin protection (a count-based invariant: at least one row with `role='admin' AND deactivated_at IS NULL`)
+- **PRD § Edge Cases** — role promotion takes effect on next API call → the role must be read fresh from the row each request, not cached in the JWT
+
+The PRD § Constraints pre-decides "single column"; this AgDR records the trade-off, the alternatives, and the upgrade path if v1's binary model proves insufficient.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|---|---|---|
+| **Single `role` column on `users` (chosen)** | One column, one CHECK constraint, one read per request; `requireAdmin` middleware is `req.user.role === 'admin'` and nothing more; last-admin invariant is `SELECT COUNT(*) FROM users WHERE role='admin' AND deactivated_at IS NULL > 1`; trivial to test | Not extensible — adding a third role (`viewer`, `billing-admin`) is a migration; per-resource permissions (e.g. "can edit profile X") not expressible at all |
+| Separate `roles` table + `user_roles` join | Each user can hold multiple roles; standard RBAC shape | Multi-role isn't needed in v1 — admin/user is exhaustive and mutually exclusive; adds two tables, one join, and re-introduces the question "is the user an admin?" as a JOIN on every protected request |
+| Full RBAC: roles + permissions + role_permissions + user_roles | Maximum flexibility, ready for "Designer can edit profiles, Editor can read but not write blogs" etc. | 4-table schema, dramatic over-engineering for a binary operator/customer split; product has zero use case for fine-grained permissions in v1 (PRD § Non-Goals defers per-org tenancy entirely) |
+| Role in `auth.users.app_metadata` (Supabase-native) | Avoids an extra column on our table; role lives where Supabase puts custom claims; can be read from the JWT without a DB hit | Couples role enforcement to the JWT — to invalidate a role change you'd need to revoke and re-issue the token (the PRD § Edge Cases explicitly wants role changes to take effect on next API call without forcing re-login); writes to `app_metadata` go through the Supabase Admin API not standard SQL — last-admin invariant becomes harder to enforce transactionally |
+| Role on Postgres role-system / RLS policies | "Right" Postgres way; nice if we use Supabase RLS heavily | We don't use RLS for the API (backend uses `service_role` and enforces in middleware); duplicating the model in the DB role system adds a second source of truth; not justified |
+
+## Decision
+
+Chosen: **Single `role` column on the application `users` table.**
+
+Schema (to be created in the cutover migration — see [AgDR-0026](./AgDR-0026-cutover-adopt-by-first-admin.md)):
+
+```sql
+CREATE TABLE users (
+  id                UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  role              TEXT NOT NULL DEFAULT 'user' CHECK (role IN ('user', 'admin')),
+  email_verified_at TIMESTAMPTZ,
+  deactivated_at    TIMESTAMPTZ,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+**Read pattern:**
+
+- `requireAuth` middleware verifies the JWT (see [AgDR-0023](./AgDR-0023-session-supabase-js-default.md))
+- A second middleware loads `SELECT id, role, email_verified_at, deactivated_at FROM users WHERE id = $1` and attaches it to `req.user`
+- This is **one** lookup per request shared across the role check, the verification check ([AgDR-0024](./AgDR-0024-soft-verification-gate.md)), and the deactivation check
+- `requireAdmin` checks `req.user.role === 'admin' && req.user.deactivated_at IS NULL`
+
+**Write pattern:**
+
+- Promote / demote: `UPDATE users SET role = 'admin', updated_at = NOW() WHERE id = $1`
+- Last-admin protection: pre-write check `SELECT COUNT(*) FROM users WHERE role='admin' AND deactivated_at IS NULL >= 2` for any operation that would reduce the active-admin count. Backend enforces; UI mirrors as a defence-in-depth disabled state with tooltip.
+
+## Consequences
+
+- **The `requireAdmin` middleware is one line.** No JOINs, no second query, no permission-set evaluation. The simplest thing that works.
+- **Role changes take effect on next API call** with zero token-revocation dance — exactly what the PRD § Edge Cases asks for. The JWT carries `user_id` only.
+- **Last-admin protection is a single-query invariant** that's easy to wrap in a transaction with the demote / deactivate write — no race condition where two admins simultaneously demote each other.
+- **Adding a third role later is a migration.** The CHECK constraint + the `'admin' | 'user'` enum in TypeScript both need updating. A single test that asserts the DB CHECK and the TS union match (similar to AgDR-0019's intent enum) catches drift.
+- **Adding per-resource permissions later requires a model change**, not just a migration. If the product evolves to need "Designer can edit profiles X, Y, Z but not blogs", we will supersede this AgDR with a new RBAC AgDR. Acceptable — the PRD § Non-Goals explicitly defers per-org tenancy and any sub-role split.
+- **`auth.users.app_metadata` is unused for role**, kept clean for any future Supabase-native concerns (e.g. RLS later).
+- **The application `users` table** is the source of truth for `role`, `email_verified_at`, and `deactivated_at` — `auth.users` is the source of truth for `email_confirmed_at` and password material. We mirror `email_confirmed_at` → `email_verified_at` rather than reading it across tables, because the application table already has to be loaded for the role check, so we save the round trip.
+- **Future supersession** would be triggered by: introduction of a third distinct role, requirement for per-resource permissions, or a product pivot to multi-tenant workspaces (which would also change the user-scoping model entirely).
+
+## Artifacts
+
+- Epic ticket: [mohamednaseramein/blog-generator#95](https://github.com/mohamednaseramein/blog-generator/issues/95)
+- PRD: [`projects/blog-generator/prd-auth-ep04.md`](https://github.com/mohamednaseramein/apexyard/blob/main/projects/blog-generator/prd-auth-ep04.md) — see US-AUTH-08 through US-AUTH-11
+- Related AgDRs: [AgDR-0023](./AgDR-0023-session-supabase-js-default.md) (session — feeds `req.user.id` to the role lookup), [AgDR-0024](./AgDR-0024-soft-verification-gate.md) (verification — same row, same lookup), [AgDR-0026](./AgDR-0026-cutover-adopt-by-first-admin.md) (cutover — creates this table)

--- a/docs/agdr/AgDR-0026-cutover-adopt-by-first-admin.md
+++ b/docs/agdr/AgDR-0026-cutover-adopt-by-first-admin.md
@@ -1,0 +1,101 @@
+---
+id: AgDR-0026
+timestamp: 2026-05-04T00:00:00Z
+agent: claude-opus-4-7 (Tech Lead role)
+model: claude-opus-4-7
+session: ep-04-auth-tech-design
+trigger: user-prompt
+status: executed
+---
+
+# AgDR-0026 — Cutover Strategy: Adopt Existing Dev Data Under First Admin
+
+> In the context of replacing the placeholder dev-user UUID `00000000-0000-0000-0000-000000000001` with real authenticated accounts in EP-04, facing the choice between adopting the existing rows under a designated first admin, deleting all pre-cutover data, splitting it across multiple owners manually, or orphaning it for later reassignment, I decided to **adopt all pre-cutover blogs and custom author profiles under the first admin** (Mohamed Naser, `mnaser.tech@gmail.com`) via a SQL migration that creates the `users` table and adds FKs, paired with a TypeScript seeder script `scripts/seed-first-admin.ts` that creates the auth user and runs idempotent UPDATEs, to achieve zero data loss for existing dev content with a clean foreign-key-enforced state post-cutover, accepting the tradeoff that the first admin starts with all historical content attributed to them and that we have to operate two coordinated artefacts (SQL migration + TS seeder) for one logical change.
+
+## Context
+
+The blog-generator has been operating since EP-01 with a single hardcoded dev-user UUID across every owned row:
+
+- `blogs.user_id = '00000000-0000-0000-0000-000000000001'`
+- `author_profiles.user_id = '00000000-0000-0000-0000-000000000001'` (for non-predefined rows)
+
+The placeholder UUID does not correspond to any `auth.users` row and there is no `users` application table. EP-04 needs to:
+
+1. Create the `users` table (see [AgDR-0025](./AgDR-0025-role-column-vs-table.md))
+2. Move every placeholder-UUID row to a real authenticated user
+3. Add foreign-key constraints so future rows can't carry a dangling `user_id`
+4. Designate the first admin so admin endpoints are usable on day one
+
+The PRD ([`prd-auth-ep04.md`](https://github.com/mohamednaseramein/apexyard/blob/main/projects/blog-generator/prd-auth-ep04.md)) § US-AUTH-12 specifies the acceptance criteria; this AgDR records the strategic choice (adopt vs. alternatives) and the SQL-migration-vs-seeder split.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|---|---|---|
+| **Adopt under first admin (chosen)** | Zero data loss for the operator's own dev content; first admin walks into a populated dashboard on day one (good demo posture); idempotent — re-running matches no rows the second time; clean FK-enforced state post-migration | First admin's account ends up with every pre-cutover blog regardless of who created it during dev; reversal requires the documented rollback (re-stamp the placeholder UUID, drop the FK) |
+| Delete all pre-cutover data | Trivial migration — `DELETE FROM blogs WHERE user_id = '…-001'` | Loses real work; demo content disappears; no recovery path; PRD § Non-Goals doesn't ask for this |
+| Split data across multiple users manually | Most accurate to "real" ownership if multiple devs contributed | We have no record of who actually authored each row — `created_at` doesn't tell us; would require manual annotation per row before migration; high effort, low payoff for v1 |
+| Orphan rows (allow NULL user_id, reassign later via UI) | Cleanest separation between "data" and "ownership"; no auto-attribution | Breaks the FK guarantee we want; introduces a long tail of orphaned rows that would never get reassigned in practice; the admin UI to reassign doesn't exist and isn't planned |
+| Drop the placeholder column entirely, recompute ownership later | Fresh start | Same problems as deletion — we lose dev content; no upside |
+
+## Decision
+
+Chosen: **Adopt under first admin**, split into two coordinated artefacts:
+
+### Artefact 1 — SQL migration (Postgres)
+
+Idempotent, runs in transaction, applied via the project's standard migration tooling:
+
+1. `CREATE TABLE users (...)` — schema per [AgDR-0025](./AgDR-0025-role-column-vs-table.md)
+2. (No FKs yet — they're added in step 5 of the seeder, after data is reassigned)
+3. Verification check: `SELECT 1` — migration is structural only at this stage
+
+### Artefact 2 — TypeScript seeder `scripts/seed-first-admin.ts`
+
+Run **once** per environment, after the SQL migration. Reads `FIRST_ADMIN_EMAIL` from env (defaults to `mnaser.tech@gmail.com` for the operator). Steps:
+
+1. **Idempotent auth-user creation** via Supabase Admin API:
+   - If `auth.users` already has a row with `FIRST_ADMIN_EMAIL`, use its `id`
+   - Otherwise call `supabase.auth.admin.createUser({ email, email_confirm: true, password: <generated-or-prompted> })`
+2. Insert into `users`: `INSERT … ON CONFLICT (id) DO NOTHING` with `role='admin'`, `email_verified_at = NOW()`
+3. Reassign placeholder UUIDs:
+   - `UPDATE blogs SET user_id = $admin_id WHERE user_id = '00000000-0000-0000-0000-000000000001'`
+   - `UPDATE author_profiles SET user_id = $admin_id WHERE user_id = '00000000-0000-0000-0000-000000000001'` (non-predefined only — predefined rows have a different ownership semantics, see existing seed scripts)
+4. Add foreign keys (idempotent — guarded by `IF NOT EXISTS` check):
+   - `ALTER TABLE blogs ADD CONSTRAINT fk_blogs_user FOREIGN KEY (user_id) REFERENCES users(id)`
+   - `ALTER TABLE author_profiles ADD CONSTRAINT fk_author_profiles_user FOREIGN KEY (user_id) REFERENCES users(id)`
+5. Verify: `SELECT COUNT(*) FROM blogs WHERE user_id = '00000000-…-001'` must return 0; same for `author_profiles`. Abort with non-zero exit if not.
+
+### Why split SQL migration + TS seeder?
+
+Three reasons:
+
+1. **The auth user creation requires the Supabase Admin API**, which is a JS-only path. SQL alone can't talk to `auth.users` because that schema is owned by Supabase and the only safe creation path is the Admin SDK.
+2. **Migrations should be deterministic and runnable in any environment without side effects.** Creating an auth user is a side effect (it provisions an external identity); keeping that out of the migration tool's tree means staging / prod deployments don't accidentally re-run it.
+3. **Rollback is per-artefact:** the SQL migration is rolled back via the migration tool; the seeder's effects (auth user existence, populated `users` row, reassigned UUIDs) are reversed via a separate documented runbook (see Consequences).
+
+## Consequences
+
+- **First admin starts with all historical content.** Acceptable because the operator (Mohamed Naser) authored or is responsible for the existing dev content. Future admins promoted via US-AUTH-11 do not retroactively get any content — they start with their own scope.
+- **Two artefacts, one logical change** — the migration ticket created via `/migration` (per Workflow Gate 3a) bundles both, and the migration AgDR (separate from this strategic AgDR) documents the runbook.
+- **Idempotency on both sides:**
+  - SQL migration: `CREATE TABLE … IF NOT EXISTS` — re-running is a no-op
+  - Seeder: every step is `WHERE … = placeholder` or `ON CONFLICT DO NOTHING` — re-running matches zero rows on the second pass
+- **Production launch blocker** (PRD § Open Questions): the production redirect URL must be configured in Supabase before the seeder runs in prod, otherwise the auth-user-creation step will succeed but verification / reset emails will point to a dev URL. Treated as a hard blocker on the prod cutover step in the PRD § Timeline.
+- **Rollback runbook** (to be expanded in the migration AgDR, not duplicated here):
+  1. Re-stamp the placeholder UUID: `UPDATE blogs SET user_id = '00000000-…-001' WHERE user_id = $admin_id` (and same for `author_profiles`) — only safe if no other users have created content yet
+  2. `DROP CONSTRAINT fk_blogs_user; DROP CONSTRAINT fk_author_profiles_user;`
+  3. `DELETE FROM users WHERE id = $admin_id; DROP TABLE users;`
+  4. Optionally remove the auth user via the Supabase Admin API (`auth.admin.deleteUser`)
+- **First-admin password generation:** the seeder either generates a random password and prints it once (CLI-friendly, operator copies it) or accepts `FIRST_ADMIN_PASSWORD` from env (CI/staging). Tech-design phase decides which mode is the default; this AgDR is agnostic.
+- **Predefined author profiles are untouched.** They are seeded by existing scripts and have their own ownership semantics (no `user_id`, or a sentinel system user, depending on AgDR-0020 / existing seed). The cutover seeder explicitly excludes them from the UPDATE.
+- **Pre-cutover blog data is now visible to the first admin** in the admin audit view (US-AUTH-10). This is a feature, not a bug — admins seeing pre-cutover content is exactly what "adopt" means.
+- **Future supersession** would be triggered by: a need to retroactively reassign content to multiple users (would require an admin-only "reassign blog ownership" feature first), or a regulatory requirement to delete all dev data before launch.
+
+## Artifacts
+
+- Epic ticket: [mohamednaseramein/blog-generator#95](https://github.com/mohamednaseramein/blog-generator/issues/95)
+- PRD: [`projects/blog-generator/prd-auth-ep04.md`](https://github.com/mohamednaseramein/apexyard/blob/main/projects/blog-generator/prd-auth-ep04.md) — see US-AUTH-12 for the AC-level detail
+- Related AgDRs: [AgDR-0021](./AgDR-0021-auth-provider-supabase.md) (auth provider — Admin API used in the seeder), [AgDR-0025](./AgDR-0025-role-column-vs-table.md) (`users` table schema), [AgDR-0024](./AgDR-0024-soft-verification-gate.md) (first admin gets `email_verified_at = NOW()` so the gate doesn't trip on day one)
+- Migration ticket + migration AgDR: TBD — to be created via `/migration` once the cutover work is scoped (Workflow Gate 3a)
+- Seeder script path: `scripts/seed-first-admin.ts` (to be added during the Build phase)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.46.1",
     "@hookform/resolvers": "^3.9.1",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-progress": "^1.1.8",
@@ -24,6 +25,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.53.2",
+    "react-router-dom": "^7.14.2",
     "tailwindcss": "^4.2.4",
     "zod": "^3.23.8"
   },

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,85 +1,21 @@
-import { jsx as _jsx, jsxs as _jsxs, Fragment as _Fragment } from "react/jsx-runtime";
-import { useState, useEffect } from 'react';
-import { BlogBriefForm } from './components/BlogBriefForm.js';
-import { AlignmentSummary } from './components/AlignmentSummary.js';
-import { OutlineStep } from './components/OutlineStep.js';
-import { DraftStep } from './components/DraftStep.js';
-import { PublishStep } from './components/PublishStep.js';
-import { WizardProgress } from './components/WizardProgress.js';
-import { BlogHistory } from './components/BlogHistory.js';
-import { ProfileWizard } from './components/ProfileWizard.js';
-import { ProfileSwitcher } from './components/ProfileSwitcher.js';
-import { ProfileSettings } from './components/ProfileSettings.js';
-import { ViewPromptPanel } from './components/ViewPromptPanel.js';
-import { Button } from './components/ui/button.js';
-import { Toast } from './components/ui/toast.js';
-import { createBlog } from './api/blog-api.js';
-import { listProfiles } from './api/profile-api.js';
-const STEP_TO_APP = {
-    1: 'brief',
-    2: 'alignment',
-    3: 'outline',
-    4: 'draft',
-    5: 'publish',
-    6: 'publish', // completed blogs open on Publish so content can be re-copied
-};
-const ACTIVE_PROFILE_KEY = 'blog-generator:active-profile-id';
-function setActiveProfile(id, setter) {
-    setter(id);
-    localStorage.setItem(ACTIVE_PROFILE_KEY, id);
-}
+import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
+import { Fragment } from 'react';
+import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
+import { AuthProvider } from './context/AuthContext';
+import { ProtectedRoute, AdminRoute } from './components/RouteGuards';
+import { isSupabaseConfigured } from './lib/supabase';
+// Pages
+import Dashboard from './pages/Dashboard';
+import LoginPage from './pages/auth/LoginPage';
+import RegisterPage from './pages/auth/RegisterPage';
+import CheckEmailPage from './pages/auth/CheckEmailPage';
+import VerifyPage from './pages/auth/VerifyPage';
+import ForgotPasswordPage from './pages/auth/ForgotPasswordPage';
+import ResetPasswordPage from './pages/auth/ResetPasswordPage';
+// Admin Pages (Stubs for now)
+const AdminUsersPage = () => _jsx("div", { className: "p-8", children: "Admin Users" });
+const AdminBlogsPage = () => _jsx("div", { className: "p-8", children: "Admin Blogs" });
+const AdminProfilesPage = () => _jsx("div", { className: "p-8", children: "Admin Profiles" });
 export function App() {
-    const [state, setState] = useState({ step: 'idle' });
-    const [error, setError] = useState(null);
-    const [activeProfileId, setActiveProfileId] = useState(() => {
-        return localStorage.getItem(ACTIVE_PROFILE_KEY);
-    });
-    useEffect(() => {
-        async function loadProfiles() {
-            try {
-                const { profiles: loaded } = await listProfiles();
-                if (!activeProfileId || !loaded.find((p) => p.id === activeProfileId)) {
-                    if (loaded.length === 0) {
-                        setState({ step: 'profile-wizard' });
-                    }
-                    else {
-                        setActiveProfile(loaded[0].id, setActiveProfileId);
-                    }
-                }
-            }
-            catch (e) {
-                setError(e.message);
-            }
-        }
-        void loadProfiles();
-    }, [activeProfileId]);
-    async function startNewBlog() {
-        setError(null);
-        setState({ step: 'creating' });
-        try {
-            const { blogId } = await createBlog();
-            setState({ step: 'brief', blogId });
-        }
-        catch (e) {
-            setError(e.message);
-            setState({ step: 'idle' });
-        }
-    }
-    function resumeBlog(blogId, currentStep) {
-        const s = currentStep < 1 ? 1 : currentStep;
-        const step = STEP_TO_APP[s] ?? 'brief';
-        if (step === 'idle' || step === 'history' || step === 'creating')
-            return;
-        setState({ step, blogId });
-    }
-    const wizardStep = state.step === 'brief' ? 1
-        : state.step === 'alignment' ? 2
-            : state.step === 'outline' ? 3
-                : state.step === 'draft' ? 4
-                    : state.step === 'publish' ? 5
-                        : 1;
-    return (_jsx("div", { className: "min-h-screen bg-gradient-to-br from-slate-50 to-indigo-50", children: _jsxs("div", { className: "mx-auto max-w-2xl px-4 py-10 sm:px-6 lg:px-8", children: [_jsxs("div", { className: "mb-10 text-center", children: [_jsx("div", { className: "mb-3 inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-indigo-600 text-white text-xl shadow-lg", children: "\u2726" }), _jsx("h1", { className: "text-3xl font-bold tracking-tight text-slate-900", children: "AI Blog Generator" }), _jsx("p", { className: "mt-2 text-slate-500 text-sm", children: "Create a fully-structured, SEO-ready blog post in minutes." })] }), (state.step === 'brief' || state.step === 'alignment' || state.step === 'outline' || state.step === 'draft' || state.step === 'publish') && (_jsx("div", { className: "mb-8", children: _jsx(WizardProgress, { current: wizardStep }) })), _jsxs("div", { className: "rounded-2xl bg-white shadow-sm ring-1 ring-slate-200 p-6 sm:p-8", children: [state.step === 'profile-wizard' && (_jsx(ProfileWizard, { onProfileSelected: (profile) => {
-                                setActiveProfile(profile.id, setActiveProfileId);
-                                setState({ step: 'idle' });
-                            } })), state.step === 'profile-settings' && (_jsx(ProfileSettings, { activeProfileId: activeProfileId, onActiveProfileChange: (id) => setActiveProfile(id, setActiveProfileId), onBack: () => setState({ step: 'idle' }) })), state.step === 'idle' && (_jsxs("div", { className: "flex flex-col items-center gap-6 py-8 text-center", children: [_jsxs("div", { className: "max-w-sm", children: [_jsx("h2", { className: "text-lg font-semibold text-slate-800", children: "Ready to write?" }), _jsx("p", { className: "mt-1 text-sm text-slate-500", children: "Walk through our step-by-step wizard and let AI handle the heavy lifting." })] }), error && _jsx(Toast, { variant: "error", children: error }), _jsxs("div", { className: "flex gap-3", children: [_jsx(Button, { onClick: () => void startNewBlog(), size: "md", children: "Start a new blog post \u2192" }), _jsx(Button, { variant: "ghost", size: "md", onClick: () => setState({ step: 'history' }), children: "My blogs" })] }), _jsx("button", { onClick: () => setState({ step: 'profile-settings' }), className: "text-xs text-slate-400 hover:text-slate-600 underline", children: "Manage author profiles" })] })), state.step === 'history' && (_jsx(BlogHistory, { onResume: resumeBlog, onNew: () => void startNewBlog() })), state.step === 'creating' && (_jsxs("div", { className: "flex flex-col items-center gap-3 py-12 text-slate-500", children: [_jsx("span", { className: "inline-block h-6 w-6 animate-spin rounded-full border-2 border-slate-200 border-t-indigo-500" }), _jsx("p", { className: "text-sm", children: "Setting up your blog\u2026" })] })), state.step === 'brief' && (_jsxs(_Fragment, { children: [_jsxs("div", { className: "mb-6 flex items-start justify-between", children: [_jsxs("div", { children: [_jsx("h2", { className: "text-lg font-semibold text-slate-800", children: "Step 1: Blog Brief" }), _jsx("p", { className: "mt-1 text-sm text-slate-500", children: "Tell us about your post. The more detail you give, the better the output." })] }), _jsx(ProfileSwitcher, { activeProfileId: activeProfileId, onProfileChange: (profile) => setActiveProfile(profile.id, setActiveProfileId), onManageProfiles: () => setState({ step: 'profile-settings' }) })] }), _jsx(BlogBriefForm, { blogId: state.blogId, activeProfileId: activeProfileId, onSuccess: () => setState({ step: 'alignment', blogId: state.blogId }) })] })), state.step === 'alignment' && (_jsxs(_Fragment, { children: [_jsx(AlignmentSummary, { blogId: state.blogId, onEdit: () => setState({ step: 'brief', blogId: state.blogId }), onConfirmed: () => setState({ step: 'outline', blogId: state.blogId }) }), _jsx(ViewPromptPanel, { blogId: state.blogId, step: "alignment" })] })), state.step === 'outline' && (_jsxs(_Fragment, { children: [_jsx(OutlineStep, { blogId: state.blogId, onBack: () => setState({ step: 'alignment', blogId: state.blogId }), onConfirmed: () => setState({ step: 'draft', blogId: state.blogId }) }), _jsx(ViewPromptPanel, { blogId: state.blogId, step: "outline" })] })), state.step === 'draft' && (_jsxs(_Fragment, { children: [_jsx(DraftStep, { blogId: state.blogId, onBack: () => setState({ step: 'outline', blogId: state.blogId }), onConfirmed: () => setState({ step: 'publish', blogId: state.blogId }) }), _jsx(ViewPromptPanel, { blogId: state.blogId, step: "draft" })] })), state.step === 'publish' && (_jsx(PublishStep, { blogId: state.blogId, onBack: () => setState({ step: 'draft', blogId: state.blogId }), onFinish: () => setState({ step: 'done', blogId: state.blogId }) })), state.step === 'done' && (_jsxs("div", { className: "flex flex-col items-center gap-6 py-8 text-center", children: [_jsx("div", { className: "flex h-14 w-14 items-center justify-center rounded-full bg-green-100 text-green-600 text-2xl", children: "\u2713" }), _jsxs("div", { children: [_jsx("h2", { className: "text-lg font-semibold text-slate-800", children: "All set" }), _jsx("p", { className: "mt-1 text-sm text-slate-500", children: "Thanks for using the wizard. Start another post whenever you are ready." })] }), _jsxs("div", { className: "flex gap-3", children: [_jsx(Button, { size: "sm", onClick: () => void startNewBlog(), children: "+ New post" }), _jsx(Button, { variant: "ghost", size: "sm", onClick: () => setState({ step: 'history' }), children: "My blogs" })] })] }))] }), _jsxs("p", { className: "mt-6 text-center text-xs text-slate-400", children: ["Powered by Claude AI \u00B7 Naser Company", import.meta.env.VITE_APP_VERSION && (_jsxs("span", { className: "ml-1 text-slate-300", children: ["v", import.meta.env.VITE_APP_VERSION] }))] })] }) }));
+    return (_jsx(AuthProvider, { children: _jsx(Router, { children: _jsxs(Fragment, { children: [!isSupabaseConfigured && (_jsxs("div", { role: "status", className: "border-b border-amber-200 bg-amber-50 px-4 py-2 text-center text-sm text-amber-950", children: ["Supabase env vars were missing at ", _jsx("strong", { className: "font-medium", children: "build" }), " time (", _jsx("code", { className: "rounded bg-amber-100/80 px-1", children: "VITE_SUPABASE_URL" }), ",", ' ', _jsx("code", { className: "rounded bg-amber-100/80 px-1", children: "VITE_SUPABASE_ANON_KEY" }), "). Auth and API calls will fail until you rebuild the frontend with real values (see", ' ', _jsx("code", { className: "rounded bg-amber-100/80 px-1", children: "docker-compose.yml" }), " build args)."] })), _jsxs(Routes, { children: [_jsx(Route, { path: "/login", element: _jsx(LoginPage, {}) }), _jsx(Route, { path: "/register", element: _jsx(RegisterPage, {}) }), _jsx(Route, { path: "/check-email", element: _jsx(CheckEmailPage, {}) }), _jsx(Route, { path: "/verify", element: _jsx(VerifyPage, {}) }), _jsx(Route, { path: "/forgot-password", element: _jsx(ForgotPasswordPage, {}) }), _jsx(Route, { path: "/reset-password", element: _jsx(ResetPasswordPage, {}) }), _jsx(Route, { element: _jsx(ProtectedRoute, {}), children: _jsx(Route, { path: "/", element: _jsx(Dashboard, {}) }) }), _jsxs(Route, { element: _jsx(AdminRoute, {}), children: [_jsx(Route, { path: "/admin/users", element: _jsx(AdminUsersPage, {}) }), _jsx(Route, { path: "/admin/blogs", element: _jsx(AdminBlogsPage, {}) }), _jsx(Route, { path: "/admin/profiles", element: _jsx(AdminProfilesPage, {}) })] }), _jsx(Route, { path: "*", element: _jsx(Navigate, { to: "/", replace: true }) })] })] }) }) }));
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,279 +1,66 @@
-import { useState, useEffect } from 'react';
-import { BlogBriefForm } from './components/BlogBriefForm.js';
-import { AlignmentSummary } from './components/AlignmentSummary.js';
-import { OutlineStep } from './components/OutlineStep.js';
-import { DraftStep } from './components/DraftStep.js';
-import { PublishStep } from './components/PublishStep.js';
-import { WizardProgress } from './components/WizardProgress.js';
-import { BlogHistory } from './components/BlogHistory.js';
-import { ProfileWizard } from './components/ProfileWizard.js';
-import { ProfileSwitcher } from './components/ProfileSwitcher.js';
-import { ProfileSettings } from './components/ProfileSettings.js';
-import { ViewPromptPanel } from './components/ViewPromptPanel.js';
-import { Button } from './components/ui/button.js';
-import { Toast } from './components/ui/toast.js';
-import { createBlog } from './api/blog-api.js';
-import { listProfiles } from './api/profile-api.js';
+import { Fragment } from 'react';
+import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
+import { AuthProvider } from './context/AuthContext';
+import { ProtectedRoute, AdminRoute } from './components/RouteGuards';
+import { isSupabaseConfigured } from './lib/supabase';
 
-type AppState =
-  | { step: 'profile-wizard' }
-  | { step: 'profile-settings' }
-  | { step: 'idle' }
-  | { step: 'history' }
-  | { step: 'creating' }
-  | { step: 'brief'; blogId: string }
-  | { step: 'alignment'; blogId: string }
-  | { step: 'outline'; blogId: string }
-  | { step: 'draft'; blogId: string }
-  | { step: 'publish'; blogId: string }
-  | { step: 'done'; blogId: string };
+// Pages
+import Dashboard from './pages/Dashboard';
+import LoginPage from './pages/auth/LoginPage';
+import RegisterPage from './pages/auth/RegisterPage';
+import CheckEmailPage from './pages/auth/CheckEmailPage';
+import VerifyPage from './pages/auth/VerifyPage';
+import ForgotPasswordPage from './pages/auth/ForgotPasswordPage';
+import ResetPasswordPage from './pages/auth/ResetPasswordPage';
 
-const STEP_TO_APP: Record<number, AppState['step']> = {
-  1: 'brief',
-  2: 'alignment',
-  3: 'outline',
-  4: 'draft',
-  5: 'publish',
-  6: 'publish', // completed blogs open on Publish so content can be re-copied
-};
-
-const ACTIVE_PROFILE_KEY = 'blog-generator:active-profile-id';
-
-function setActiveProfile(id: string, setter: (id: string) => void) {
-  setter(id);
-  localStorage.setItem(ACTIVE_PROFILE_KEY, id);
-}
+// Admin Pages (Stubs for now)
+const AdminUsersPage = () => <div className="p-8">Admin Users</div>;
+const AdminBlogsPage = () => <div className="p-8">Admin Blogs</div>;
+const AdminProfilesPage = () => <div className="p-8">Admin Profiles</div>;
 
 export function App() {
-  const [state, setState] = useState<AppState>({ step: 'idle' });
-  const [error, setError] = useState<string | null>(null);
-  const [activeProfileId, setActiveProfileId] = useState<string | null>(() => {
-    return localStorage.getItem(ACTIVE_PROFILE_KEY);
-  });
-
-  useEffect(() => {
-    async function loadProfiles() {
-      try {
-        const { profiles: loaded } = await listProfiles();
-
-        if (!activeProfileId || !loaded.find((p) => p.id === activeProfileId)) {
-          if (loaded.length === 0) {
-            setState({ step: 'profile-wizard' });
-          } else {
-            setActiveProfile(loaded[0].id, setActiveProfileId);
-          }
-        }
-      } catch (e) {
-        setError((e as Error).message);
-      }
-    }
-    void loadProfiles();
-  }, [activeProfileId]);
-
-  async function startNewBlog() {
-    setError(null);
-    setState({ step: 'creating' });
-    try {
-      const { blogId } = await createBlog();
-      setState({ step: 'brief', blogId });
-    } catch (e) {
-      setError((e as Error).message);
-      setState({ step: 'idle' });
-    }
-  }
-
-  function resumeBlog(blogId: string, currentStep: number) {
-    const s = currentStep < 1 ? 1 : currentStep;
-    const step = STEP_TO_APP[s] ?? 'brief';
-    if (step === 'idle' || step === 'history' || step === 'creating') return;
-    setState({ step, blogId });
-  }
-
-  const wizardStep =
-    state.step === 'brief' ? 1
-    : state.step === 'alignment' ? 2
-    : state.step === 'outline' ? 3
-    : state.step === 'draft' ? 4
-    : state.step === 'publish' ? 5
-    : 1;
-
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-indigo-50">
-      <div className="mx-auto max-w-2xl px-4 py-10 sm:px-6 lg:px-8">
-
-        {/* Header */}
-        <div className="mb-10 text-center">
-          <div className="mb-3 inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-indigo-600 text-white text-xl shadow-lg">
-            ✦
-          </div>
-          <h1 className="text-3xl font-bold tracking-tight text-slate-900">AI Blog Generator</h1>
-          <p className="mt-2 text-slate-500 text-sm">
-            Create a fully-structured, SEO-ready blog post in minutes.
-          </p>
-        </div>
-
-        {/* Wizard progress */}
-        {(state.step === 'brief' || state.step === 'alignment' || state.step === 'outline' || state.step === 'draft' || state.step === 'publish') && (
-          <div className="mb-8">
-            <WizardProgress current={wizardStep} />
-          </div>
-        )}
-
-        {/* Card */}
-        <div className="rounded-2xl bg-white shadow-sm ring-1 ring-slate-200 p-6 sm:p-8">
-
-          {state.step === 'profile-wizard' && (
-            <ProfileWizard
-              onProfileSelected={(profile) => {
-                setActiveProfile(profile.id, setActiveProfileId);
-                setState({ step: 'idle' });
-              }}
-            />
-          )}
-
-          {state.step === 'profile-settings' && (
-            <ProfileSettings
-              activeProfileId={activeProfileId}
-              onActiveProfileChange={(id) => setActiveProfile(id, setActiveProfileId)}
-              onBack={() => setState({ step: 'idle' })}
-            />
-          )}
-
-          {state.step === 'idle' && (
-            <div className="flex flex-col items-center gap-6 py-8 text-center">
-              <div className="max-w-sm">
-                <h2 className="text-lg font-semibold text-slate-800">Ready to write?</h2>
-                <p className="mt-1 text-sm text-slate-500">
-                  Walk through our step-by-step wizard and let AI handle the heavy lifting.
-                </p>
-              </div>
-              {error && <Toast variant="error">{error}</Toast>}
-              <div className="flex gap-3">
-                <Button onClick={() => void startNewBlog()} size="md">
-                  Start a new blog post →
-                </Button>
-                <Button variant="ghost" size="md" onClick={() => setState({ step: 'history' })}>
-                  My blogs
-                </Button>
-              </div>
-              <button
-                onClick={() => setState({ step: 'profile-settings' })}
-                className="text-xs text-slate-400 hover:text-slate-600 underline"
-              >
-                Manage author profiles
-              </button>
+    <AuthProvider>
+      <Router>
+        <Fragment>
+          {!isSupabaseConfigured && (
+            <div
+              role="status"
+              className="border-b border-amber-200 bg-amber-50 px-4 py-2 text-center text-sm text-amber-950"
+            >
+              Supabase env vars were missing at <strong className="font-medium">build</strong> time
+              (<code className="rounded bg-amber-100/80 px-1">VITE_SUPABASE_URL</code>,{' '}
+              <code className="rounded bg-amber-100/80 px-1">VITE_SUPABASE_ANON_KEY</code>). Auth and
+              API calls will fail until you rebuild the frontend with real values (see{' '}
+              <code className="rounded bg-amber-100/80 px-1">docker-compose.yml</code> build args).
             </div>
           )}
+          <Routes>
+            {/* Public Auth Routes */}
+            <Route path="/login" element={<LoginPage />} />
+            <Route path="/register" element={<RegisterPage />} />
+            <Route path="/check-email" element={<CheckEmailPage />} />
+            <Route path="/verify" element={<VerifyPage />} />
+            <Route path="/forgot-password" element={<ForgotPasswordPage />} />
+            <Route path="/reset-password" element={<ResetPasswordPage />} />
 
-          {state.step === 'history' && (
-            <BlogHistory
-              onResume={resumeBlog}
-              onNew={() => void startNewBlog()}
-            />
-          )}
+            {/* Protected App Routes */}
+            <Route element={<ProtectedRoute />}>
+              <Route path="/" element={<Dashboard />} />
+            </Route>
 
-          {state.step === 'creating' && (
-            <div className="flex flex-col items-center gap-3 py-12 text-slate-500">
-              <span className="inline-block h-6 w-6 animate-spin rounded-full border-2 border-slate-200 border-t-indigo-500" />
-              <p className="text-sm">Setting up your blog…</p>
-            </div>
-          )}
+            {/* Admin Routes */}
+            <Route element={<AdminRoute />}>
+              <Route path="/admin/users" element={<AdminUsersPage />} />
+              <Route path="/admin/blogs" element={<AdminBlogsPage />} />
+              <Route path="/admin/profiles" element={<AdminProfilesPage />} />
+            </Route>
 
-          {state.step === 'brief' && (
-            <>
-              <div className="mb-6 flex items-start justify-between">
-                <div>
-                  <h2 className="text-lg font-semibold text-slate-800">Step 1: Blog Brief</h2>
-                  <p className="mt-1 text-sm text-slate-500">
-                    Tell us about your post. The more detail you give, the better the output.
-                  </p>
-                </div>
-                <ProfileSwitcher
-                  activeProfileId={activeProfileId}
-                  onProfileChange={(profile) => setActiveProfile(profile.id, setActiveProfileId)}
-                  onManageProfiles={() => setState({ step: 'profile-settings' })}
-                />
-              </div>
-              <BlogBriefForm
-                blogId={state.blogId}
-                activeProfileId={activeProfileId}
-                onSuccess={() => setState({ step: 'alignment', blogId: state.blogId })}
-              />
-            </>
-          )}
-
-          {state.step === 'alignment' && (
-            <>
-              <AlignmentSummary
-                blogId={state.blogId}
-                onEdit={() => setState({ step: 'brief', blogId: state.blogId })}
-                onConfirmed={() => setState({ step: 'outline', blogId: state.blogId })}
-              />
-              <ViewPromptPanel blogId={state.blogId} step="alignment" />
-            </>
-          )}
-
-          {state.step === 'outline' && (
-            <>
-              <OutlineStep
-                blogId={state.blogId}
-                onBack={() => setState({ step: 'alignment', blogId: state.blogId })}
-                onConfirmed={() => setState({ step: 'draft', blogId: state.blogId })}
-              />
-              <ViewPromptPanel blogId={state.blogId} step="outline" />
-            </>
-          )}
-
-          {state.step === 'draft' && (
-            <>
-              <DraftStep
-                blogId={state.blogId}
-                onBack={() => setState({ step: 'outline', blogId: state.blogId })}
-                onConfirmed={() => setState({ step: 'publish', blogId: state.blogId })}
-              />
-              <ViewPromptPanel blogId={state.blogId} step="draft" />
-            </>
-          )}
-
-          {state.step === 'publish' && (
-            <PublishStep
-              blogId={state.blogId}
-              onBack={() => setState({ step: 'draft', blogId: state.blogId })}
-              onFinish={() => setState({ step: 'done', blogId: state.blogId })}
-            />
-          )}
-
-          {state.step === 'done' && (
-            <div className="flex flex-col items-center gap-6 py-8 text-center">
-              <div className="flex h-14 w-14 items-center justify-center rounded-full bg-green-100 text-green-600 text-2xl">
-                ✓
-              </div>
-              <div>
-                <h2 className="text-lg font-semibold text-slate-800">All set</h2>
-                <p className="mt-1 text-sm text-slate-500">
-                  Thanks for using the wizard. Start another post whenever you are ready.
-                </p>
-              </div>
-              <div className="flex gap-3">
-                <Button size="sm" onClick={() => void startNewBlog()}>
-                  + New post
-                </Button>
-                <Button variant="ghost" size="sm" onClick={() => setState({ step: 'history' })}>
-                  My blogs
-                </Button>
-              </div>
-            </div>
-          )}
-
-        </div>
-
-        <p className="mt-6 text-center text-xs text-slate-400">
-          Powered by Claude AI · Naser Company
-          {import.meta.env.VITE_APP_VERSION && (
-            <span className="ml-1 text-slate-300">v{import.meta.env.VITE_APP_VERSION}</span>
-          )}
-        </p>
-      </div>
-    </div>
+            {/* Fallback */}
+            <Route path="*" element={<Navigate to="/" replace />} />
+          </Routes>
+        </Fragment>
+      </Router>
+    </AuthProvider>
   );
 }

--- a/frontend/src/api/blog-api.js
+++ b/frontend/src/api/blog-api.js
@@ -1,9 +1,10 @@
+import { authedFetch } from '../lib/authed-fetch.js';
 const BASE = '/api/blogs';
 export async function getBrief(blogId) {
     return request(`${BASE}/${blogId}/brief`);
 }
 async function request(url, options) {
-    const res = await fetch(url, {
+    const res = await authedFetch(url, {
         headers: { 'Content-Type': 'application/json' },
         ...options,
     });
@@ -70,7 +71,7 @@ export async function confirmAlignment(blogId) {
 }
 /** GET /outline — same section shape as generate; null if no outline row yet (404). */
 export async function getOutline(blogId) {
-    const res = await fetch(`${BASE}/${blogId}/outline`, {
+    const res = await authedFetch(`${BASE}/${blogId}/outline`, {
         headers: { 'Content-Type': 'application/json' },
     });
     if (res.status === 404)

--- a/frontend/src/api/blog-api.ts
+++ b/frontend/src/api/blog-api.ts
@@ -1,3 +1,5 @@
+import { authedFetch } from '../lib/authed-fetch.js';
+
 const BASE = '/api/blogs';
 
 export interface SubmitBriefPayload {
@@ -38,7 +40,7 @@ export async function getBrief(blogId: string): Promise<BlogBriefResponse> {
 }
 
 async function request<T>(url: string, options?: RequestInit): Promise<T> {
-  const res = await fetch(url, {
+  const res = await authedFetch(url, {
     headers: { 'Content-Type': 'application/json' },
     ...options,
   });
@@ -174,7 +176,7 @@ export async function getOutline(
   outlineConfirmed: boolean;
   outlineIterations: number;
 } | null> {
-  const res = await fetch(`${BASE}/${blogId}/outline`, {
+  const res = await authedFetch(`${BASE}/${blogId}/outline`, {
     headers: { 'Content-Type': 'application/json' },
   });
   if (res.status === 404) return null;

--- a/frontend/src/api/profile-api.js
+++ b/frontend/src/api/profile-api.js
@@ -1,6 +1,7 @@
+import { authedFetch } from '../lib/authed-fetch.js';
 const BASE = '/api/profiles';
 async function request(url, options) {
-    const res = await fetch(url, {
+    const res = await authedFetch(url, {
         headers: { 'Content-Type': 'application/json' },
         ...options,
     });

--- a/frontend/src/api/profile-api.ts
+++ b/frontend/src/api/profile-api.ts
@@ -1,3 +1,5 @@
+import { authedFetch } from '../lib/authed-fetch.js';
+
 const BASE = '/api/profiles';
 
 export type BlogIntent = 'thought_leadership' | 'seo' | 'product_announcement' | 'newsletter' | 'deep_dive';
@@ -30,7 +32,7 @@ export interface CloneProfilePayload {
 }
 
 async function request<T>(url: string, options?: RequestInit): Promise<T> {
-  const res = await fetch(url, {
+  const res = await authedFetch(url, {
     headers: { 'Content-Type': 'application/json' },
     ...options,
   });

--- a/frontend/src/components/BlogBriefForm.js
+++ b/frontend/src/components/BlogBriefForm.js
@@ -171,8 +171,15 @@ export function BlogBriefForm({ blogId, activeProfileId, onSuccess }) {
         return () => {
             cancelled = true;
         };
-    }, [activeProfileId, dirtyFields.audiencePersona, dirtyFields.toneOfVoice, getValues, loadingBrief, prefillSource, reset]);
-    }, [activeProfileId, dirtyFields.audiencePersona, dirtyFields.toneOfVoice, getValues, loadingBrief, prefillSource, reset]);
+    }, [
+        activeProfileId,
+        dirtyFields.audiencePersona,
+        dirtyFields.toneOfVoice,
+        getValues,
+        loadingBrief,
+        prefillSource,
+        reset,
+    ]);
     async function onSubmit(values) {
         setSubmitError(null);
         try {

--- a/frontend/src/components/RouteGuards.js
+++ b/frontend/src/components/RouteGuards.js
@@ -1,0 +1,26 @@
+import { jsx as _jsx } from "react/jsx-runtime";
+import { Navigate, Outlet } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+export const ProtectedRoute = () => {
+    const { user, loading } = useAuth();
+    if (loading) {
+        return _jsx("div", { className: "p-8 text-center text-slate-500", children: "Loading..." });
+    }
+    if (!user) {
+        return _jsx(Navigate, { to: "/login", replace: true });
+    }
+    return _jsx(Outlet, {});
+};
+export const AdminRoute = () => {
+    const { user, role, loading } = useAuth();
+    if (loading) {
+        return _jsx("div", { className: "p-8 text-center text-slate-500", children: "Loading..." });
+    }
+    if (!user) {
+        return _jsx(Navigate, { to: "/login", replace: true });
+    }
+    if (role !== 'admin') {
+        return _jsx(Navigate, { to: "/", replace: true });
+    }
+    return _jsx(Outlet, {});
+};

--- a/frontend/src/components/RouteGuards.tsx
+++ b/frontend/src/components/RouteGuards.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+export const ProtectedRoute: React.FC = () => {
+  const { user, loading } = useAuth();
+
+  if (loading) {
+    return <div className="p-8 text-center text-slate-500">Loading...</div>;
+  }
+
+  if (!user) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return <Outlet />;
+};
+
+export const AdminRoute: React.FC = () => {
+  const { user, role, loading } = useAuth();
+
+  if (loading) {
+    return <div className="p-8 text-center text-slate-500">Loading...</div>;
+  }
+
+  if (!user) {
+    return <Navigate to="/login" replace />;
+  }
+
+  if (role !== 'admin') {
+    return <Navigate to="/" replace />;
+  }
+
+  return <Outlet />;
+};

--- a/frontend/src/context/AuthContext.js
+++ b/frontend/src/context/AuthContext.js
@@ -1,0 +1,79 @@
+import { jsx as _jsx } from "react/jsx-runtime";
+import { createContext, useContext, useEffect, useState } from 'react';
+import { supabase } from '../lib/supabase';
+const AuthContext = createContext({
+    user: null,
+    session: null,
+    role: null,
+    emailVerifiedAt: null,
+    deactivatedAt: null,
+    loading: true,
+    logout: async () => { },
+});
+export const AuthProvider = ({ children }) => {
+    const [user, setUser] = useState(null);
+    const [session, setSession] = useState(null);
+    const [role, setRole] = useState(null);
+    const [emailVerifiedAt, setEmailVerifiedAt] = useState(null);
+    const [deactivatedAt, setDeactivatedAt] = useState(null);
+    const [loading, setLoading] = useState(true);
+    useEffect(() => {
+        // Get initial session
+        supabase.auth
+            .getSession()
+            .then(({ data: { session } }) => {
+            setSession(session);
+            setUser(session?.user ?? null);
+            if (session?.user) {
+                void fetchProfile(session.user.id);
+            }
+            else {
+                setLoading(false);
+            }
+        })
+            .catch((err) => {
+            console.error('getSession failed:', err);
+            setLoading(false);
+        });
+        // Listen for auth changes
+        const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+            setSession(session);
+            setUser(session?.user ?? null);
+            if (session?.user) {
+                fetchProfile(session.user.id);
+            }
+            else {
+                setRole(null);
+                setEmailVerifiedAt(null);
+                setDeactivatedAt(null);
+                setLoading(false);
+            }
+        });
+        return () => subscription.unsubscribe();
+    }, []);
+    const fetchProfile = async (userId) => {
+        try {
+            const { data, error } = await supabase
+                .from('users')
+                .select('role, email_verified_at, deactivated_at')
+                .eq('id', userId)
+                .single();
+            if (!error && data) {
+                setRole(data.role);
+                setEmailVerifiedAt(data.email_verified_at);
+                setDeactivatedAt(data.deactivated_at);
+            }
+        }
+        catch (e) {
+            console.error('Error fetching profile:', e);
+        }
+        finally {
+            setLoading(false);
+        }
+    };
+    const logout = async () => {
+        await supabase.auth.signOut();
+    };
+    return (_jsx(AuthContext.Provider, { value: { user, session, role, emailVerifiedAt, deactivatedAt, loading, logout }, children: children }));
+};
+export const useAuth = () => useContext(AuthContext);

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,0 +1,101 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { supabase } from '../lib/supabase';
+import { User, Session } from '@supabase/supabase-js';
+
+export interface AuthContextType {
+  user: User | null;
+  session: Session | null;
+  role: 'admin' | 'user' | null;
+  emailVerifiedAt: string | null;
+  deactivatedAt: string | null;
+  loading: boolean;
+  logout: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextType>({
+  user: null,
+  session: null,
+  role: null,
+  emailVerifiedAt: null,
+  deactivatedAt: null,
+  loading: true,
+  logout: async () => {},
+});
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [user, setUser] = useState<User | null>(null);
+  const [session, setSession] = useState<Session | null>(null);
+  const [role, setRole] = useState<'admin' | 'user' | null>(null);
+  const [emailVerifiedAt, setEmailVerifiedAt] = useState<string | null>(null);
+  const [deactivatedAt, setDeactivatedAt] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    // Get initial session
+    supabase.auth
+      .getSession()
+      .then(({ data: { session } }) => {
+        setSession(session);
+        setUser(session?.user ?? null);
+        if (session?.user) {
+          void fetchProfile(session.user.id);
+        } else {
+          setLoading(false);
+        }
+      })
+      .catch((err) => {
+        console.error('getSession failed:', err);
+        setLoading(false);
+      });
+
+    // Listen for auth changes
+    const { data: { subscription } } = supabase.auth.onAuthStateChange(
+      (_event, session) => {
+        setSession(session);
+        setUser(session?.user ?? null);
+        if (session?.user) {
+          fetchProfile(session.user.id);
+        } else {
+          setRole(null);
+          setEmailVerifiedAt(null);
+          setDeactivatedAt(null);
+          setLoading(false);
+        }
+      }
+    );
+
+    return () => subscription.unsubscribe();
+  }, []);
+
+  const fetchProfile = async (userId: string) => {
+    try {
+      const { data, error } = await supabase
+        .from('users')
+        .select('role, email_verified_at, deactivated_at')
+        .eq('id', userId)
+        .single();
+      
+      if (!error && data) {
+        setRole(data.role);
+        setEmailVerifiedAt(data.email_verified_at);
+        setDeactivatedAt(data.deactivated_at);
+      }
+    } catch (e) {
+      console.error('Error fetching profile:', e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const logout = async () => {
+    await supabase.auth.signOut();
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, session, role, emailVerifiedAt, deactivatedAt, loading, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => useContext(AuthContext);

--- a/frontend/src/lib/authed-fetch.js
+++ b/frontend/src/lib/authed-fetch.js
@@ -1,0 +1,14 @@
+import { supabase } from './supabase.js';
+/** fetch() with Supabase access token when a session exists (Express API uses requireAuth). */
+export async function authedFetch(url, options = {}) {
+    const { data: { session } } = await supabase.auth.getSession();
+    const headers = new Headers(options.headers);
+    if (!headers.has('Content-Type')) {
+        headers.set('Content-Type', 'application/json');
+    }
+    const token = session?.access_token;
+    if (token) {
+        headers.set('Authorization', `Bearer ${token}`);
+    }
+    return fetch(url, { ...options, headers });
+}

--- a/frontend/src/lib/authed-fetch.ts
+++ b/frontend/src/lib/authed-fetch.ts
@@ -1,0 +1,15 @@
+import { supabase } from './supabase.js';
+
+/** fetch() with Supabase access token when a session exists (Express API uses requireAuth). */
+export async function authedFetch(url: string, options: RequestInit = {}): Promise<Response> {
+  const { data: { session } } = await supabase.auth.getSession();
+  const headers = new Headers(options.headers);
+  if (!headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json');
+  }
+  const token = session?.access_token;
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+  return fetch(url, { ...options, headers });
+}

--- a/frontend/src/lib/supabase.js
+++ b/frontend/src/lib/supabase.js
@@ -1,0 +1,14 @@
+import { createClient } from '@supabase/supabase-js';
+const rawUrl = import.meta.env.VITE_SUPABASE_URL?.trim();
+const rawKey = import.meta.env.VITE_SUPABASE_ANON_KEY?.trim();
+/** True when real project URL + anon key were baked in at build time (not placeholders). */
+export const isSupabaseConfigured = Boolean(rawUrl && rawKey);
+// createClient('', '') throws ("supabaseUrl is required") and prevents the app from mounting at all.
+const fallbackUrl = 'http://127.0.0.1:54321';
+const fallbackAnonKey = '00000000000000000000000000000000';
+const supabaseUrl = rawUrl || fallbackUrl;
+const supabaseAnonKey = rawKey || fallbackAnonKey;
+if (!isSupabaseConfigured) {
+    console.warn('[blog-generator] Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY — using local placeholders so the UI can load. Rebuild the frontend image with real Supabase build args for auth to work.');
+}
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -1,0 +1,22 @@
+import { createClient } from '@supabase/supabase-js';
+
+const rawUrl = (import.meta.env.VITE_SUPABASE_URL as string | undefined)?.trim();
+const rawKey = (import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined)?.trim();
+
+/** True when real project URL + anon key were baked in at build time (not placeholders). */
+export const isSupabaseConfigured = Boolean(rawUrl && rawKey);
+
+// createClient('', '') throws ("supabaseUrl is required") and prevents the app from mounting at all.
+const fallbackUrl = 'http://127.0.0.1:54321';
+const fallbackAnonKey = '00000000000000000000000000000000';
+
+const supabaseUrl = rawUrl || fallbackUrl;
+const supabaseAnonKey = rawKey || fallbackAnonKey;
+
+if (!isSupabaseConfigured) {
+  console.warn(
+    '[blog-generator] Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY — using local placeholders so the UI can load. Rebuild the frontend image with real Supabase build args for auth to work.'
+  );
+}
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -1,0 +1,87 @@
+import { jsx as _jsx, jsxs as _jsxs, Fragment as _Fragment } from "react/jsx-runtime";
+import { useState, useEffect } from 'react';
+import { BlogBriefForm } from '../components/BlogBriefForm.js';
+import { AlignmentSummary } from '../components/AlignmentSummary.js';
+import { OutlineStep } from '../components/OutlineStep.js';
+import { DraftStep } from '../components/DraftStep.js';
+import { PublishStep } from '../components/PublishStep.js';
+import { WizardProgress } from '../components/WizardProgress.js';
+import { BlogHistory } from '../components/BlogHistory.js';
+import { ProfileWizard } from '../components/ProfileWizard.js';
+import { ProfileSwitcher } from '../components/ProfileSwitcher.js';
+import { ProfileSettings } from '../components/ProfileSettings.js';
+import { ViewPromptPanel } from '../components/ViewPromptPanel.js';
+import { Button } from '../components/ui/button.js';
+import { Toast } from '../components/ui/toast.js';
+import { createBlog } from '../api/blog-api.js';
+import { listProfiles } from '../api/profile-api.js';
+import { useAuth } from '../context/AuthContext';
+const STEP_TO_APP = {
+    1: 'brief',
+    2: 'alignment',
+    3: 'outline',
+    4: 'draft',
+    5: 'publish',
+    6: 'publish', // completed blogs open on Publish so content can be re-copied
+};
+const ACTIVE_PROFILE_KEY = 'blog-generator:active-profile-id';
+function setActiveProfile(id, setter) {
+    setter(id);
+    localStorage.setItem(ACTIVE_PROFILE_KEY, id);
+}
+export default function Dashboard() {
+    const { logout, role } = useAuth();
+    const [state, setState] = useState({ step: 'idle' });
+    const [error, setError] = useState(null);
+    const [activeProfileId, setActiveProfileId] = useState(() => {
+        return localStorage.getItem(ACTIVE_PROFILE_KEY);
+    });
+    useEffect(() => {
+        async function loadProfiles() {
+            try {
+                const { profiles: loaded } = await listProfiles();
+                if (!activeProfileId || !loaded.find((p) => p.id === activeProfileId)) {
+                    if (loaded.length === 0) {
+                        setState({ step: 'profile-wizard' });
+                    }
+                    else {
+                        setActiveProfile(loaded[0].id, setActiveProfileId);
+                    }
+                }
+            }
+            catch (e) {
+                setError(e.message);
+            }
+        }
+        void loadProfiles();
+    }, [activeProfileId]);
+    async function startNewBlog() {
+        setError(null);
+        setState({ step: 'creating' });
+        try {
+            const { blogId } = await createBlog();
+            setState({ step: 'brief', blogId });
+        }
+        catch (e) {
+            setError(e.message);
+            setState({ step: 'idle' });
+        }
+    }
+    function resumeBlog(blogId, currentStep) {
+        const s = currentStep < 1 ? 1 : currentStep;
+        const step = STEP_TO_APP[s] ?? 'brief';
+        if (step === 'idle' || step === 'history' || step === 'creating')
+            return;
+        setState({ step, blogId });
+    }
+    const wizardStep = state.step === 'brief' ? 1
+        : state.step === 'alignment' ? 2
+            : state.step === 'outline' ? 3
+                : state.step === 'draft' ? 4
+                    : state.step === 'publish' ? 5
+                        : 1;
+    return (_jsx("div", { className: "min-h-screen bg-gradient-to-br from-slate-50 to-indigo-50", children: _jsxs("div", { className: "mx-auto max-w-2xl px-4 py-10 sm:px-6 lg:px-8", children: [_jsxs("div", { className: "mb-10 text-center", children: [_jsx("div", { className: "mb-3 inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-indigo-600 text-white text-xl shadow-lg", children: "\u2726" }), _jsx("h1", { className: "text-3xl font-bold tracking-tight text-slate-900", children: "AI Blog Generator" }), _jsx("p", { className: "mt-2 text-slate-500 text-sm", children: "Create a fully-structured, SEO-ready blog post in minutes." }), _jsxs("div", { className: "mt-4 flex justify-center", children: [_jsx("button", { onClick: logout, className: "text-sm text-red-600 hover:underline", children: "Log out" }), role === 'admin' && (_jsx("a", { href: "/admin/users", className: "ml-4 text-sm text-indigo-600 hover:underline", children: "Admin Dashboard" }))] })] }), (state.step === 'brief' || state.step === 'alignment' || state.step === 'outline' || state.step === 'draft' || state.step === 'publish') && (_jsx("div", { className: "mb-8", children: _jsx(WizardProgress, { current: wizardStep }) })), _jsxs("div", { className: "rounded-2xl bg-white shadow-sm ring-1 ring-slate-200 p-6 sm:p-8", children: [state.step === 'profile-wizard' && (_jsx(ProfileWizard, { onProfileSelected: (profile) => {
+                                setActiveProfile(profile.id, setActiveProfileId);
+                                setState({ step: 'idle' });
+                            } })), state.step === 'profile-settings' && (_jsx(ProfileSettings, { activeProfileId: activeProfileId, onActiveProfileChange: (id) => setActiveProfile(id, setActiveProfileId), onBack: () => setState({ step: 'idle' }) })), state.step === 'idle' && (_jsxs("div", { className: "flex flex-col items-center gap-6 py-8 text-center", children: [_jsxs("div", { className: "max-w-sm", children: [_jsx("h2", { className: "text-lg font-semibold text-slate-800", children: "Ready to write?" }), _jsx("p", { className: "mt-1 text-sm text-slate-500", children: "Walk through our step-by-step wizard and let AI handle the heavy lifting." })] }), error && _jsx(Toast, { variant: "error", children: error }), _jsxs("div", { className: "flex gap-3", children: [_jsx(Button, { onClick: () => void startNewBlog(), size: "md", children: "Start a new blog post \u2192" }), _jsx(Button, { variant: "ghost", size: "md", onClick: () => setState({ step: 'history' }), children: "My blogs" })] }), _jsx("button", { onClick: () => setState({ step: 'profile-settings' }), className: "text-xs text-slate-400 hover:text-slate-600 underline", children: "Manage author profiles" })] })), state.step === 'history' && (_jsx(BlogHistory, { onResume: resumeBlog, onNew: () => void startNewBlog() })), state.step === 'creating' && (_jsxs("div", { className: "flex flex-col items-center gap-3 py-12 text-slate-500", children: [_jsx("span", { className: "inline-block h-6 w-6 animate-spin rounded-full border-2 border-slate-200 border-t-indigo-500" }), _jsx("p", { className: "text-sm", children: "Setting up your blog\u2026" })] })), state.step === 'brief' && (_jsxs(_Fragment, { children: [_jsxs("div", { className: "mb-6 flex items-start justify-between", children: [_jsxs("div", { children: [_jsx("h2", { className: "text-lg font-semibold text-slate-800", children: "Step 1: Blog Brief" }), _jsx("p", { className: "mt-1 text-sm text-slate-500", children: "Tell us about your post. The more detail you give, the better the output." })] }), _jsx(ProfileSwitcher, { activeProfileId: activeProfileId, onProfileChange: (profile) => setActiveProfile(profile.id, setActiveProfileId), onManageProfiles: () => setState({ step: 'profile-settings' }) })] }), _jsx(BlogBriefForm, { blogId: state.blogId, activeProfileId: activeProfileId, onSuccess: () => setState({ step: 'alignment', blogId: state.blogId }) })] })), state.step === 'alignment' && (_jsxs(_Fragment, { children: [_jsx(AlignmentSummary, { blogId: state.blogId, onEdit: () => setState({ step: 'brief', blogId: state.blogId }), onConfirmed: () => setState({ step: 'outline', blogId: state.blogId }) }), _jsx(ViewPromptPanel, { blogId: state.blogId, step: "alignment" })] })), state.step === 'outline' && (_jsxs(_Fragment, { children: [_jsx(OutlineStep, { blogId: state.blogId, onBack: () => setState({ step: 'alignment', blogId: state.blogId }), onConfirmed: () => setState({ step: 'draft', blogId: state.blogId }) }), _jsx(ViewPromptPanel, { blogId: state.blogId, step: "outline" })] })), state.step === 'draft' && (_jsxs(_Fragment, { children: [_jsx(DraftStep, { blogId: state.blogId, onBack: () => setState({ step: 'outline', blogId: state.blogId }), onConfirmed: () => setState({ step: 'publish', blogId: state.blogId }) }), _jsx(ViewPromptPanel, { blogId: state.blogId, step: "draft" })] })), state.step === 'publish' && (_jsx(PublishStep, { blogId: state.blogId, onBack: () => setState({ step: 'draft', blogId: state.blogId }), onFinish: () => setState({ step: 'done', blogId: state.blogId }) })), state.step === 'done' && (_jsxs("div", { className: "flex flex-col items-center gap-6 py-8 text-center", children: [_jsx("div", { className: "flex h-14 w-14 items-center justify-center rounded-full bg-green-100 text-green-600 text-2xl", children: "\u2713" }), _jsxs("div", { children: [_jsx("h2", { className: "text-lg font-semibold text-slate-800", children: "All set" }), _jsx("p", { className: "mt-1 text-sm text-slate-500", children: "Thanks for using the wizard. Start another post whenever you are ready." })] }), _jsxs("div", { className: "flex gap-3", children: [_jsx(Button, { size: "sm", onClick: () => void startNewBlog(), children: "+ New post" }), _jsx(Button, { variant: "ghost", size: "sm", onClick: () => setState({ step: 'history' }), children: "My blogs" })] })] }))] }), _jsxs("p", { className: "mt-6 text-center text-xs text-slate-400", children: ["Powered by Claude AI \u00B7 Naser Company", import.meta.env.VITE_APP_VERSION && (_jsxs("span", { className: "ml-1 text-slate-300", children: ["v", import.meta.env.VITE_APP_VERSION] }))] })] }) }));
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,0 +1,287 @@
+import { useState, useEffect } from 'react';
+import { BlogBriefForm } from '../components/BlogBriefForm.js';
+import { AlignmentSummary } from '../components/AlignmentSummary.js';
+import { OutlineStep } from '../components/OutlineStep.js';
+import { DraftStep } from '../components/DraftStep.js';
+import { PublishStep } from '../components/PublishStep.js';
+import { WizardProgress } from '../components/WizardProgress.js';
+import { BlogHistory } from '../components/BlogHistory.js';
+import { ProfileWizard } from '../components/ProfileWizard.js';
+import { ProfileSwitcher } from '../components/ProfileSwitcher.js';
+import { ProfileSettings } from '../components/ProfileSettings.js';
+import { ViewPromptPanel } from '../components/ViewPromptPanel.js';
+import { Button } from '../components/ui/button.js';
+import { Toast } from '../components/ui/toast.js';
+import { createBlog } from '../api/blog-api.js';
+import { listProfiles } from '../api/profile-api.js';
+import { useAuth } from '../context/AuthContext';
+
+type AppState =
+  | { step: 'profile-wizard' }
+  | { step: 'profile-settings' }
+  | { step: 'idle' }
+  | { step: 'history' }
+  | { step: 'creating' }
+  | { step: 'brief'; blogId: string }
+  | { step: 'alignment'; blogId: string }
+  | { step: 'outline'; blogId: string }
+  | { step: 'draft'; blogId: string }
+  | { step: 'publish'; blogId: string }
+  | { step: 'done'; blogId: string };
+
+const STEP_TO_APP: Record<number, AppState['step']> = {
+  1: 'brief',
+  2: 'alignment',
+  3: 'outline',
+  4: 'draft',
+  5: 'publish',
+  6: 'publish', // completed blogs open on Publish so content can be re-copied
+};
+
+const ACTIVE_PROFILE_KEY = 'blog-generator:active-profile-id';
+
+function setActiveProfile(id: string, setter: (id: string) => void) {
+  setter(id);
+  localStorage.setItem(ACTIVE_PROFILE_KEY, id);
+}
+
+export default function Dashboard() {
+  const { logout, role } = useAuth();
+  const [state, setState] = useState<AppState>({ step: 'idle' });
+  const [error, setError] = useState<string | null>(null);
+  const [activeProfileId, setActiveProfileId] = useState<string | null>(() => {
+    return localStorage.getItem(ACTIVE_PROFILE_KEY);
+  });
+
+  useEffect(() => {
+    async function loadProfiles() {
+      try {
+        const { profiles: loaded } = await listProfiles();
+
+        if (!activeProfileId || !loaded.find((p) => p.id === activeProfileId)) {
+          if (loaded.length === 0) {
+            setState({ step: 'profile-wizard' });
+          } else {
+            setActiveProfile(loaded[0].id, setActiveProfileId);
+          }
+        }
+      } catch (e) {
+        setError((e as Error).message);
+      }
+    }
+    void loadProfiles();
+  }, [activeProfileId]);
+
+  async function startNewBlog() {
+    setError(null);
+    setState({ step: 'creating' });
+    try {
+      const { blogId } = await createBlog();
+      setState({ step: 'brief', blogId });
+    } catch (e) {
+      setError((e as Error).message);
+      setState({ step: 'idle' });
+    }
+  }
+
+  function resumeBlog(blogId: string, currentStep: number) {
+    const s = currentStep < 1 ? 1 : currentStep;
+    const step = STEP_TO_APP[s] ?? 'brief';
+    if (step === 'idle' || step === 'history' || step === 'creating') return;
+    setState({ step, blogId });
+  }
+
+  const wizardStep =
+    state.step === 'brief' ? 1
+    : state.step === 'alignment' ? 2
+    : state.step === 'outline' ? 3
+    : state.step === 'draft' ? 4
+    : state.step === 'publish' ? 5
+    : 1;
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-indigo-50">
+      <div className="mx-auto max-w-2xl px-4 py-10 sm:px-6 lg:px-8">
+
+        {/* Header */}
+        <div className="mb-10 text-center">
+          <div className="mb-3 inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-indigo-600 text-white text-xl shadow-lg">
+            ✦
+          </div>
+          <h1 className="text-3xl font-bold tracking-tight text-slate-900">AI Blog Generator</h1>
+          <p className="mt-2 text-slate-500 text-sm">
+            Create a fully-structured, SEO-ready blog post in minutes.
+          </p>
+          <div className="mt-4 flex justify-center">
+             <button onClick={logout} className="text-sm text-red-600 hover:underline">Log out</button>
+             {role === 'admin' && (
+               <a href="/admin/users" className="ml-4 text-sm text-indigo-600 hover:underline">Admin Dashboard</a>
+             )}
+          </div>
+        </div>
+
+        {/* Wizard progress */}
+        {(state.step === 'brief' || state.step === 'alignment' || state.step === 'outline' || state.step === 'draft' || state.step === 'publish') && (
+          <div className="mb-8">
+            <WizardProgress current={wizardStep} />
+          </div>
+        )}
+
+        {/* Card */}
+        <div className="rounded-2xl bg-white shadow-sm ring-1 ring-slate-200 p-6 sm:p-8">
+
+          {state.step === 'profile-wizard' && (
+            <ProfileWizard
+              onProfileSelected={(profile) => {
+                setActiveProfile(profile.id, setActiveProfileId);
+                setState({ step: 'idle' });
+              }}
+            />
+          )}
+
+          {state.step === 'profile-settings' && (
+            <ProfileSettings
+              activeProfileId={activeProfileId}
+              onActiveProfileChange={(id) => setActiveProfile(id, setActiveProfileId)}
+              onBack={() => setState({ step: 'idle' })}
+            />
+          )}
+
+          {state.step === 'idle' && (
+            <div className="flex flex-col items-center gap-6 py-8 text-center">
+              <div className="max-w-sm">
+                <h2 className="text-lg font-semibold text-slate-800">Ready to write?</h2>
+                <p className="mt-1 text-sm text-slate-500">
+                  Walk through our step-by-step wizard and let AI handle the heavy lifting.
+                </p>
+              </div>
+              {error && <Toast variant="error">{error}</Toast>}
+              <div className="flex gap-3">
+                <Button onClick={() => void startNewBlog()} size="md">
+                  Start a new blog post →
+                </Button>
+                <Button variant="ghost" size="md" onClick={() => setState({ step: 'history' })}>
+                  My blogs
+                </Button>
+              </div>
+              <button
+                onClick={() => setState({ step: 'profile-settings' })}
+                className="text-xs text-slate-400 hover:text-slate-600 underline"
+              >
+                Manage author profiles
+              </button>
+            </div>
+          )}
+
+          {state.step === 'history' && (
+            <BlogHistory
+              onResume={resumeBlog}
+              onNew={() => void startNewBlog()}
+            />
+          )}
+
+          {state.step === 'creating' && (
+            <div className="flex flex-col items-center gap-3 py-12 text-slate-500">
+              <span className="inline-block h-6 w-6 animate-spin rounded-full border-2 border-slate-200 border-t-indigo-500" />
+              <p className="text-sm">Setting up your blog…</p>
+            </div>
+          )}
+
+          {state.step === 'brief' && (
+            <>
+              <div className="mb-6 flex items-start justify-between">
+                <div>
+                  <h2 className="text-lg font-semibold text-slate-800">Step 1: Blog Brief</h2>
+                  <p className="mt-1 text-sm text-slate-500">
+                    Tell us about your post. The more detail you give, the better the output.
+                  </p>
+                </div>
+                <ProfileSwitcher
+                  activeProfileId={activeProfileId}
+                  onProfileChange={(profile) => setActiveProfile(profile.id, setActiveProfileId)}
+                  onManageProfiles={() => setState({ step: 'profile-settings' })}
+                />
+              </div>
+              <BlogBriefForm
+                blogId={state.blogId}
+                activeProfileId={activeProfileId}
+                onSuccess={() => setState({ step: 'alignment', blogId: state.blogId })}
+              />
+            </>
+          )}
+
+          {state.step === 'alignment' && (
+            <>
+              <AlignmentSummary
+                blogId={state.blogId}
+                onEdit={() => setState({ step: 'brief', blogId: state.blogId })}
+                onConfirmed={() => setState({ step: 'outline', blogId: state.blogId })}
+              />
+              <ViewPromptPanel blogId={state.blogId} step="alignment" />
+            </>
+          )}
+
+          {state.step === 'outline' && (
+            <>
+              <OutlineStep
+                blogId={state.blogId}
+                onBack={() => setState({ step: 'alignment', blogId: state.blogId })}
+                onConfirmed={() => setState({ step: 'draft', blogId: state.blogId })}
+              />
+              <ViewPromptPanel blogId={state.blogId} step="outline" />
+            </>
+          )}
+
+          {state.step === 'draft' && (
+            <>
+              <DraftStep
+                blogId={state.blogId}
+                onBack={() => setState({ step: 'outline', blogId: state.blogId })}
+                onConfirmed={() => setState({ step: 'publish', blogId: state.blogId })}
+              />
+              <ViewPromptPanel blogId={state.blogId} step="draft" />
+            </>
+          )}
+
+          {state.step === 'publish' && (
+            <PublishStep
+              blogId={state.blogId}
+              onBack={() => setState({ step: 'draft', blogId: state.blogId })}
+              onFinish={() => setState({ step: 'done', blogId: state.blogId })}
+            />
+          )}
+
+          {state.step === 'done' && (
+            <div className="flex flex-col items-center gap-6 py-8 text-center">
+              <div className="flex h-14 w-14 items-center justify-center rounded-full bg-green-100 text-green-600 text-2xl">
+                ✓
+              </div>
+              <div>
+                <h2 className="text-lg font-semibold text-slate-800">All set</h2>
+                <p className="mt-1 text-sm text-slate-500">
+                  Thanks for using the wizard. Start another post whenever you are ready.
+                </p>
+              </div>
+              <div className="flex gap-3">
+                <Button size="sm" onClick={() => void startNewBlog()}>
+                  + New post
+                </Button>
+                <Button variant="ghost" size="sm" onClick={() => setState({ step: 'history' })}>
+                  My blogs
+                </Button>
+              </div>
+            </div>
+          )}
+
+        </div>
+
+        <p className="mt-6 text-center text-xs text-slate-400">
+          Powered by Claude AI · Naser Company
+          {import.meta.env.VITE_APP_VERSION && (
+            <span className="ml-1 text-slate-300">v{import.meta.env.VITE_APP_VERSION}</span>
+          )}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/auth/CheckEmailPage.js
+++ b/frontend/src/pages/auth/CheckEmailPage.js
@@ -1,0 +1,5 @@
+import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
+import { Link } from 'react-router-dom';
+export default function CheckEmailPage() {
+    return (_jsx("div", { className: "flex min-h-screen flex-col items-center justify-center bg-slate-50 py-12 sm:px-6 lg:px-8", children: _jsx("div", { className: "sm:mx-auto sm:w-full sm:max-w-md", children: _jsxs("div", { className: "bg-white px-4 py-8 shadow sm:rounded-lg sm:px-10 border border-slate-200 text-center", children: [_jsx("div", { className: "mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-indigo-100 mb-4", children: _jsx("span", { className: "text-indigo-600 text-xl", children: "\u2709\uFE0F" }) }), _jsx("h2", { className: "text-2xl font-bold tracking-tight text-slate-900 mb-2", children: "Check your email" }), _jsx("p", { className: "text-slate-500 mb-6", children: "We've sent a verification link to your email address. Please verify your email to start creating blogs." }), _jsx("div", { className: "text-sm", children: _jsx(Link, { to: "/login", className: "font-medium text-indigo-600 hover:text-indigo-500", children: "Return to login" }) })] }) }) }));
+}

--- a/frontend/src/pages/auth/CheckEmailPage.tsx
+++ b/frontend/src/pages/auth/CheckEmailPage.tsx
@@ -1,0 +1,24 @@
+import { Link } from 'react-router-dom';
+
+export default function CheckEmailPage() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-slate-50 py-12 sm:px-6 lg:px-8">
+      <div className="sm:mx-auto sm:w-full sm:max-w-md">
+        <div className="bg-white px-4 py-8 shadow sm:rounded-lg sm:px-10 border border-slate-200 text-center">
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-indigo-100 mb-4">
+            <span className="text-indigo-600 text-xl">✉️</span>
+          </div>
+          <h2 className="text-2xl font-bold tracking-tight text-slate-900 mb-2">Check your email</h2>
+          <p className="text-slate-500 mb-6">
+            We've sent a verification link to your email address. Please verify your email to start creating blogs.
+          </p>
+          <div className="text-sm">
+            <Link to="/login" className="font-medium text-indigo-600 hover:text-indigo-500">
+              Return to login
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/auth/ForgotPasswordPage.js
+++ b/frontend/src/pages/auth/ForgotPasswordPage.js
@@ -1,0 +1,40 @@
+import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { supabase } from '../../lib/supabase';
+import { Button } from '../../components/ui/button';
+export default function ForgotPasswordPage() {
+    const [email, setEmail] = useState('');
+    const [status, setStatus] = useState('idle');
+    const [errorMsg, setErrorMsg] = useState('');
+    const handleReset = async (e) => {
+        e.preventDefault();
+        setStatus('loading');
+        setErrorMsg('');
+        try {
+            const { error } = await supabase.auth.resetPasswordForEmail(email, {
+                redirectTo: `${window.location.origin}/reset-password`,
+            });
+            if (error) {
+                throw error;
+            }
+            setStatus('success');
+        }
+        catch (err) {
+            // For security, timing-safe implementation would always show success,
+            // but Supabase returns errors for rate-limits etc.
+            if (err.status === 429) {
+                setErrorMsg('Too many requests. Please try again later.');
+                setStatus('error');
+            }
+            else {
+                // Generic success to prevent email enumeration
+                setStatus('success');
+            }
+        }
+    };
+    if (status === 'success') {
+        return (_jsx("div", { className: "flex min-h-screen flex-col items-center justify-center bg-slate-50 py-12 sm:px-6 lg:px-8", children: _jsxs("div", { className: "sm:mx-auto sm:w-full sm:max-w-md bg-white px-4 py-8 shadow sm:rounded-lg sm:px-10 border border-slate-200 text-center", children: [_jsx("h2", { className: "text-2xl font-bold tracking-tight text-slate-900 mb-2", children: "Check your email" }), _jsxs("p", { className: "text-slate-500 mb-6", children: ["If an account exists for ", email, ", we have sent a password reset link."] }), _jsx(Link, { to: "/login", className: "font-medium text-indigo-600 hover:text-indigo-500", children: "Return to login" })] }) }));
+    }
+    return (_jsxs("div", { className: "flex min-h-screen flex-col items-center justify-center bg-slate-50 py-12 sm:px-6 lg:px-8", children: [_jsx("div", { className: "sm:mx-auto sm:w-full sm:max-w-md", children: _jsx("h2", { className: "mt-6 text-center text-3xl font-bold tracking-tight text-slate-900", children: "Reset your password" }) }), _jsx("div", { className: "mt-8 sm:mx-auto sm:w-full sm:max-w-md", children: _jsxs("div", { className: "bg-white px-4 py-8 shadow sm:rounded-lg sm:px-10 border border-slate-200", children: [_jsxs("form", { className: "space-y-6", onSubmit: handleReset, children: [status === 'error' && (_jsx("div", { className: "rounded-md bg-red-50 p-4", children: _jsx("div", { className: "text-sm text-red-700", children: errorMsg }) })), _jsxs("div", { children: [_jsx("label", { className: "block text-sm font-medium text-slate-700", children: "Email address" }), _jsx("div", { className: "mt-1", children: _jsx("input", { type: "email", required: true, value: email, onChange: (e) => setEmail(e.target.value), className: "block w-full appearance-none rounded-md border border-slate-300 px-3 py-2 shadow-sm placeholder:text-slate-400 focus:border-indigo-500 focus:outline-none focus:ring-indigo-500 sm:text-sm" }) })] }), _jsx("div", { children: _jsx(Button, { type: "submit", className: "w-full", disabled: status === 'loading', children: status === 'loading' ? 'Sending...' : 'Send reset link' }) })] }), _jsx("div", { className: "mt-6 text-center text-sm", children: _jsx(Link, { to: "/login", className: "font-medium text-indigo-600 hover:text-indigo-500", children: "Back to login" }) })] }) })] }));
+}

--- a/frontend/src/pages/auth/ForgotPasswordPage.tsx
+++ b/frontend/src/pages/auth/ForgotPasswordPage.tsx
@@ -1,0 +1,111 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { supabase, isSupabaseConfigured } from '../../lib/supabase';
+import { Button } from '../../components/ui/button';
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState('');
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
+  const [errorMsg, setErrorMsg] = useState('');
+
+  const handleReset = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setStatus('loading');
+    setErrorMsg('');
+
+    if (!isSupabaseConfigured) {
+      setErrorMsg('Supabase is not configured at build time. Rebuild with VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY.');
+      setStatus('error');
+      return;
+    }
+
+    try {
+      const { error } = await supabase.auth.resetPasswordForEmail(email, {
+        redirectTo: `${window.location.origin}/reset-password`,
+      });
+
+      if (import.meta.env.DEV) {
+        console.debug('[auth] resetPasswordForEmail', { error: error?.message ?? null });
+      }
+
+      if (error) {
+        throw error;
+      }
+
+      setStatus('success');
+    } catch (err: any) {
+      // For security, timing-safe implementation would always show success,
+      // but Supabase returns errors for rate-limits etc.
+      if (err.status === 429) {
+        setErrorMsg('Too many requests. Please try again later.');
+        setStatus('error');
+      } else {
+        // Generic success to prevent email enumeration
+        setStatus('success'); 
+      }
+    }
+  };
+
+  if (status === 'success') {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center bg-slate-50 py-12 sm:px-6 lg:px-8">
+        <div className="sm:mx-auto sm:w-full sm:max-w-md bg-white px-4 py-8 shadow sm:rounded-lg sm:px-10 border border-slate-200 text-center">
+          <h2 className="text-2xl font-bold tracking-tight text-slate-900 mb-2">Check your email</h2>
+          <p className="text-slate-500 mb-6">
+            If an account exists for {email}, we have sent a password reset link.
+          </p>
+          <Link to="/login" className="font-medium text-indigo-600 hover:text-indigo-500">
+            Return to login
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-slate-50 py-12 sm:px-6 lg:px-8">
+      <div className="sm:mx-auto sm:w-full sm:max-w-md">
+        <h2 className="mt-6 text-center text-3xl font-bold tracking-tight text-slate-900">
+          Reset your password
+        </h2>
+      </div>
+
+      <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+        <div className="bg-white px-4 py-8 shadow sm:rounded-lg sm:px-10 border border-slate-200">
+          <form className="space-y-6" onSubmit={handleReset}>
+            {status === 'error' && (
+              <div className="rounded-md bg-red-50 p-4">
+                <div className="text-sm text-red-700">{errorMsg}</div>
+              </div>
+            )}
+            
+            <div>
+              <label className="block text-sm font-medium text-slate-700">Email address</label>
+              <div className="mt-1">
+                <input
+                  type="email"
+                  required
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  className="block w-full appearance-none rounded-md border border-slate-300 px-3 py-2 shadow-sm placeholder:text-slate-400 focus:border-indigo-500 focus:outline-none focus:ring-indigo-500 sm:text-sm"
+                />
+              </div>
+            </div>
+
+            <div>
+              <Button type="submit" className="w-full" disabled={status === 'loading'}>
+                {status === 'loading' ? 'Sending...' : 'Send reset link'}
+              </Button>
+            </div>
+          </form>
+
+          <div className="mt-6 text-center text-sm">
+            <Link to="/login" className="font-medium text-indigo-600 hover:text-indigo-500">
+              Back to login
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/auth/LoginPage.js
+++ b/frontend/src/pages/auth/LoginPage.js
@@ -1,0 +1,36 @@
+import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { supabase } from '../../lib/supabase';
+import { Button } from '../../components/ui/button';
+export default function LoginPage() {
+    const [email, setEmail] = useState('');
+    const [password, setPassword] = useState('');
+    const [error, setError] = useState(null);
+    const [loading, setLoading] = useState(false);
+    const navigate = useNavigate();
+    const handleLogin = async (e) => {
+        e.preventDefault();
+        setError(null);
+        setLoading(true);
+        try {
+            const { error } = await supabase.auth.signInWithPassword({
+                email,
+                password,
+            });
+            if (error) {
+                setError('Invalid email or password');
+            }
+            else {
+                navigate('/');
+            }
+        }
+        catch (err) {
+            setError('An unexpected error occurred');
+        }
+        finally {
+            setLoading(false);
+        }
+    };
+    return (_jsxs("div", { className: "flex min-h-screen flex-col items-center justify-center bg-slate-50 py-12 sm:px-6 lg:px-8", children: [_jsx("div", { className: "sm:mx-auto sm:w-full sm:max-w-md", children: _jsx("h2", { className: "mt-6 text-center text-3xl font-bold tracking-tight text-slate-900", children: "Sign in to your account" }) }), _jsx("div", { className: "mt-8 sm:mx-auto sm:w-full sm:max-w-md", children: _jsxs("div", { className: "bg-white px-4 py-8 shadow sm:rounded-lg sm:px-10 border border-slate-200", children: [_jsxs("form", { className: "space-y-6", onSubmit: handleLogin, children: [error && (_jsx("div", { className: "rounded-md bg-red-50 p-4", children: _jsx("div", { className: "text-sm text-red-700", children: error }) })), _jsxs("div", { children: [_jsx("label", { className: "block text-sm font-medium text-slate-700", children: "Email address" }), _jsx("div", { className: "mt-1", children: _jsx("input", { type: "email", required: true, value: email, onChange: (e) => setEmail(e.target.value), className: "block w-full appearance-none rounded-md border border-slate-300 px-3 py-2 shadow-sm placeholder:text-slate-400 focus:border-indigo-500 focus:outline-none focus:ring-indigo-500 sm:text-sm" }) })] }), _jsxs("div", { children: [_jsx("label", { className: "block text-sm font-medium text-slate-700", children: "Password" }), _jsx("div", { className: "mt-1", children: _jsx("input", { type: "password", required: true, value: password, onChange: (e) => setPassword(e.target.value), className: "block w-full appearance-none rounded-md border border-slate-300 px-3 py-2 shadow-sm placeholder:text-slate-400 focus:border-indigo-500 focus:outline-none focus:ring-indigo-500 sm:text-sm" }) })] }), _jsx("div", { className: "flex items-center justify-between", children: _jsx("div", { className: "text-sm", children: _jsx(Link, { to: "/forgot-password", className: "font-medium text-indigo-600 hover:text-indigo-500", children: "Forgot your password?" }) }) }), _jsx("div", { children: _jsx(Button, { type: "submit", className: "w-full", disabled: loading, children: loading ? 'Signing in...' : 'Sign in' }) })] }), _jsxs("div", { className: "mt-6", children: [_jsxs("div", { className: "relative", children: [_jsx("div", { className: "absolute inset-0 flex items-center", children: _jsx("div", { className: "w-full border-t border-slate-300" }) }), _jsx("div", { className: "relative flex justify-center text-sm", children: _jsx("span", { className: "bg-white px-2 text-slate-500", children: "Or continue with" }) })] }), _jsx("div", { className: "mt-6 text-center text-sm", children: _jsx(Link, { to: "/register", className: "font-medium text-indigo-600 hover:text-indigo-500", children: "Create a new account" }) })] })] }) })] }));
+}

--- a/frontend/src/pages/auth/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage.tsx
@@ -1,0 +1,114 @@
+import React, { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { supabase } from '../../lib/supabase';
+import { Button } from '../../components/ui/button';
+
+export default function LoginPage() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const navigate = useNavigate();
+
+  const handleLogin = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    try {
+      const { error } = await supabase.auth.signInWithPassword({
+        email,
+        password,
+      });
+
+      if (error) {
+        setError('Invalid email or password');
+      } else {
+        navigate('/');
+      }
+    } catch (err) {
+      setError('An unexpected error occurred');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-slate-50 py-12 sm:px-6 lg:px-8">
+      <div className="sm:mx-auto sm:w-full sm:max-w-md">
+        <h2 className="mt-6 text-center text-3xl font-bold tracking-tight text-slate-900">
+          Sign in to your account
+        </h2>
+      </div>
+
+      <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+        <div className="bg-white px-4 py-8 shadow sm:rounded-lg sm:px-10 border border-slate-200">
+          <form className="space-y-6" onSubmit={handleLogin}>
+            {error && (
+              <div className="rounded-md bg-red-50 p-4">
+                <div className="text-sm text-red-700">{error}</div>
+              </div>
+            )}
+            
+            <div>
+              <label className="block text-sm font-medium text-slate-700">Email address</label>
+              <div className="mt-1">
+                <input
+                  type="email"
+                  required
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  className="block w-full appearance-none rounded-md border border-slate-300 px-3 py-2 shadow-sm placeholder:text-slate-400 focus:border-indigo-500 focus:outline-none focus:ring-indigo-500 sm:text-sm"
+                />
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-slate-700">Password</label>
+              <div className="mt-1">
+                <input
+                  type="password"
+                  required
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  className="block w-full appearance-none rounded-md border border-slate-300 px-3 py-2 shadow-sm placeholder:text-slate-400 focus:border-indigo-500 focus:outline-none focus:ring-indigo-500 sm:text-sm"
+                />
+              </div>
+            </div>
+
+            <div className="flex items-center justify-between">
+              <div className="text-sm">
+                <Link to="/forgot-password" className="font-medium text-indigo-600 hover:text-indigo-500">
+                  Forgot your password?
+                </Link>
+              </div>
+            </div>
+
+            <div>
+              <Button type="submit" className="w-full" disabled={loading}>
+                {loading ? 'Signing in...' : 'Sign in'}
+              </Button>
+            </div>
+          </form>
+
+          <div className="mt-6">
+            <div className="relative">
+              <div className="absolute inset-0 flex items-center">
+                <div className="w-full border-t border-slate-300" />
+              </div>
+              <div className="relative flex justify-center text-sm">
+                <span className="bg-white px-2 text-slate-500">Or continue with</span>
+              </div>
+            </div>
+
+            <div className="mt-6 text-center text-sm">
+              <Link to="/register" className="font-medium text-indigo-600 hover:text-indigo-500">
+                Create a new account
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/auth/RegisterPage.js
+++ b/frontend/src/pages/auth/RegisterPage.js
@@ -1,0 +1,46 @@
+import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { supabase } from '../../lib/supabase';
+import { Button } from '../../components/ui/button';
+export default function RegisterPage() {
+    const [email, setEmail] = useState('');
+    const [password, setPassword] = useState('');
+    const [error, setError] = useState(null);
+    const [loading, setLoading] = useState(false);
+    const navigate = useNavigate();
+    const handleRegister = async (e) => {
+        e.preventDefault();
+        setError(null);
+        setLoading(true);
+        if (password.length < 8) {
+            setError('Password must be at least 8 characters');
+            setLoading(false);
+            return;
+        }
+        try {
+            const { error } = await supabase.auth.signUp({
+                email,
+                password,
+            });
+            if (error) {
+                if (error.message.toLowerCase().includes('already registered')) {
+                    setError('An account with this email already exists. Try logging in or resetting your password.');
+                }
+                else {
+                    setError(error.message);
+                }
+            }
+            else {
+                navigate('/check-email');
+            }
+        }
+        catch (err) {
+            setError('An unexpected error occurred');
+        }
+        finally {
+            setLoading(false);
+        }
+    };
+    return (_jsxs("div", { className: "flex min-h-screen flex-col items-center justify-center bg-slate-50 py-12 sm:px-6 lg:px-8", children: [_jsx("div", { className: "sm:mx-auto sm:w-full sm:max-w-md", children: _jsx("h2", { className: "mt-6 text-center text-3xl font-bold tracking-tight text-slate-900", children: "Create a new account" }) }), _jsx("div", { className: "mt-8 sm:mx-auto sm:w-full sm:max-w-md", children: _jsxs("div", { className: "bg-white px-4 py-8 shadow sm:rounded-lg sm:px-10 border border-slate-200", children: [_jsxs("form", { className: "space-y-6", onSubmit: handleRegister, children: [error && (_jsx("div", { className: "rounded-md bg-red-50 p-4", children: _jsx("div", { className: "text-sm text-red-700", children: error }) })), _jsxs("div", { children: [_jsx("label", { className: "block text-sm font-medium text-slate-700", children: "Email address" }), _jsx("div", { className: "mt-1", children: _jsx("input", { type: "email", required: true, value: email, onChange: (e) => setEmail(e.target.value), className: "block w-full appearance-none rounded-md border border-slate-300 px-3 py-2 shadow-sm placeholder:text-slate-400 focus:border-indigo-500 focus:outline-none focus:ring-indigo-500 sm:text-sm" }) })] }), _jsxs("div", { children: [_jsx("label", { className: "block text-sm font-medium text-slate-700", children: "Password" }), _jsx("div", { className: "mt-1", children: _jsx("input", { type: "password", required: true, value: password, onChange: (e) => setPassword(e.target.value), className: "block w-full appearance-none rounded-md border border-slate-300 px-3 py-2 shadow-sm placeholder:text-slate-400 focus:border-indigo-500 focus:outline-none focus:ring-indigo-500 sm:text-sm" }) })] }), _jsx("div", { children: _jsx(Button, { type: "submit", className: "w-full", disabled: loading, children: loading ? 'Creating account...' : 'Create account' }) })] }), _jsxs("div", { className: "mt-6 text-center text-sm", children: [_jsx("span", { className: "text-slate-500", children: "Already have an account? " }), _jsx(Link, { to: "/login", className: "font-medium text-indigo-600 hover:text-indigo-500", children: "Sign in instead" })] })] }) })] }));
+}

--- a/frontend/src/pages/auth/RegisterPage.tsx
+++ b/frontend/src/pages/auth/RegisterPage.tsx
@@ -1,0 +1,127 @@
+import React, { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { supabase, isSupabaseConfigured } from '../../lib/supabase';
+import { Button } from '../../components/ui/button';
+
+export default function RegisterPage() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const navigate = useNavigate();
+
+  const handleRegister = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    if (password.length < 8) {
+      setError('Password must be at least 8 characters');
+      setLoading(false);
+      return;
+    }
+
+    if (!isSupabaseConfigured) {
+      setError(
+        'Supabase is not configured (missing VITE_SUPABASE_URL / VITE_SUPABASE_ANON_KEY at build time). Rebuild the frontend with real env vars — no verification email can be sent until then.'
+      );
+      setLoading(false);
+      return;
+    }
+
+    try {
+      const { data, error } = await supabase.auth.signUp({
+        email,
+        password,
+        options: {
+          emailRedirectTo: `${window.location.origin}/verify`,
+        },
+      });
+
+      if (import.meta.env.DEV) {
+        // Email is sent by Supabase servers — it will not appear in the browser Network tab.
+        // session != null usually means "confirm email" is disabled in the Supabase project.
+        console.debug('[auth] signUp', {
+          error: error?.message ?? null,
+          hasSession: Boolean(data.session),
+          userId: data.user?.id ?? null,
+        });
+      }
+
+      if (error) {
+        if (error.message.toLowerCase().includes('already registered')) {
+          setError('An account with this email already exists. Try logging in or resetting your password.');
+        } else {
+          setError(error.message);
+        }
+      } else {
+        navigate('/check-email');
+      }
+    } catch (err) {
+      setError('An unexpected error occurred');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-slate-50 py-12 sm:px-6 lg:px-8">
+      <div className="sm:mx-auto sm:w-full sm:max-w-md">
+        <h2 className="mt-6 text-center text-3xl font-bold tracking-tight text-slate-900">
+          Create a new account
+        </h2>
+      </div>
+
+      <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+        <div className="bg-white px-4 py-8 shadow sm:rounded-lg sm:px-10 border border-slate-200">
+          <form className="space-y-6" onSubmit={handleRegister}>
+            {error && (
+              <div className="rounded-md bg-red-50 p-4">
+                <div className="text-sm text-red-700">{error}</div>
+              </div>
+            )}
+            
+            <div>
+              <label className="block text-sm font-medium text-slate-700">Email address</label>
+              <div className="mt-1">
+                <input
+                  type="email"
+                  required
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  className="block w-full appearance-none rounded-md border border-slate-300 px-3 py-2 shadow-sm placeholder:text-slate-400 focus:border-indigo-500 focus:outline-none focus:ring-indigo-500 sm:text-sm"
+                />
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-slate-700">Password</label>
+              <div className="mt-1">
+                <input
+                  type="password"
+                  required
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  className="block w-full appearance-none rounded-md border border-slate-300 px-3 py-2 shadow-sm placeholder:text-slate-400 focus:border-indigo-500 focus:outline-none focus:ring-indigo-500 sm:text-sm"
+                />
+              </div>
+            </div>
+
+            <div>
+              <Button type="submit" className="w-full" disabled={loading}>
+                {loading ? 'Creating account...' : 'Create account'}
+              </Button>
+            </div>
+          </form>
+
+          <div className="mt-6 text-center text-sm">
+            <span className="text-slate-500">Already have an account? </span>
+            <Link to="/login" className="font-medium text-indigo-600 hover:text-indigo-500">
+              Sign in instead
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/auth/ResetPasswordPage.js
+++ b/frontend/src/pages/auth/ResetPasswordPage.js
@@ -1,0 +1,60 @@
+import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { supabase } from '../../lib/supabase';
+import { Button } from '../../components/ui/button';
+export default function ResetPasswordPage() {
+    const [password, setPassword] = useState('');
+    const [confirmPassword, setConfirmPassword] = useState('');
+    const [error, setError] = useState(null);
+    const [loading, setLoading] = useState(false);
+    const navigate = useNavigate();
+    useEffect(() => {
+        // Check if we have an active session or a recovery hash in the URL
+        // Supabase handles the #access_token=... automatically and logs the user in.
+        // If there is no session, they probably came here without a valid token.
+        supabase.auth.getSession().then(({ data: { session } }) => {
+            if (!session) {
+                // We'll let them try, but it might fail if they aren't authenticated
+                // Wait, supabase needs the user to be signed in to update their password.
+                // If the token is expired, they won't be signed in.
+                setError('This reset link is no longer valid or has expired.');
+            }
+        });
+    }, []);
+    const handleUpdate = async (e) => {
+        e.preventDefault();
+        setError(null);
+        setLoading(true);
+        if (password.length < 8) {
+            setError('Password must be at least 8 characters');
+            setLoading(false);
+            return;
+        }
+        if (password !== confirmPassword) {
+            setError('Passwords do not match');
+            setLoading(false);
+            return;
+        }
+        try {
+            const { error: updateError } = await supabase.auth.updateUser({
+                password: password
+            });
+            if (updateError) {
+                setError(updateError.message);
+            }
+            else {
+                // On success, revoke other sessions and redirect to login
+                await supabase.auth.signOut();
+                navigate('/login', { state: { message: 'Password updated — please log in' } });
+            }
+        }
+        catch (err) {
+            setError('An unexpected error occurred');
+        }
+        finally {
+            setLoading(false);
+        }
+    };
+    return (_jsxs("div", { className: "flex min-h-screen flex-col items-center justify-center bg-slate-50 py-12 sm:px-6 lg:px-8", children: [_jsx("div", { className: "sm:mx-auto sm:w-full sm:max-w-md", children: _jsx("h2", { className: "mt-6 text-center text-3xl font-bold tracking-tight text-slate-900", children: "Set new password" }) }), _jsx("div", { className: "mt-8 sm:mx-auto sm:w-full sm:max-w-md", children: _jsx("div", { className: "bg-white px-4 py-8 shadow sm:rounded-lg sm:px-10 border border-slate-200", children: _jsxs("form", { className: "space-y-6", onSubmit: handleUpdate, children: [error && (_jsx("div", { className: "rounded-md bg-red-50 p-4", children: _jsx("div", { className: "text-sm text-red-700", children: error }) })), _jsxs("div", { children: [_jsx("label", { className: "block text-sm font-medium text-slate-700", children: "New Password" }), _jsx("div", { className: "mt-1", children: _jsx("input", { type: "password", required: true, value: password, onChange: (e) => setPassword(e.target.value), className: "block w-full appearance-none rounded-md border border-slate-300 px-3 py-2 shadow-sm placeholder:text-slate-400 focus:border-indigo-500 focus:outline-none focus:ring-indigo-500 sm:text-sm" }) })] }), _jsxs("div", { children: [_jsx("label", { className: "block text-sm font-medium text-slate-700", children: "Confirm Password" }), _jsx("div", { className: "mt-1", children: _jsx("input", { type: "password", required: true, value: confirmPassword, onChange: (e) => setConfirmPassword(e.target.value), className: "block w-full appearance-none rounded-md border border-slate-300 px-3 py-2 shadow-sm placeholder:text-slate-400 focus:border-indigo-500 focus:outline-none focus:ring-indigo-500 sm:text-sm" }) })] }), _jsx("div", { children: _jsx(Button, { type: "submit", className: "w-full", disabled: loading || error === 'This reset link is no longer valid or has expired.', children: loading ? 'Updating...' : 'Update Password' }) })] }) }) })] }));
+}

--- a/frontend/src/pages/auth/ResetPasswordPage.tsx
+++ b/frontend/src/pages/auth/ResetPasswordPage.tsx
@@ -1,0 +1,116 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { supabase } from '../../lib/supabase';
+import { Button } from '../../components/ui/button';
+
+export default function ResetPasswordPage() {
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    // Check if we have an active session or a recovery hash in the URL
+    // Supabase handles the #access_token=... automatically and logs the user in.
+    // If there is no session, they probably came here without a valid token.
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session) {
+        // We'll let them try, but it might fail if they aren't authenticated
+        // Wait, supabase needs the user to be signed in to update their password.
+        // If the token is expired, they won't be signed in.
+        setError('This reset link is no longer valid or has expired.');
+      }
+    });
+  }, []);
+
+  const handleUpdate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    if (password.length < 8) {
+      setError('Password must be at least 8 characters');
+      setLoading(false);
+      return;
+    }
+
+    if (password !== confirmPassword) {
+      setError('Passwords do not match');
+      setLoading(false);
+      return;
+    }
+
+    try {
+      const { error: updateError } = await supabase.auth.updateUser({
+        password: password
+      });
+
+      if (updateError) {
+        setError(updateError.message);
+      } else {
+        // On success, revoke other sessions and redirect to login
+        await supabase.auth.signOut();
+        navigate('/login', { state: { message: 'Password updated — please log in' } });
+      }
+    } catch (err) {
+      setError('An unexpected error occurred');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-slate-50 py-12 sm:px-6 lg:px-8">
+      <div className="sm:mx-auto sm:w-full sm:max-w-md">
+        <h2 className="mt-6 text-center text-3xl font-bold tracking-tight text-slate-900">
+          Set new password
+        </h2>
+      </div>
+
+      <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+        <div className="bg-white px-4 py-8 shadow sm:rounded-lg sm:px-10 border border-slate-200">
+          <form className="space-y-6" onSubmit={handleUpdate}>
+            {error && (
+              <div className="rounded-md bg-red-50 p-4">
+                <div className="text-sm text-red-700">{error}</div>
+              </div>
+            )}
+            
+            <div>
+              <label className="block text-sm font-medium text-slate-700">New Password</label>
+              <div className="mt-1">
+                <input
+                  type="password"
+                  required
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  className="block w-full appearance-none rounded-md border border-slate-300 px-3 py-2 shadow-sm placeholder:text-slate-400 focus:border-indigo-500 focus:outline-none focus:ring-indigo-500 sm:text-sm"
+                />
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-slate-700">Confirm Password</label>
+              <div className="mt-1">
+                <input
+                  type="password"
+                  required
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  className="block w-full appearance-none rounded-md border border-slate-300 px-3 py-2 shadow-sm placeholder:text-slate-400 focus:border-indigo-500 focus:outline-none focus:ring-indigo-500 sm:text-sm"
+                />
+              </div>
+            </div>
+
+            <div>
+              <Button type="submit" className="w-full" disabled={loading || error === 'This reset link is no longer valid or has expired.'}>
+                {loading ? 'Updating...' : 'Update Password'}
+              </Button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/auth/VerifyPage.js
+++ b/frontend/src/pages/auth/VerifyPage.js
@@ -1,0 +1,29 @@
+import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { supabase } from '../../lib/supabase';
+export default function VerifyPage() {
+    const [status, setStatus] = useState('verifying');
+    const navigate = useNavigate();
+    useEffect(() => {
+        // Supabase automatically handles the hash token on load and signs the user in
+        // We just wait for the session
+        const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
+            if (event === 'SIGNED_IN' && session) {
+                setStatus('success');
+                setTimeout(() => navigate('/'), 2000);
+            }
+        });
+        // Timeout if nothing happens
+        const timer = setTimeout(() => {
+            if (status === 'verifying') {
+                setStatus('error');
+            }
+        }, 5000);
+        return () => {
+            subscription.unsubscribe();
+            clearTimeout(timer);
+        };
+    }, [navigate, status]);
+    return (_jsx("div", { className: "flex min-h-screen flex-col items-center justify-center bg-slate-50 py-12 sm:px-6 lg:px-8", children: _jsxs("div", { className: "sm:mx-auto sm:w-full sm:max-w-md bg-white px-4 py-8 shadow sm:rounded-lg sm:px-10 border border-slate-200 text-center", children: [status === 'verifying' && _jsx("p", { children: "Verifying your email..." }), status === 'success' && _jsx("p", { className: "text-green-600", children: "Email verified! Redirecting to dashboard..." }), status === 'error' && _jsx("p", { className: "text-red-600", children: "Verification failed or expired. Try logging in or request a new link." })] }) }));
+}

--- a/frontend/src/pages/auth/VerifyPage.tsx
+++ b/frontend/src/pages/auth/VerifyPage.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { supabase } from '../../lib/supabase';
+
+export default function VerifyPage() {
+  const [status, setStatus] = useState<'verifying' | 'success' | 'error'>('verifying');
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    // Supabase automatically handles the hash token on load and signs the user in
+    // We just wait for the session
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
+      if (event === 'SIGNED_IN' && session) {
+        setStatus('success');
+        setTimeout(() => navigate('/'), 2000);
+      }
+    });
+
+    // Timeout if nothing happens
+    const timer = setTimeout(() => {
+      if (status === 'verifying') {
+        setStatus('error');
+      }
+    }, 5000);
+
+    return () => {
+      subscription.unsubscribe();
+      clearTimeout(timer);
+    };
+  }, [navigate, status]);
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-slate-50 py-12 sm:px-6 lg:px-8">
+      <div className="sm:mx-auto sm:w-full sm:max-w-md bg-white px-4 py-8 shadow sm:rounded-lg sm:px-10 border border-slate-200 text-center">
+        {status === 'verifying' && <p>Verifying your email...</p>}
+        {status === 'success' && <p className="text-green-600">Email verified! Redirecting to dashboard...</p>}
+        {status === 'error' && <p className="text-red-600">Verification failed or expired. Try logging in or request a new link.</p>}
+      </div>
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,12 @@
 {
   "name": "blog-generator",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blog-generator",
+      "version": "0.1.0",
       "workspaces": [
         "backend",
         "frontend"
@@ -46,6 +48,7 @@
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-progress": "^1.1.8",
         "@radix-ui/react-toast": "^1.2.15",
+        "@supabase/supabase-js": "^2.46.1",
         "@tailwindcss/vite": "^4.2.4",
         "@tanstack/react-query": "^5.60.5",
         "class-variance-authority": "^0.7.1",
@@ -56,6 +59,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.53.2",
+        "react-router-dom": "^7.14.2",
         "tailwindcss": "^4.2.4",
         "zod": "^3.23.8"
       },
@@ -4384,6 +4388,54 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.2.tgz",
+      "integrity": "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.2.tgz",
+      "integrity": "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==",
+      "dependencies": {
+        "react-router": "7.14.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4544,6 +4596,11 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",

--- a/scripts/seed-first-admin.ts
+++ b/scripts/seed-first-admin.ts
@@ -29,14 +29,18 @@ async function seed() {
   let adminUser = usersData.users.find(u => u.email === FIRST_ADMIN_EMAIL);
 
   if (!adminUser) {
+    const initialPassword = process.env.FIRST_ADMIN_PASSWORD;
+    if (!initialPassword) {
+      console.error(
+        '❌  FIRST_ADMIN_PASSWORD must be set in the environment to create the first admin (never commit passwords).'
+      );
+      process.exit(1);
+    }
     console.log('👤 Creating auth user via Admin API...');
-    // Create the user
-    // Note: They will need to reset password or we can generate one. 
-    // Usually admin uses a strong password or resets it via email.
     const { data: createdData, error: createError } = await supabase.auth.admin.createUser({
       email: FIRST_ADMIN_EMAIL,
       email_confirm: true,
-      password: 'TemporaryPassword123!', // Admin can reset this later or login with it once
+      password: initialPassword,
     });
 
     if (createError || !createdData.user) {

--- a/scripts/seed-first-admin.ts
+++ b/scripts/seed-first-admin.ts
@@ -1,0 +1,99 @@
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+
+dotenv.config({ path: 'backend/.env' });
+
+const url = process.env.SUPABASE_URL;
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!url || !key) {
+  console.error('❌  SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set in backend/.env');
+  process.exit(1);
+}
+
+const supabase = createClient(url, key, { auth: { persistSession: false } });
+
+const FIRST_ADMIN_EMAIL = process.env.FIRST_ADMIN_EMAIL || 'mnaser.tech@gmail.com';
+const DUMMY_USER_ID = '00000000-0000-0000-0000-000000000001';
+
+async function seed() {
+  console.log(`🌱 Seeding first admin: ${FIRST_ADMIN_EMAIL}`);
+
+  // 1. Check if user exists
+  const { data: usersData, error: listError } = await supabase.auth.admin.listUsers();
+  if (listError) {
+    console.error('❌  Failed to list users:', listError.message);
+    process.exit(1);
+  }
+
+  let adminUser = usersData.users.find(u => u.email === FIRST_ADMIN_EMAIL);
+
+  if (!adminUser) {
+    console.log('👤 Creating auth user via Admin API...');
+    // Create the user
+    // Note: They will need to reset password or we can generate one. 
+    // Usually admin uses a strong password or resets it via email.
+    const { data: createdData, error: createError } = await supabase.auth.admin.createUser({
+      email: FIRST_ADMIN_EMAIL,
+      email_confirm: true,
+      password: 'TemporaryPassword123!', // Admin can reset this later or login with it once
+    });
+
+    if (createError || !createdData.user) {
+      console.error('❌  Failed to create user:', createError?.message);
+      process.exit(1);
+    }
+    adminUser = createdData.user;
+    console.log(`✅ Auth user created with ID: ${adminUser.id}`);
+  } else {
+    console.log(`✅ Auth user already exists with ID: ${adminUser.id}`);
+  }
+
+  // 2. Ensure they are admin in public.users table (trigger might have created them as 'user')
+  console.log('👑 Promoting to admin...');
+  const { error: updateRoleError } = await supabase
+    .from('users')
+    .update({ role: 'admin', email_verified_at: adminUser.email_confirmed_at })
+    .eq('id', adminUser.id);
+
+  if (updateRoleError) {
+    console.error('❌  Failed to promote to admin:', updateRoleError.message);
+    process.exit(1);
+  }
+
+  // 3. Migrate blogs
+  console.log('🔄 Migrating blogs...');
+  const { data: blogsMigrated, error: blogsError } = await supabase
+    .from('blogs')
+    .update({ user_id: adminUser.id })
+    .eq('user_id', DUMMY_USER_ID)
+    .select('id');
+
+  if (blogsError) {
+    console.error('❌  Failed to migrate blogs:', blogsError.message);
+  } else {
+    console.log(`✅ Migrated ${blogsMigrated?.length || 0} blogs to new admin`);
+  }
+
+  // 4. Migrate author profiles
+  console.log('🔄 Migrating author profiles...');
+  const { data: profilesMigrated, error: profilesError } = await supabase
+    .from('author_profiles')
+    .update({ user_id: adminUser.id })
+    .eq('user_id', DUMMY_USER_ID)
+    .eq('is_predefined', false)
+    .select('id');
+
+  if (profilesError) {
+    console.error('❌  Failed to migrate profiles:', profilesError.message);
+  } else {
+    console.log(`✅ Migrated ${profilesMigrated?.length || 0} author profiles to new admin`);
+  }
+
+  console.log('🎉 Seed complete! First admin is ready.');
+}
+
+seed().catch(err => {
+  console.error('❌ Unexpected error:', err);
+  process.exit(1);
+});

--- a/scripts/seed-first-admin.ts
+++ b/scripts/seed-first-admin.ts
@@ -13,10 +13,14 @@ if (!url || !key) {
 
 const supabase = createClient(url, key, { auth: { persistSession: false } });
 
-const FIRST_ADMIN_EMAIL = process.env.FIRST_ADMIN_EMAIL || 'mnaser.tech@gmail.com';
+const FIRST_ADMIN_EMAIL = process.env.FIRST_ADMIN_EMAIL;
 const DUMMY_USER_ID = '00000000-0000-0000-0000-000000000001';
 
 async function seed() {
+  if (!FIRST_ADMIN_EMAIL) {
+    console.error('❌  FIRST_ADMIN_EMAIL must be set in the environment (do not hardcode real emails).');
+    process.exit(1);
+  }
   console.log(`🌱 Seeding first admin: ${FIRST_ADMIN_EMAIL}`);
 
   // 1. Check if user exists


### PR DESCRIPTION
## Summary
- Adds Supabase-backed bearer auth middleware + role/verification guards.
- Adds admin endpoints and a seed-first-admin helper.
- Updates frontend to use authenticated fetch + auth pages/context.

## Security hardening (follow-up)
- Pins `search_path` and revokes `PUBLIC` execute for SECURITY DEFINER trigger functions.
- Adds a CHECK constraint to constrain `users.role` to `admin|user`.
- Seed script now requires explicit `FIRST_ADMIN_EMAIL`.

## Test plan
- [x] `npm -w backend test`
- [x] `npm -w backend run typecheck`
- [x] `npm -w frontend run typecheck`
- [ ] Start stack: `docker compose --env-file backend/.env up --build`
- [ ] Register/login and verify admin routes are protected

## Glossary
- **Bearer token**: JWT sent as `Authorization: Bearer <token>`.
- **SECURITY DEFINER**: Postgres function that runs with owner privileges.
- **RLS**: Row Level Security in Postgres/Supabase.