### PR TITLE
fix(#100): allow workflow to write backend/.env on EC2

### DIFF
--- a/.github/workflows/deploy-ec2.yml
+++ b/.github/workflows/deploy-ec2.yml
@@ -81,7 +81,26 @@ jobs:
             
             echo "[deploy] Writing backend/.env from GitHub Actions Environment (development)"
             umask 077
-            mkdir -p backend
+            mkdir -p backend 2>/dev/null || true
+            if [ ! -w backend ]; then
+              echo "[deploy] WARN: backend/ is not writable; attempting sudo permission fix"
+              if command -v sudo >/dev/null 2>&1; then
+                sudo mkdir -p backend
+                sudo chown -R "$(id -un)":"$(id -gn)" backend || true
+                sudo chmod -R u+rwX backend || true
+              fi
+            fi
+            if [ -e backend/.env ] && [ ! -w backend/.env ]; then
+              echo "[deploy] WARN: backend/.env exists but is not writable; attempting sudo remove"
+              if command -v sudo >/dev/null 2>&1; then
+                sudo rm -f backend/.env || true
+              fi
+            fi
+            if [ ! -w backend ]; then
+              echo "[deploy] ERROR: backend/ is not writable; cannot create backend/.env" >&2
+              ls -ld backend || true
+              exit 1
+            fi
             _frontend_url="${VITE_BASE_URL:-}"
             {
               printf 'SUPABASE_URL=%s\n' "${SUPABASE_URL:-}"

--- a/.github/workflows/deploy-ec2.yml
+++ b/.github/workflows/deploy-ec2.yml
@@ -81,27 +81,46 @@ jobs:
             
             echo "[deploy] Writing backend/.env from GitHub Actions Environment (development)"
             umask 077
+            if [ -L backend ]; then
+              echo "[deploy] ERROR: backend/ is a symlink; refusing to write backend/.env" >&2
+              ls -ld backend || true
+              exit 1
+            fi
             mkdir -p backend 2>/dev/null || true
-            if [ ! -w backend ]; then
-              echo "[deploy] WARN: backend/ is not writable; attempting sudo permission fix"
+            if [ ! -d backend ]; then
+              echo "[deploy] ERROR: backend/ is not a directory; cannot write backend/.env" >&2
+              ls -ld backend || true
+              exit 1
+            fi
+
+            _env_target="backend/.env"
+            if [ -L "${_env_target}" ]; then
+              echo "[deploy] ERROR: backend/.env is a symlink; refusing to overwrite" >&2
+              ls -ld "${_env_target}" || true
+              exit 1
+            fi
+
+            # Ensure the deploy user can write the target path (no recursive chmod/chown).
+            if [ ! -w backend ] || { [ -e "${_env_target}" ] && [ ! -w "${_env_target}" ]; }; then
+              echo "[deploy] WARN: backend/ or backend/.env not writable; attempting sudo -n fix"
               if command -v sudo >/dev/null 2>&1; then
-                sudo mkdir -p backend
-                sudo chown -R "$(id -un)":"$(id -gn)" backend || true
-                sudo chmod -R u+rwX backend || true
+                sudo -n mkdir -p backend
+                sudo -n chown "$(id -u)":"$(id -g)" backend || true
+                sudo -n chmod u+rwx backend || true
+                if [ -e "${_env_target}" ]; then
+                  sudo -n chown "$(id -u)":"$(id -g)" "${_env_target}" || true
+                  sudo -n chmod 600 "${_env_target}" || true
+                fi
               fi
             fi
-            if [ -e backend/.env ] && [ ! -w backend/.env ]; then
-              echo "[deploy] WARN: backend/.env exists but is not writable; attempting sudo remove"
-              if command -v sudo >/dev/null 2>&1; then
-                sudo rm -f backend/.env || true
-              fi
-            fi
+
             if [ ! -w backend ]; then
               echo "[deploy] ERROR: backend/ is not writable; cannot create backend/.env" >&2
               ls -ld backend || true
               exit 1
             fi
             _frontend_url="${VITE_BASE_URL:-}"
+            _tmp_env="$(mktemp)"
             {
               printf 'SUPABASE_URL=%s\n' "${SUPABASE_URL:-}"
               printf 'SUPABASE_SERVICE_ROLE_KEY=%s\n' "${SUPABASE_SERVICE_ROLE_KEY:-}"
@@ -118,8 +137,16 @@ jobs:
               printf 'JWT_SECRET=%s\n' "${JWT_SECRET:-}"
               printf '\n'
               printf 'VITE_BASE_URL=%s\n' "${VITE_BASE_URL:-}"
-            } > backend/.env
-            chmod 600 backend/.env || true
+            } > "${_tmp_env}"
+            chmod 600 "${_tmp_env}" || true
+
+            if [ -e "${_env_target}" ] && [ ! -w "${_env_target}" ]; then
+              echo "[deploy] ERROR: backend/.env exists but is not writable; cannot replace" >&2
+              ls -l "${_env_target}" || true
+              exit 1
+            fi
+            mv -f "${_tmp_env}" "${_env_target}"
+            chmod 600 "${_env_target}" || true
 
             if [ -x scripts/deploy-ec2.sh ]; then
               echo "[deploy] Starting deployment script..."


### PR DESCRIPTION
## Summary
Fixes deploy failure: `bash: backend/.env: Permission denied`.

- Best-effort permission repair using `sudo` when `backend/` or `backend/.env` is not writable
- Clear diagnostics + hard fail if the filesystem remains read-only

Closes #100

## Test plan
- [ ] Merge and re-run `Deploy to EC2` on `main`
- [ ] Confirm workflow writes `backend/.env` and completes deploy

## Glossary
- **Permission repair**: A best-effort `chown`/`chmod` to make an existing directory writable for the deploy user.

Made with [Cursor](https://cursor.com)