### PR TITLE
fix(#102): improve unverified email login error

### DIFF
--- a/frontend/src/pages/auth/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage.tsx
@@ -17,23 +17,21 @@ export default function LoginPage() {
     setLoading(true);
 
     try {
-      const { data, error } = await supabase.auth.signInWithPassword({
+      const { error } = await supabase.auth.signInWithPassword({
         email,
         password,
       });
 
       if (error) {
-        const msg = (error as AuthError)?.message?.toLowerCase?.() || '';
-        if (msg.includes('email not confirmed') || msg.includes('not confirmed') || msg.includes('not verified')) {
+        const authErr = error as AuthError & { code?: string };
+        const code = authErr.code || '';
+        const msg = authErr.message?.toLowerCase?.() || '';
+        if (code === 'email_not_confirmed' || msg.includes('email not confirmed') || msg.includes('not confirmed')) {
           setError('Email not verified. Please verify your email and try again.');
         } else {
           setError('Invalid email or password');
         }
       } else {
-        if (data?.user && !data.user.email_confirmed_at) {
-          setError('Email not verified. Please verify your email and try again.');
-          return;
-        }
         navigate('/');
       }
     } catch (err) {

--- a/frontend/src/pages/auth/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { supabase } from '../../lib/supabase';
 import { Button } from '../../components/ui/button';
+import type { AuthError } from '@supabase/supabase-js';
 
 export default function LoginPage() {
   const [email, setEmail] = useState('');
@@ -16,14 +17,23 @@ export default function LoginPage() {
     setLoading(true);
 
     try {
-      const { error } = await supabase.auth.signInWithPassword({
+      const { data, error } = await supabase.auth.signInWithPassword({
         email,
         password,
       });
 
       if (error) {
-        setError('Invalid email or password');
+        const msg = (error as AuthError)?.message?.toLowerCase?.() || '';
+        if (msg.includes('email not confirmed') || msg.includes('not confirmed') || msg.includes('not verified')) {
+          setError('Email not verified. Please verify your email and try again.');
+        } else {
+          setError('Invalid email or password');
+        }
       } else {
+        if (data?.user && !data.user.email_confirmed_at) {
+          setError('Email not verified. Please verify your email and try again.');
+          return;
+        }
         navigate('/');
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
Improve UX for login with an unverified email:
- Show a clear message telling the user to verify their email
- Keep generic invalid-credentials message for other auth failures

Closes #102

## Test plan
- [ ] Create a user and do not verify email
- [ ] Attempt login with correct password
- [ ] Confirm UI shows: "Email not verified. Please verify your email and try again."
- [ ] Attempt login with wrong password
- [ ] Confirm UI still shows: "Invalid email or password"

## Glossary
- **Unverified email**: A user account whose `email_confirmed_at` is not set in Supabase.

Made with [Cursor](https://cursor.com)