### PR TITLE
feat(#105): Google (Gmail) login via Supabase OAuth

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import CheckEmailPage from './pages/auth/CheckEmailPage';
 import VerifyPage from './pages/auth/VerifyPage';
 import ForgotPasswordPage from './pages/auth/ForgotPasswordPage';
 import ResetPasswordPage from './pages/auth/ResetPasswordPage';
+import OAuthCallbackPage from './pages/auth/OAuthCallbackPage';
 
 // Admin Pages (Stubs for now)
 const AdminUsersPage = () => <div className="p-8">Admin Users</div>;
@@ -43,6 +44,7 @@ export function App() {
             <Route path="/verify" element={<VerifyPage />} />
             <Route path="/forgot-password" element={<ForgotPasswordPage />} />
             <Route path="/reset-password" element={<ResetPasswordPage />} />
+            <Route path="/auth/callback" element={<OAuthCallbackPage />} />
 
             {/* Protected App Routes */}
             <Route element={<ProtectedRoute />}>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { BlogBriefForm } from '../components/BlogBriefForm.js';
 import { AlignmentSummary } from '../components/AlignmentSummary.js';
 import { OutlineStep } from '../components/OutlineStep.js';
@@ -47,6 +48,7 @@ function setActiveProfile(id: string, setter: (id: string) => void) {
 
 export default function Dashboard() {
   const { logout, role } = useAuth();
+  const navigate = useNavigate();
   const [state, setState] = useState<AppState>({ step: 'idle' });
   const [error, setError] = useState<string | null>(null);
   const [activeProfileId, setActiveProfileId] = useState<string | null>(() => {
@@ -113,7 +115,15 @@ export default function Dashboard() {
             Create a fully-structured, SEO-ready blog post in minutes.
           </p>
           <div className="mt-4 flex justify-center">
-             <button onClick={logout} className="text-sm text-red-600 hover:underline">Log out</button>
+             <button
+               onClick={async () => {
+                 await logout();
+                 navigate('/login', { replace: true });
+               }}
+               className="text-sm text-red-600 hover:underline"
+             >
+               Log out
+             </button>
              {role === 'admin' && (
                <a href="/admin/users" className="ml-4 text-sm text-indigo-600 hover:underline">Admin Dashboard</a>
              )}

--- a/frontend/src/pages/auth/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage.tsx
@@ -11,6 +11,25 @@ export default function LoginPage() {
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
 
+  const handleGoogleLogin = async () => {
+    setError(null);
+    setLoading(true);
+    try {
+      const { error } = await supabase.auth.signInWithOAuth({
+        provider: 'google',
+        options: {
+          redirectTo: `${window.location.origin}/auth/callback`,
+        },
+      });
+      if (error) setError(error.message);
+      // On success, user is redirected away to Google. No further action here.
+    } catch {
+      setError('An unexpected error occurred');
+    } finally {
+      setLoading(false);
+    }
+  };
+
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
@@ -109,10 +128,16 @@ export default function LoginPage() {
               </div>
             </div>
 
-            <div className="mt-6 text-center text-sm">
+            <div className="mt-6 space-y-3">
+              <Button type="button" className="w-full" variant="ghost" disabled={loading} onClick={() => void handleGoogleLogin()}>
+                Continue with Google
+              </Button>
+
+              <div className="text-center text-sm">
               <Link to="/register" className="font-medium text-indigo-600 hover:text-indigo-500">
                 Create a new account
               </Link>
+              </div>
             </div>
           </div>
         </div>

--- a/frontend/src/pages/auth/OAuthCallbackPage.tsx
+++ b/frontend/src/pages/auth/OAuthCallbackPage.tsx
@@ -16,11 +16,39 @@ export default function OAuthCallbackPage() {
 
     const timer = setTimeout(() => finish('error'), 12000);
 
-    // Force token parsing from the URL (hash/query) and then rely on auth events.
-    void supabase.auth.getSession().then(({ data, error }) => {
-      if (error) return;
+    const url = new URL(window.location.href);
+    const code = url.searchParams.get('code');
+    const errorParam = url.searchParams.get('error');
+
+    // Clear sensitive/verbose callback params as early as possible.
+    // This keeps the code out of copy/paste, screenshots, and referrers.
+    window.history.replaceState({}, document.title, '/auth/callback');
+
+    // Supabase OAuth commonly returns an auth code (PKCE) that must be exchanged for a session.
+    const init = async () => {
+      if (errorParam) {
+        finish('error');
+        return;
+      }
+
+      if (code) {
+        const { data, error } = await supabase.auth.exchangeCodeForSession(code);
+        if (error) {
+          finish('error');
+          return;
+        }
+        if (data.session) {
+          finish('success');
+          return;
+        }
+      }
+
+      // Fallback: if a session already exists (hash-token flows), treat as success.
+      const { data } = await supabase.auth.getSession();
       if (data.session) finish('success');
-    });
+    };
+
+    void init().catch(() => finish('error'));
 
     const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
       if (event === 'SIGNED_IN' && session) {

--- a/frontend/src/pages/auth/OAuthCallbackPage.tsx
+++ b/frontend/src/pages/auth/OAuthCallbackPage.tsx
@@ -4,6 +4,7 @@ import { supabase } from '../../lib/supabase';
 
 export default function OAuthCallbackPage() {
   const [status, setStatus] = useState<'verifying' | 'success' | 'error'>('verifying');
+  const [errorMessage, setErrorMessage] = useState<string>('Google sign-in failed or expired.');
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -19,6 +20,8 @@ export default function OAuthCallbackPage() {
     const url = new URL(window.location.href);
     const code = url.searchParams.get('code');
     const errorParam = url.searchParams.get('error');
+    const errorDescription = url.searchParams.get('error_description');
+    const errorCode = url.searchParams.get('error_code');
 
     // Clear sensitive/verbose callback params as early as possible.
     // This keeps the code out of copy/paste, screenshots, and referrers.
@@ -27,6 +30,10 @@ export default function OAuthCallbackPage() {
     // Supabase OAuth commonly returns an auth code (PKCE) that must be exchanged for a session.
     const init = async () => {
       if (errorParam) {
+        const parts = [errorCode, errorDescription].filter(Boolean) as string[];
+        if (parts.length) {
+          setErrorMessage(parts.join(': ').slice(0, 180));
+        }
         finish('error');
         return;
       }
@@ -34,6 +41,7 @@ export default function OAuthCallbackPage() {
       if (code) {
         const { data, error } = await supabase.auth.exchangeCodeForSession(code);
         if (error) {
+          setErrorMessage(error.message || 'Google sign-in failed. Please try again.');
           finish('error');
           return;
         }
@@ -79,7 +87,7 @@ export default function OAuthCallbackPage() {
         {status === 'success' && <p className="text-green-600">Signed in! Redirecting…</p>}
         {status === 'error' && (
           <div className="space-y-3">
-            <p className="text-red-600">Google sign-in failed or expired.</p>
+            <p className="text-red-600">{errorMessage}</p>
             <Link className="underline text-indigo-600 hover:text-indigo-500" to="/login">
               Back to login
             </Link>

--- a/frontend/src/pages/auth/OAuthCallbackPage.tsx
+++ b/frontend/src/pages/auth/OAuthCallbackPage.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { supabase } from '../../lib/supabase';
+
+export default function OAuthCallbackPage() {
+  const [status, setStatus] = useState<'verifying' | 'success' | 'error'>('verifying');
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    let done = false;
+    const finish = (next: 'success' | 'error') => {
+      if (done) return;
+      done = true;
+      setStatus(next);
+    };
+
+    const timer = setTimeout(() => finish('error'), 12000);
+
+    // Force token parsing from the URL (hash/query) and then rely on auth events.
+    void supabase.auth.getSession().then(({ data, error }) => {
+      if (error) return;
+      if (data.session) finish('success');
+    });
+
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
+      if (event === 'SIGNED_IN' && session) {
+        finish('success');
+      }
+      if (event === 'SIGNED_OUT') {
+        // If the callback returns but we never get a session, treat as error after timeout.
+        setStatus('verifying');
+      }
+    });
+
+    return () => {
+      clearTimeout(timer);
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (status !== 'success') return;
+    const t = setTimeout(() => navigate('/', { replace: true }), 800);
+    return () => clearTimeout(t);
+  }, [navigate, status]);
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-slate-50 py-12 sm:px-6 lg:px-8">
+      <div className="sm:mx-auto sm:w-full sm:max-w-md bg-white px-4 py-8 shadow sm:rounded-lg sm:px-10 border border-slate-200 text-center">
+        {status === 'verifying' && <p>Finishing sign-in…</p>}
+        {status === 'success' && <p className="text-green-600">Signed in! Redirecting…</p>}
+        {status === 'error' && (
+          <div className="space-y-3">
+            <p className="text-red-600">Google sign-in failed or expired.</p>
+            <Link className="underline text-indigo-600 hover:text-indigo-500" to="/login">
+              Back to login
+            </Link>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- Add a "Continue with Google" button on `/login` using Supabase OAuth.
- Add `/auth/callback` route to finalize the OAuth session and redirect into the app.

## Test plan
- [x] `npm run typecheck --workspace=frontend`
- [ ] In Supabase Dashboard: enable Google provider + set redirect allowlist, then verify login end-to-end.

## Supabase config checklist
- Enable **Auth → Providers → Google**.
- Add redirect URLs:
  - `http://localhost:5173/auth/callback`
  - `https://blog-generator.mnaser.me/auth/callback`

## Glossary
- **OAuth**: A delegated login flow where Google authenticates the user and returns to the app.
- **Callback URL**: The in-app route that receives the post-login redirect.

Closes #105

Made with [Cursor](https://cursor.com)