### PR TITLE
fix(#105): stabilize Google OAuth callback

### DIFF
--- a/frontend/src/pages/auth/OAuthCallbackPage.tsx
+++ b/frontend/src/pages/auth/OAuthCallbackPage.tsx
@@ -23,9 +23,11 @@ export default function OAuthCallbackPage() {
     const errorDescription = url.searchParams.get('error_description');
     const errorCode = url.searchParams.get('error_code');
 
-    // Clear sensitive/verbose callback params as early as possible.
-    // This keeps the code out of copy/paste, screenshots, and referrers.
-    window.history.replaceState({}, document.title, '/auth/callback');
+    const clearCallbackUrl = () => {
+      // Clear sensitive/verbose callback params once Supabase has had a chance
+      // to read them (PKCE query `code` or implicit hash tokens).
+      window.history.replaceState({}, document.title, '/auth/callback');
+    };
 
     // Supabase OAuth commonly returns an auth code (PKCE) that must be exchanged for a session.
     const init = async () => {
@@ -35,6 +37,7 @@ export default function OAuthCallbackPage() {
           setErrorMessage(parts.join(': ').slice(0, 180));
         }
         finish('error');
+        clearCallbackUrl();
         return;
       }
 
@@ -43,17 +46,26 @@ export default function OAuthCallbackPage() {
         if (error) {
           setErrorMessage(error.message || 'Google sign-in failed. Please try again.');
           finish('error');
+          clearCallbackUrl();
           return;
         }
         if (data.session) {
           finish('success');
+          clearCallbackUrl();
           return;
         }
       }
 
       // Fallback: if a session already exists (hash-token flows), treat as success.
       const { data } = await supabase.auth.getSession();
-      if (data.session) finish('success');
+      if (data.session) {
+        finish('success');
+        clearCallbackUrl();
+        return;
+      }
+
+      // No session created; now it's safe to clear the URL.
+      clearCallbackUrl();
     };
 
     void init().catch(() => finish('error'));

--- a/scripts/deploy-ec2.sh
+++ b/scripts/deploy-ec2.sh
@@ -36,21 +36,21 @@ if [[ "${DOWN_BEFORE_DEPLOY:-}" == "1" || "${DOWN_BEFORE_DEPLOY:-}" == "true" ]]
 fi
 
 if [[ "${DEPLOY_BUILD_NO_CACHE:-1}" == "1" || "${DEPLOY_BUILD_NO_CACHE:-1}" == "true" ]]; then
-  echo "[deploy] docker compose build --no-cache"
-  dc --env-file backend/.env build --no-cache
+  echo "[deploy] docker compose build --no-cache --pull"
+  dc --env-file backend/.env build --no-cache --pull
 else
-  echo "[deploy] docker compose build (using cache; DEPLOY_BUILD_NO_CACHE=0)"
-  dc --env-file backend/.env build
+  echo "[deploy] docker compose build --pull (using cache; DEPLOY_BUILD_NO_CACHE=0)"
+  dc --env-file backend/.env build --pull
 fi
 
 # Prefer health-aware up when available (Compose 2.29+)
 if dc --env-file backend/.env up -d --help 2>&1 | grep -qE '[[:space:]]--wait[[:space:]]'; then
-  echo "[deploy] docker compose up -d --wait"
-  dc --env-file backend/.env up -d --wait
+  echo "[deploy] docker compose up -d --wait --force-recreate --remove-orphans"
+  dc --env-file backend/.env up -d --wait --force-recreate --remove-orphans
 else
   echo "[deploy] NOTE: this Compose has no 'up -d --wait' - consider upgrading to Docker Compose 2.29+"
-  echo "[deploy] docker compose up -d"
-  dc --env-file backend/.env up -d
+  echo "[deploy] docker compose up -d --force-recreate --remove-orphans"
+  dc --env-file backend/.env up -d --force-recreate --remove-orphans
 fi
 
 echo "[deploy] docker compose ps"


### PR DESCRIPTION
## Summary
- Fix Google OAuth callback flow by clearing URL params only after Supabase session exchange completes.
- Make EC2 deploy rebuild reliably by pulling base images and force-recreating containers.

## Test plan
- [x] `npm test` (backend) locally
- [ ] In prod, click **Continue with Google** and verify redirect returns to `/auth/callback` and lands in the app

## Glossary
- **PKCE**: OAuth flow where an authorization code is exchanged for a session using a verifier.
- **Supabase Auth callback**: Provider redirects to `...supabase.co/auth/v1/callback`, then Supabase forwards back to the app `redirectTo` URL.

Made with [Cursor](https://cursor.com)