### PR TITLE
fix(#109): prevent ENOSPC during deploy builds

### DIFF
--- a/.github/workflows/deploy-ec2.yml
+++ b/.github/workflows/deploy-ec2.yml
@@ -20,6 +20,9 @@ jobs:
         env:
           GITHUB_REPO: ${{ github.repository }}
           GIT_CLONE_TOKEN: ${{ secrets.GIT_CLONE_TOKEN }}
+          # Keep deploys resilient on small disks by pruning old Docker cache/images
+          # before building. Set DEPLOY_PRUNE_BEFORE_BUILD=0 to disable.
+          DEPLOY_PRUNE_BEFORE_BUILD: "1"
           SUPABASE_URL: ${{ vars.SUPABASE_URL }}
           SUPABASE_ANON_KEY: ${{ vars.SUPABASE_ANON_KEY }}
           VITE_SUPABASE_URL: ${{ vars.VITE_SUPABASE_URL }}
@@ -35,7 +38,7 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           command_timeout: 45m
-          envs: GITHUB_REPO,GIT_CLONE_TOKEN,SUPABASE_URL,SUPABASE_ANON_KEY,VITE_SUPABASE_URL,VITE_SUPABASE_ANON_KEY,SUPABASE_DB_URL,VITE_BASE_URL,ANTHROPIC_MODEL,SUPABASE_SERVICE_ROLE_KEY,ANTHROPIC_API_KEY,JWT_SECRET
+          envs: GITHUB_REPO,GIT_CLONE_TOKEN,DEPLOY_PRUNE_BEFORE_BUILD,SUPABASE_URL,SUPABASE_ANON_KEY,VITE_SUPABASE_URL,VITE_SUPABASE_ANON_KEY,SUPABASE_DB_URL,VITE_BASE_URL,ANTHROPIC_MODEL,SUPABASE_SERVICE_ROLE_KEY,ANTHROPIC_API_KEY,JWT_SECRET
           script: |
             set -euo pipefail
             DEPLOY_PATH="${{ secrets.DEPLOY_PATH }}"

--- a/scripts/deploy-ec2.sh
+++ b/scripts/deploy-ec2.sh
@@ -29,6 +29,45 @@ dc() {
   fi
 }
 
+docker_df() {
+  if command -v docker >/dev/null 2>&1; then
+    docker system df || true
+  fi
+}
+
+docker_prune_safe() {
+  # Deploys can fail with ENOSPC during image builds if old images/build cache accumulate.
+  # We intentionally do NOT prune volumes here to avoid deleting persistent data.
+  if ! command -v docker >/dev/null 2>&1; then
+    return 0
+  fi
+
+  echo "[deploy] Disk usage before prune (docker system df)"
+  docker_df
+
+  # Builder cache is the most common culprit during repeated builds.
+  echo "[deploy] Pruning builder cache (docker builder prune -af)"
+  docker builder prune -af || true
+
+  echo "[deploy] Pruning unused images (docker image prune -af)"
+  docker image prune -af || true
+
+  echo "[deploy] Pruning stopped containers (docker container prune -f)"
+  docker container prune -f || true
+
+  echo "[deploy] Disk usage after prune (docker system df)"
+  docker_df
+}
+
+# Default to pruning to keep deploys resilient on small disks.
+if [[ "${DEPLOY_PRUNE_BEFORE_BUILD:-1}" == "1" || "${DEPLOY_PRUNE_BEFORE_BUILD:-1}" == "true" ]]; then
+  docker_prune_safe
+else
+  echo "[deploy] Skipping prune (DEPLOY_PRUNE_BEFORE_BUILD=0)"
+  echo "[deploy] Current docker disk usage (docker system df)"
+  docker_df
+fi
+
 # shellcheck disable=SC2070
 if [[ "${DOWN_BEFORE_DEPLOY:-}" == "1" || "${DOWN_BEFORE_DEPLOY:-}" == "true" ]]; then
   echo "[deploy] DOWN_BEFORE_DEPLOY: docker compose down (full stack stop)"


### PR DESCRIPTION
## Summary
- Prevent EC2 deploy failures caused by Docker disk exhaustion (ENOSPC during `npm ci` in image builds).
- Prune Docker builder cache + unused images + stopped containers before build.
- Log `docker system df` before/after pruning for easy debugging.

## Safety
- Does **not** prune Docker volumes.
- Can be disabled with `DEPLOY_PRUNE_BEFORE_BUILD=0`.

## Test plan
- [ ] Run deploy workflow; confirm build completes even when host has accumulated Docker cache.

## Glossary
- **ENOSPC**: “No space left on device”.

Made with [Cursor](https://cursor.com)