### PR TITLE
fix(#15): remove Manage author profiles link

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -177,12 +177,6 @@ export default function Dashboard() {
                   My blogs
                 </Button>
               </div>
-              <button
-                onClick={() => setState({ step: 'profile-settings' })}
-                className="text-xs text-slate-400 hover:text-slate-600 underline"
-              >
-                Manage author profiles
-              </button>
             </div>
           )}
 


### PR DESCRIPTION
## Summary
- Removes the 'Manage author profiles' link from the Dashboard idle state (main page).

## Test plan
- Load the app and sign in.
- Confirm the Dashboard idle screen no longer shows the 'Manage author profiles' link.

## Glossary
- Dashboard: The app’s main page shown at route `/`.
- Author profile: A saved writing persona used by the blog generator.

## References
- ApexYard tracking: https://github.com/mohamednaseramein/apexyard/issues/15
- blog-generator context: https://github.com/mohamednaseramein/blog-generator/issues/113

Made with [Cursor](https://cursor.com)