### PR TITLE
feat(#138): copy the full post as plain text from the Publish step

### DIFF
--- a/backend/src/handlers/__tests__/blog-events-handler.test.ts
+++ b/backend/src/handlers/__tests__/blog-events-handler.test.ts
@@ -40,6 +40,16 @@ describe('handleRecordEvent', () => {
     expect(next).not.toHaveBeenCalled();
   });
 
+  it('logs an exported event for the all_text section', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { req, res, next } = makeReqRes('blog-1', { type: 'exported', section: 'all_text' });
+    await handleRecordEvent(req, res, next);
+
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('section=all_text'));
+    expect(next).not.toHaveBeenCalled();
+    logSpy.mockRestore();
+  });
+
   it('returns 204 for an unknown section (silently ignored)', async () => {
     const { req, res, end, next } = makeReqRes('blog-1', { type: 'exported', section: 'unknown' });
     await handleRecordEvent(req, res, next);

--- a/backend/src/handlers/blog-events-handler.ts
+++ b/backend/src/handlers/blog-events-handler.ts
@@ -3,7 +3,7 @@ import { getBlogByIdAndUser } from '../repositories/blog-repository.js';
 import { AppError } from '../middleware/error-handler.js';
 import { getUserId } from '../middleware/auth.js';
 
-const VALID_SECTIONS = ['all', 'all_html', 'title', 'meta', 'slug', 'body', 'body_html'] as const;
+const VALID_SECTIONS = ['all', 'all_html', 'all_text', 'title', 'meta', 'slug', 'body', 'body_html'] as const;
 type ExportSection = (typeof VALID_SECTIONS)[number];
 
 export async function handleRecordEvent(

--- a/frontend/src/api/blog-api.ts
+++ b/frontend/src/api/blog-api.ts
@@ -244,6 +244,7 @@ export async function getDraft(blogId: string): Promise<{
 export type ExportSection =
   | 'all'
   | 'all_html'
+  | 'all_text'
   | 'title'
   | 'seo_title'
   | 'seo_snippet'

--- a/frontend/src/components/PublishStep.tsx
+++ b/frontend/src/components/PublishStep.tsx
@@ -4,7 +4,12 @@ import { Check, Copy, XCircle } from 'lucide-react';
 import { clsx } from 'clsx';
 import { getDraft, getBrief, recordExportEvent, completeBlog } from '../api/blog-api.js';
 import type { ExportSection } from '../api/blog-api.js';
-import { buildFullDocumentHtml, buildSeoMetaSnippet, markdownToSafeHtml } from '../lib/publishContent.js';
+import {
+  buildFullDocumentHtml,
+  buildSeoMetaSnippet,
+  markdownToPlainText,
+  markdownToSafeHtml,
+} from '../lib/publishContent.js';
 import { Button } from './ui/button.js';
 import { Toast } from './ui/toast.js';
 
@@ -202,6 +207,16 @@ export function PublishStep({ blogId, onBack, onFinish }: Props) {
     return lines.join('\n');
   }
 
+  function buildFullBlockText() {
+    const lines: string[] = [];
+    if (title) lines.push(title);
+    if (suggestedSlug) lines.push(`Slug: ${suggestedSlug}`);
+    if (metaDescription) lines.push(`Meta: ${metaDescription}`);
+    if (lines.length) lines.push('');
+    if (markdown) lines.push(markdownToPlainText(markdown));
+    return lines.join('\n').trim();
+  }
+
   function buildFullBlockHtml() {
     return buildFullDocumentHtml({
       title,
@@ -339,6 +354,12 @@ export function PublishStep({ blogId, onBack, onFinish }: Props) {
                     statusKey="all_html"
                     copyStatus={copyStatus}
                     onCopy={() => void copy('all_html', buildFullBlockHtml(), blogId, 'all_html')}
+                  />
+                  <CopyButton
+                    label="Copy all (Text)"
+                    statusKey="all_text"
+                    copyStatus={copyStatus}
+                    onCopy={() => void copy('all_text', buildFullBlockText(), blogId, 'all_text')}
                   />
                 </div>
               </div>

--- a/frontend/src/lib/publishContent.ts
+++ b/frontend/src/lib/publishContent.ts
@@ -19,6 +19,60 @@ export function markdownToSafeHtml(markdown: string): string {
   return DOMPurify.sanitize(String(raw), { USE_PROFILES: { html: true } });
 }
 
+const PLAIN_TEXT_BLOCK_TAGS = new Set([
+  'P', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'BLOCKQUOTE', 'UL', 'OL', 'DIV', 'TABLE', 'TR',
+]);
+
+/** Recursively flatten a DOM node to text, separating block elements with blank lines. */
+function flattenToText(node: Node): string {
+  let out = '';
+  node.childNodes.forEach((child) => {
+    if (child.nodeType === Node.TEXT_NODE) {
+      out += (child.textContent ?? '').replace(/\s+/g, ' ');
+      return;
+    }
+    if (child.nodeType !== Node.ELEMENT_NODE) return;
+    const el = child as Element;
+    switch (el.tagName) {
+      case 'BR':
+        out += '\n';
+        break;
+      case 'HR':
+        out += '\n\n---\n\n';
+        break;
+      case 'PRE':
+        // Code blocks keep their own whitespace — don't collapse it.
+        out += `\n\n${(el.textContent ?? '').replace(/\s+$/, '')}\n\n`;
+        break;
+      case 'LI':
+        out += `\n- ${flattenToText(el).trim()}`;
+        break;
+      default:
+        if (PLAIN_TEXT_BLOCK_TAGS.has(el.tagName)) {
+          out += `\n\n${flattenToText(el).trim()}\n\n`;
+        } else {
+          out += flattenToText(el);
+        }
+    }
+  });
+  return out;
+}
+
+/**
+ * Turn markdown into readable plain text — markdown/HTML syntax removed,
+ * block structure preserved as blank lines. Backs the "Copy all (Text)"
+ * export. Browser-only (`DOMParser`), matching this module's existing
+ * marked / DOMPurify browser assumption.
+ */
+export function markdownToPlainText(markdown: string): string {
+  const html = markdownToSafeHtml(markdown);
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  return flattenToText(doc.body)
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
 const DEFAULT_BASE_URL = 'https://blog-generator.mnaser.me';
 
 export interface FullDocumentHtmlOptions {


### PR DESCRIPTION
## Summary

Adds a third **Copy all (Text)** button to the Publish step's "Full post" export group, next to the existing Markdown and HTML buttons — for pasting clean, formatting-free prose into editors, email, or CMS fields that don't take Markdown/HTML.

- **`lib/publishContent.ts`** — new `markdownToPlainText()`: renders Markdown to safe HTML (reusing `markdownToSafeHtml`), then DOM-walks it to readable plain text. Block elements become blank-line-separated, list items get a `- ` prefix, `<pre>` code blocks keep their whitespace verbatim, link text is retained (syntax dropped).
- **`components/PublishStep.tsx`** — `buildFullBlockText()` (title + optional slug/meta + plain-text body, mirroring `buildFullBlockMarkdown()`), plus the third `CopyButton` recording the `all_text` export event. Reuses the existing `CopyButton` / `useCopyFeedback` — same Copied / Copy failed feedback.
- **`api/blog-api.ts`** — `'all_text'` added to the `ExportSection` union.
- **`backend/.../blog-events-handler.ts`** — `'all_text'` added to `VALID_SECTIONS`. Without this the analytics event would be silently dropped (the handler only logs sections on the allow-list). New test asserts the `all_text` section is logged.

## Testing

1. Frontend: `cd frontend && npm run typecheck && VITE_PUBLIC_URL=… npm run build` — both pass
2. Backend: `cd backend && npm run typecheck && npm run test` — passes (132 tests, incl. the new `all_text` case)
3. Manual: Publish step → Export → "Full post" → **Copy all (Text)** → paste into a plain editor. Confirm: no `#`/`**`/link syntax, headings and paragraphs on their own lines, list items readable, title + slug/meta header block present
4. Confirm the button shows Copied / Copy failed feedback like the other two

Refs #138.

---

## Glossary

| Term | Definition |
|------|------------|
| `ExportSection` | Union type tagging *which* part of a post was copied (`all`, `all_html`, now `all_text`, …). Sent to the backend events endpoint for export analytics. |
| `VALID_SECTIONS` | Backend allow-list of `ExportSection` values the events handler will log. A section not on the list is silently ignored — hence the backend half of this change. |
| `markdownToPlainText` | New helper: Markdown → sanitized HTML → DOM-walk → plain text. The HTML hop reuses the existing sanitiser so no new parsing path is introduced. |
| DOM walk | Recursively traversing the parsed HTML node tree (`DOMParser`), emitting text and inserting blank lines at block boundaries — more robust than regex-stripping Markdown syntax. |
| `useCopyFeedback` | Existing hook tracking per-button `idle / success / error` state and firing the clipboard write + export event. The new button reuses it unchanged. |