### PR TITLE
feat(GH-142): admin dashboard, usage metrics, profile editing

### DIFF
--- a/backend/src/handlers/admin-handler.ts
+++ b/backend/src/handlers/admin-handler.ts
@@ -1,6 +1,11 @@
 import type { Request, Response } from 'express';
+import type { User as AuthUserRow } from '@supabase/supabase-js';
 import { getSupabase } from '../db/supabase.js';
 import { getUserId } from '../middleware/auth.js';
+import { displayTitleFromBriefEmbed } from '../repositories/blog-repository.js';
+import { AppError } from '../middleware/error-handler.js';
+import { parseProfileUpdateBody } from './profile-handler.js';
+import { updateProfile, getProfilesOwnedByUser } from '../repositories/profile-repository.js';
 
 /** Express may type params as `string | string[]`; routes here use a single segment. */
 function routeParam(value: string | string[] | undefined): string | undefined {
@@ -8,31 +13,40 @@ function routeParam(value: string | string[] | undefined): string | undefined {
   return Array.isArray(value) ? value[0] : value;
 }
 
+async function listAllAuthUsers(supabase: ReturnType<typeof getSupabase>): Promise<AuthUserRow[]> {
+  const perPage = 200;
+  const all: AuthUserRow[] = [];
+  for (let page = 1; page < 100; page += 1) {
+    const { data, error } = await supabase.auth.admin.listUsers({ page, perPage });
+    if (error) throw error;
+    const batch = data.users ?? [];
+    all.push(...batch);
+    if (batch.length < perPage) break;
+  }
+  return all;
+}
+
 export async function listUsers(req: Request, res: Response) {
   try {
     const supabase = getSupabase();
-    
-    // We get auth users via Admin API for email, and join with public.users
-    const { data: authUsers, error: authError } = await supabase.auth.admin.listUsers();
-    if (authError) throw authError;
 
-    const { data: publicUsers, error: dbError } = await supabase
-      .from('users')
-      .select('*');
+    const authUsers = await listAllAuthUsers(supabase);
+
+    const { data: publicUsers, error: dbError } = await supabase.from('users').select('*');
     if (dbError) throw dbError;
 
-    const userMap = new Map(publicUsers.map((u: any) => [u.id, u]));
+    const userMap = new Map((publicUsers as { id: string }[]).map((u) => [u.id, u]));
 
-    const users = authUsers.users.map(u => {
-      const p = userMap.get(u.id) || {};
+    const users = authUsers.map((u) => {
+      const p = (userMap.get(u.id) ?? {}) as Record<string, unknown>;
       return {
         id: u.id,
         email: u.email,
-        role: p.role || 'user',
-        email_verified_at: p.email_verified_at || u.email_confirmed_at,
-        deactivated_at: p.deactivated_at || null,
-        created_at: p.created_at || u.created_at,
-        last_sign_in_at: u.last_sign_in_at
+        role: (typeof p['role'] === 'string' ? p['role'] : null) || 'user',
+        email_verified_at: (p['email_verified_at'] as string | null) ?? u.email_confirmed_at ?? null,
+        deactivated_at: (p['deactivated_at'] as string | null) ?? null,
+        created_at: (p['created_at'] as string | null) ?? u.created_at,
+        last_sign_in_at: u.last_sign_in_at ?? null,
       };
     });
 
@@ -62,6 +76,22 @@ export async function deactivateUser(req: Request, res: Response) {
     }
 
     const { error } = await supabase.from('users').update({ deactivated_at: new Date().toISOString() }).eq('id', id);
+    if (error) throw error;
+    res.json({ success: true });
+  } catch (err) {
+    res.status(500).json({ error: (err as Error).message });
+  }
+}
+
+export async function reactivateUser(req: Request, res: Response) {
+  const id = routeParam(req.params.id);
+  if (!id) {
+    res.status(400).json({ error: 'Missing user id' });
+    return;
+  }
+  try {
+    const supabase = getSupabase();
+    const { error } = await supabase.from('users').update({ deactivated_at: null }).eq('id', id);
     if (error) throw error;
     res.json({ success: true });
   } catch (err) {
@@ -161,22 +191,128 @@ export async function listAllBlogs(req: Request, res: Response) {
     const supabase = getSupabase();
     const { data: blogs, error } = await supabase
       .from('blogs')
-      .select('*, users(id)'); // In a real scenario we'd join auth.users or mapped email.
-    
+      .select('id, user_id, current_step, status, created_at, updated_at, blog_briefs(title, primary_keyword)')
+      .order('updated_at', { ascending: false });
+
     if (error) throw error;
 
-    // Fetch emails for these users
-    const userIds = [...new Set(blogs.map((b: any) => b.user_id))];
-    const { data: authUsers } = await supabase.auth.admin.listUsers();
-    const emailMap = new Map((authUsers?.users || []).map(u => [u.id, u.email]));
+    const authUsers = await listAllAuthUsers(supabase);
+    const emailMap = new Map(authUsers.map((u) => [u.id, u.email]));
 
-    const enrichedBlogs = blogs.map((b: any) => ({
-      ...b,
-      owner_email: emailMap.get(b.user_id) || 'Unknown'
+    const enrichedBlogs = (blogs ?? []).map((b: Record<string, unknown>) => ({
+      id: b['id'],
+      user_id: b['user_id'],
+      current_step: b['current_step'],
+      status: b['status'],
+      created_at: b['created_at'],
+      updated_at: b['updated_at'],
+      title: displayTitleFromBriefEmbed(b['blog_briefs']),
+      owner_email: emailMap.get(b['user_id'] as string) || 'Unknown',
     }));
 
     res.json(enrichedBlogs);
   } catch (err) {
+    res.status(500).json({ error: (err as Error).message });
+  }
+}
+
+export async function getUserUsage(req: Request, res: Response) {
+  const userId = routeParam(req.params.id);
+  if (!userId) {
+    res.status(400).json({ error: 'Missing user id' });
+    return;
+  }
+  try {
+    const supabase = getSupabase();
+
+    const { count: blogCount } = await supabase
+      .from('blogs')
+      .select('*', { count: 'exact', head: true })
+      .eq('user_id', userId);
+
+    const { count: authorProfileCount } = await supabase
+      .from('author_profiles')
+      .select('*', { count: 'exact', head: true })
+      .eq('user_id', userId)
+      .eq('is_predefined', false);
+
+    const { data: blogRows, error: blogErr } = await supabase.from('blogs').select('id').eq('user_id', userId);
+    if (blogErr) throw blogErr;
+    const blogIds = (blogRows ?? []).map((r: { id: string }) => r.id);
+
+    let aiCheckCount = 0;
+    let referenceCount = 0;
+    if (blogIds.length > 0) {
+      const { count: ac } = await supabase
+        .from('blog_ai_checks')
+        .select('*', { count: 'exact', head: true })
+        .in('blog_id', blogIds);
+      aiCheckCount = ac ?? 0;
+
+      const { count: rc } = await supabase
+        .from('blog_references')
+        .select('*', { count: 'exact', head: true })
+        .in('blog_id', blogIds);
+      referenceCount = rc ?? 0;
+    }
+
+    const { data: lastBlog } = await supabase
+      .from('blogs')
+      .select('updated_at')
+      .eq('user_id', userId)
+      .order('updated_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    res.json({
+      user_id: userId,
+      blog_count: blogCount ?? 0,
+      author_profile_count: authorProfileCount ?? 0,
+      ai_check_count: aiCheckCount,
+      reference_count: referenceCount,
+      last_blog_activity_at: (lastBlog as { updated_at?: string } | null)?.updated_at ?? null,
+    });
+  } catch (err) {
+    res.status(500).json({ error: (err as Error).message });
+  }
+}
+
+export async function listUserProfiles(req: Request, res: Response) {
+  const userId = routeParam(req.params.id);
+  if (!userId) {
+    res.status(400).json({ error: 'Missing user id' });
+    return;
+  }
+  try {
+    const profiles = await getProfilesOwnedByUser(userId);
+    res.json({ profiles });
+  } catch (err) {
+    res.status(500).json({ error: (err as Error).message });
+  }
+}
+
+export async function adminUpdateUserProfile(req: Request, res: Response) {
+  const userId = routeParam(req.params.userId);
+  const profileId = routeParam(req.params.profileId);
+  if (!userId || !profileId) {
+    res.status(400).json({ error: 'Missing user id or profile id' });
+    return;
+  }
+
+  const parsed = parseProfileUpdateBody(req.body);
+  if (!parsed.ok) {
+    res.status(400).json({ error: parsed.errors.join('; ') });
+    return;
+  }
+
+  try {
+    const profile = await updateProfile(userId, profileId, parsed.updates);
+    res.json({ profile });
+  } catch (err) {
+    if (err instanceof AppError) {
+      res.status(err.status).json({ error: err.message });
+      return;
+    }
     res.status(500).json({ error: (err as Error).message });
   }
 }
@@ -196,6 +332,29 @@ export async function getAnyBlog(req: Request, res: Response) {
       return;
     }
     res.json(blog);
+  } catch (err) {
+    res.status(500).json({ error: (err as Error).message });
+  }
+}
+
+export async function deleteAnyBlog(req: Request, res: Response) {
+  const id = routeParam(req.params.id);
+  if (!id) {
+    res.status(400).json({ error: 'Missing blog id' });
+    return;
+  }
+  try {
+    const supabase = getSupabase();
+    const { data: existing, error: fetchErr } = await supabase.from('blogs').select('id').eq('id', id).maybeSingle();
+    if (fetchErr) throw fetchErr;
+    if (!existing) {
+      res.status(404).json({ error: 'Blog not found' });
+      return;
+    }
+
+    const { error } = await supabase.from('blogs').delete().eq('id', id);
+    if (error) throw error;
+    res.json({ success: true });
   } catch (err) {
     res.status(500).json({ error: (err as Error).message });
   }

--- a/backend/src/handlers/profile-handler.ts
+++ b/backend/src/handlers/profile-handler.ts
@@ -28,6 +28,90 @@ const FIELD_LIMITS = {
   voiceNote: { min: 0, max: 500 },
 };
 
+export type ProfilePartialUpdate = {
+  name?: string;
+  authorRole?: string;
+  audiencePersona?: string;
+  intent?: string;
+  toneOfVoice?: string;
+  voiceNote?: string;
+};
+
+/** Shared validation for PUT /api/profiles/:id and admin profile updates. */
+export function parseProfileUpdateBody(
+  body: unknown,
+): { ok: true; updates: ProfilePartialUpdate } | { ok: false; errors: string[] } {
+  if (typeof body !== 'object' || body === null) {
+    return { ok: false, errors: ['Body must be an object'] };
+  }
+
+  const b = body as Record<string, unknown>;
+  const errors: string[] = [];
+
+  if ('name' in b) {
+    if (typeof b.name !== 'string' || b.name.length < FIELD_LIMITS.name.min || b.name.length > FIELD_LIMITS.name.max) {
+      errors.push(`name must be a string between ${FIELD_LIMITS.name.min} and ${FIELD_LIMITS.name.max} chars`);
+    }
+  }
+
+  if ('authorRole' in b) {
+    if (
+      typeof b.authorRole !== 'string' ||
+      b.authorRole.length < 1 ||
+      b.authorRole.length > FIELD_LIMITS.authorRole.max
+    ) {
+      errors.push(`authorRole must be a string between 1 and ${FIELD_LIMITS.authorRole.max} chars`);
+    }
+  }
+
+  if ('audiencePersona' in b) {
+    if (
+      typeof b.audiencePersona !== 'string' ||
+      b.audiencePersona.length < 1 ||
+      b.audiencePersona.length > FIELD_LIMITS.audiencePersona.max
+    ) {
+      errors.push(`audiencePersona must be a string between 1 and ${FIELD_LIMITS.audiencePersona.max} chars`);
+    }
+  }
+
+  if ('toneOfVoice' in b) {
+    if (
+      typeof b.toneOfVoice !== 'string' ||
+      b.toneOfVoice.length < 1 ||
+      b.toneOfVoice.length > FIELD_LIMITS.toneOfVoice.max
+    ) {
+      errors.push(`toneOfVoice must be a string between 1 and ${FIELD_LIMITS.toneOfVoice.max} chars`);
+    }
+  }
+
+  if ('intent' in b) {
+    if (typeof b.intent !== 'string' || !VALID_INTENTS.has(b.intent as BlogIntent)) {
+      errors.push(`intent must be one of: ${Array.from(VALID_INTENTS).join(', ')}`);
+    }
+  }
+
+  if ('voiceNote' in b) {
+    if (typeof b.voiceNote !== 'string' || b.voiceNote.length > FIELD_LIMITS.voiceNote.max) {
+      errors.push(`voiceNote must be a string up to ${FIELD_LIMITS.voiceNote.max} chars`);
+    }
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  const updates: ProfilePartialUpdate = {
+    ...(b.name !== undefined && { name: b.name as string }),
+    ...(b.authorRole !== undefined && { authorRole: b.authorRole as string }),
+    ...(b.audiencePersona !== undefined && { audiencePersona: b.audiencePersona as string }),
+    ...(b.intent !== undefined && { intent: b.intent as string }),
+    ...(b.toneOfVoice !== undefined && { toneOfVoice: b.toneOfVoice as string }),
+    ...(b.voiceNote !== undefined && { voiceNote: b.voiceNote as string }),
+  };
+
+  return { ok: true, updates };
+}
+
 function validateCreateProfileInput(body: unknown): string[] {
   if (typeof body !== 'object' || body === null) {
     return ['Body must be an object'];
@@ -173,61 +257,12 @@ export async function handleUpdateProfile(
   try {
     const userId = getUserId(req);
     const id = req.params['id'] as string;
-    const body = req.body as Record<string, unknown>;
-
-    // Validate fields that are present
-    const errors: string[] = [];
-
-    if ('name' in body) {
-      if (typeof body.name !== 'string' || body.name.length < FIELD_LIMITS.name.min || body.name.length > FIELD_LIMITS.name.max) {
-        errors.push(`name must be a string between ${FIELD_LIMITS.name.min} and ${FIELD_LIMITS.name.max} chars`);
-      }
+    const parsed = parseProfileUpdateBody(req.body);
+    if (!parsed.ok) {
+      throw new AppError(400, 'VALIDATION_ERROR', parsed.errors.join('; '));
     }
 
-    if ('authorRole' in body) {
-      if (typeof body.authorRole !== 'string' || body.authorRole.length < 1 || body.authorRole.length > FIELD_LIMITS.authorRole.max) {
-        errors.push(`authorRole must be a string between 1 and ${FIELD_LIMITS.authorRole.max} chars`);
-      }
-    }
-
-    if ('audiencePersona' in body) {
-      if (typeof body.audiencePersona !== 'string' || body.audiencePersona.length < 1 || body.audiencePersona.length > FIELD_LIMITS.audiencePersona.max) {
-        errors.push(`audiencePersona must be a string between 1 and ${FIELD_LIMITS.audiencePersona.max} chars`);
-      }
-    }
-
-    if ('toneOfVoice' in body) {
-      if (typeof body.toneOfVoice !== 'string' || body.toneOfVoice.length < 1 || body.toneOfVoice.length > FIELD_LIMITS.toneOfVoice.max) {
-        errors.push(`toneOfVoice must be a string between 1 and ${FIELD_LIMITS.toneOfVoice.max} chars`);
-      }
-    }
-
-    if ('intent' in body) {
-      if (typeof body.intent !== 'string' || !VALID_INTENTS.has(body.intent as BlogIntent)) {
-        errors.push(`intent must be one of: ${Array.from(VALID_INTENTS).join(', ')}`);
-      }
-    }
-
-    if ('voiceNote' in body) {
-      if (typeof body.voiceNote !== 'string' || body.voiceNote.length > FIELD_LIMITS.voiceNote.max) {
-        errors.push(`voiceNote must be a string up to ${FIELD_LIMITS.voiceNote.max} chars`);
-      }
-    }
-
-    if (errors.length > 0) {
-      throw new AppError(400, 'VALIDATION_ERROR', errors.join('; '));
-    }
-
-    const updates = {
-      ...(body.name !== undefined && { name: body.name as string }),
-      ...(body.authorRole !== undefined && { authorRole: body.authorRole as string }),
-      ...(body.audiencePersona !== undefined && { audiencePersona: body.audiencePersona as string }),
-      ...(body.intent !== undefined && { intent: body.intent as string }),
-      ...(body.toneOfVoice !== undefined && { toneOfVoice: body.toneOfVoice as string }),
-      ...(body.voiceNote !== undefined && { voiceNote: body.voiceNote as string }),
-    };
-
-    const profile = await updateProfile(userId, id, updates);
+    const profile = await updateProfile(userId, id, parsed.updates);
     res.json({ profile });
   } catch (err) {
     next(err);

--- a/backend/src/repositories/profile-repository.ts
+++ b/backend/src/repositories/profile-repository.ts
@@ -34,6 +34,19 @@ function toModel(row: AuthorProfileRow): AuthorProfile {
   };
 }
 
+export async function getProfilesOwnedByUser(userId: string): Promise<AuthorProfile[]> {
+  const { data, error } = await getSupabase()
+    .from('author_profiles')
+    .select()
+    .eq('user_id', userId)
+    .eq('is_predefined', false)
+    .order('created_at', { ascending: true })
+    .returns<AuthorProfileRow[]>();
+
+  if (error) throw new Error(error.message);
+  return (data ?? []).map(toModel);
+}
+
 export async function getAllProfiles(userId: string): Promise<AuthorProfile[]> {
   const { data, error } = await getSupabase()
     .from('author_profiles')

--- a/backend/src/routes/admin-routes.ts
+++ b/backend/src/routes/admin-routes.ts
@@ -8,12 +8,17 @@ const router = Router();
 router.use(requireAuth, requireAdmin);
 
 router.get('/users', adminHandler.listUsers);
+router.get('/users/:id/usage', adminHandler.getUserUsage);
+router.get('/users/:id/profiles', adminHandler.listUserProfiles);
+router.put('/users/:userId/profiles/:profileId', adminHandler.adminUpdateUserProfile);
 router.post('/users/:id/deactivate', adminHandler.deactivateUser);
+router.post('/users/:id/reactivate', adminHandler.reactivateUser);
 router.post('/users/:id/promote', adminHandler.promoteUser);
 router.post('/users/:id/demote', adminHandler.demoteUser);
 router.post('/users/:id/force-reset', adminHandler.forceResetUser);
 
 router.get('/blogs', adminHandler.listAllBlogs);
+router.delete('/blogs/:id', adminHandler.deleteAnyBlog);
 router.get('/blogs/:id', adminHandler.getAnyBlog);
 
 export const adminRoutes = router;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,11 +17,7 @@ import ResetPasswordPage from './pages/auth/ResetPasswordPage';
 import OAuthCallbackPage from './pages/auth/OAuthCallbackPage';
 import ProfilePage from './pages/ProfilePage';
 import AiDetectorRulesPage from './pages/AiDetectorRulesPage';
-
-// Admin Pages (Stubs for now)
-const AdminUsersPage = () => <div className="p-8">Admin Users</div>;
-const AdminBlogsPage = () => <div className="p-8">Admin Blogs</div>;
-const AdminProfilesPage = () => <div className="p-8">Admin Profiles</div>;
+import AdminDashboardPage from './pages/AdminDashboardPage';
 
 export function App() {
   return (
@@ -64,11 +60,12 @@ export function App() {
               <Route path="/profile" element={<ProfilePage />} />
             </Route>
 
-            {/* Admin Routes */}
+            {/* Admin — users, blogs, roles (service role on server) */}
             <Route element={<AdminRoute />}>
-              <Route path="/admin/users" element={<AdminUsersPage />} />
-              <Route path="/admin/blogs" element={<AdminBlogsPage />} />
-              <Route path="/admin/profiles" element={<AdminProfilesPage />} />
+              <Route path="/admin" element={<AdminDashboardPage />} />
+              <Route path="/admin/users" element={<Navigate to="/admin" replace />} />
+              <Route path="/admin/blogs" element={<Navigate to="/admin" replace />} />
+              <Route path="/admin/profiles" element={<Navigate to="/admin" replace />} />
             </Route>
 
             {/* Fallback */}

--- a/frontend/src/api/admin-api.ts
+++ b/frontend/src/api/admin-api.ts
@@ -1,0 +1,111 @@
+import { authedFetch } from '../lib/authed-fetch.js';
+import type { AuthorProfile, BlogIntent } from './profile-api.js';
+
+const BASE = '/api/admin';
+
+export interface AdminUserRow {
+  id: string;
+  email: string | undefined;
+  role: string;
+  email_verified_at: string | null;
+  deactivated_at: string | null;
+  created_at: string | null;
+  last_sign_in_at: string | null;
+}
+
+export interface AdminBlogRow {
+  id: string;
+  user_id: string;
+  current_step: number;
+  status: string;
+  created_at: string;
+  updated_at: string;
+  title: string | null;
+  owner_email: string;
+}
+
+export interface AdminUserUsage {
+  user_id: string;
+  blog_count: number;
+  author_profile_count: number;
+  ai_check_count: number;
+  reference_count: number;
+  last_blog_activity_at: string | null;
+}
+
+export type AdminProfileUpdatePayload = {
+  name?: string;
+  authorRole?: string;
+  audiencePersona?: string;
+  intent?: BlogIntent;
+  toneOfVoice?: string;
+  voiceNote?: string;
+};
+
+function extractApiError(body: unknown): string {
+  if (!body || typeof body !== 'object') return 'Request failed';
+  const o = body as Record<string, unknown>;
+  if (typeof o.message === 'string') return o.message;
+  if (typeof o.error === 'string') return o.error;
+  if (o.error && typeof o.error === 'object' && o.error !== null && 'message' in o.error) {
+    const m = (o.error as { message?: unknown }).message;
+    if (typeof m === 'string') return m;
+  }
+  return 'Request failed';
+}
+
+async function parseJson<T>(res: Response): Promise<T> {
+  const text = await res.text();
+  let body: unknown = null;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    throw new Error(res.ok ? 'Invalid JSON from server' : text || res.statusText);
+  }
+  if (!res.ok) {
+    throw new Error(extractApiError(body));
+  }
+  return body as T;
+}
+
+export async function listAdminUsers(): Promise<AdminUserRow[]> {
+  const res = await authedFetch(`${BASE}/users`);
+  return parseJson<AdminUserRow[]>(res);
+}
+
+export async function listAdminBlogs(): Promise<AdminBlogRow[]> {
+  const res = await authedFetch(`${BASE}/blogs`);
+  return parseJson<AdminBlogRow[]>(res);
+}
+
+export async function getAdminUserUsage(userId: string): Promise<AdminUserUsage> {
+  const res = await authedFetch(`${BASE}/users/${encodeURIComponent(userId)}/usage`);
+  return parseJson<AdminUserUsage>(res);
+}
+
+export async function listAdminUserProfiles(userId: string): Promise<{ profiles: AuthorProfile[] }> {
+  const res = await authedFetch(`${BASE}/users/${encodeURIComponent(userId)}/profiles`);
+  return parseJson<{ profiles: AuthorProfile[] }>(res);
+}
+
+export async function adminUpdateUserProfile(
+  userId: string,
+  profileId: string,
+  payload: AdminProfileUpdatePayload,
+): Promise<{ profile: AuthorProfile }> {
+  const res = await authedFetch(
+    `${BASE}/users/${encodeURIComponent(userId)}/profiles/${encodeURIComponent(profileId)}`,
+    { method: 'PUT', body: JSON.stringify(payload) },
+  );
+  return parseJson<{ profile: AuthorProfile }>(res);
+}
+
+export async function postAdminUserAction(path: string): Promise<{ success: boolean }> {
+  const res = await authedFetch(`${BASE}${path}`, { method: 'POST', body: '{}' });
+  return parseJson<{ success: boolean }>(res);
+}
+
+export async function deleteAdminBlog(blogId: string): Promise<{ success: boolean }> {
+  const res = await authedFetch(`${BASE}/blogs/${encodeURIComponent(blogId)}`, { method: 'DELETE' });
+  return parseJson<{ success: boolean }>(res);
+}

--- a/frontend/src/components/AdminUserPanel.tsx
+++ b/frontend/src/components/AdminUserPanel.tsx
@@ -1,0 +1,254 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { AuthorProfile, BlogIntent } from '../api/profile-api.js';
+import {
+  getAdminUserUsage,
+  listAdminUserProfiles,
+  adminUpdateUserProfile,
+  type AdminUserUsage,
+} from '../api/admin-api.js';
+import { Button } from './ui/button.js';
+import { Input } from './ui/input.js';
+import { Textarea } from './ui/textarea.js';
+import { Field } from './ui/field.js';
+
+const INTENT_OPTIONS: { value: BlogIntent; label: string }[] = [
+  { value: 'thought_leadership', label: 'Thought leadership' },
+  { value: 'seo', label: 'SEO' },
+  { value: 'product_announcement', label: 'Product announcement' },
+  { value: 'newsletter', label: 'Newsletter' },
+  { value: 'deep_dive', label: 'Deep dive' },
+];
+
+interface Props {
+  userId: string;
+  userLabel: string;
+  onClose: () => void;
+  onSaved?: () => void;
+}
+
+function profileToForm(p: AuthorProfile) {
+  return {
+    name: p.name,
+    authorRole: p.authorRole,
+    audiencePersona: p.audiencePersona,
+    intent: p.intent,
+    toneOfVoice: p.toneOfVoice,
+    voiceNote: p.voiceNote ?? '',
+  };
+}
+
+export function AdminUserPanel({ userId, userLabel, onClose, onSaved }: Props) {
+  const [usage, setUsage] = useState<AdminUserUsage | null>(null);
+  const [profiles, setProfiles] = useState<AuthorProfile[]>([]);
+  const [detailLoading, setDetailLoading] = useState(true);
+  const [detailError, setDetailError] = useState<string | null>(null);
+  const [selectedProfileId, setSelectedProfileId] = useState<string>('');
+  const [form, setForm] = useState({
+    name: '',
+    authorRole: '',
+    audiencePersona: '',
+    intent: 'thought_leadership' as BlogIntent,
+    toneOfVoice: '',
+    voiceNote: '',
+  });
+  const [saving, setSaving] = useState(false);
+
+  const loadDetail = useCallback(async () => {
+    setDetailLoading(true);
+    setDetailError(null);
+    try {
+      const [u, { profiles: plist }] = await Promise.all([
+        getAdminUserUsage(userId),
+        listAdminUserProfiles(userId),
+      ]);
+      setUsage(u);
+      setProfiles(plist);
+      const first = plist[0];
+      if (first) {
+        setSelectedProfileId(first.id);
+        setForm(profileToForm(first));
+      } else {
+        setSelectedProfileId('');
+        setForm({
+          name: '',
+          authorRole: '',
+          audiencePersona: '',
+          intent: 'thought_leadership',
+          toneOfVoice: '',
+          voiceNote: '',
+        });
+      }
+    } catch (e) {
+      setDetailError((e as Error).message);
+    } finally {
+      setDetailLoading(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    void loadDetail();
+  }, [loadDetail]);
+
+  useEffect(() => {
+    const p = profiles.find((x) => x.id === selectedProfileId);
+    if (p) setForm(profileToForm(p));
+  }, [selectedProfileId, profiles]);
+
+  async function handleSave() {
+    if (!selectedProfileId) return;
+    setSaving(true);
+    setDetailError(null);
+    try {
+      await adminUpdateUserProfile(userId, selectedProfileId, form);
+      await loadDetail();
+      onSaved?.();
+    } catch (e) {
+      setDetailError((e as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <section
+      className="mb-10 rounded-xl border border-indigo-200 bg-indigo-50/40 p-4 shadow-sm sm:p-6"
+      aria-labelledby="admin-user-panel-title"
+    >
+      <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 id="admin-user-panel-title" className="text-lg font-semibold text-slate-900">
+            User: {userLabel}
+          </h2>
+          <p className="text-xs text-slate-500">ID {userId}</p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="ghost" size="sm" type="button" onClick={() => void loadDetail()} disabled={detailLoading}>
+            Refresh
+          </Button>
+          <Button variant="ghost" size="sm" type="button" onClick={onClose}>
+            Close
+          </Button>
+        </div>
+      </div>
+
+      {detailError && (
+        <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800">{detailError}</div>
+      )}
+
+      {detailLoading ? (
+        <p className="text-sm text-slate-600">Loading usage and profiles…</p>
+      ) : (
+        <>
+          <h3 className="mb-2 text-sm font-semibold uppercase tracking-wide text-slate-600">Usage</h3>
+          {usage && (
+            <dl className="mb-6 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+              <div className="rounded-lg border border-slate-200 bg-white px-3 py-2">
+                <dt className="text-xs text-slate-500">Blog posts</dt>
+                <dd className="text-lg font-semibold text-slate-900">{usage.blog_count}</dd>
+              </div>
+              <div className="rounded-lg border border-slate-200 bg-white px-3 py-2">
+                <dt className="text-xs text-slate-500">Author profiles</dt>
+                <dd className="text-lg font-semibold text-slate-900">{usage.author_profile_count}</dd>
+              </div>
+              <div className="rounded-lg border border-slate-200 bg-white px-3 py-2">
+                <dt className="text-xs text-slate-500">AI check runs</dt>
+                <dd className="text-lg font-semibold text-slate-900">{usage.ai_check_count}</dd>
+              </div>
+              <div className="rounded-lg border border-slate-200 bg-white px-3 py-2">
+                <dt className="text-xs text-slate-500">Reference URLs</dt>
+                <dd className="text-lg font-semibold text-slate-900">{usage.reference_count}</dd>
+              </div>
+              <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 sm:col-span-2 lg:col-span-1">
+                <dt className="text-xs text-slate-500">Last blog activity</dt>
+                <dd className="text-sm font-medium text-slate-900">
+                  {usage.last_blog_activity_at
+                    ? new Date(usage.last_blog_activity_at).toLocaleString()
+                    : '—'}
+                </dd>
+              </div>
+            </dl>
+          )}
+
+          <h3 className="mb-2 text-sm font-semibold uppercase tracking-wide text-slate-600">Author profile (editable)</h3>
+          {profiles.length === 0 ? (
+            <p className="text-sm text-slate-600">
+              This user has no custom author profiles yet. They can create one from the in-app profile flow.
+            </p>
+          ) : (
+            <div className="max-w-2xl space-y-4 rounded-lg border border-slate-200 bg-white p-4">
+              <label className="block text-sm text-slate-700">
+                <span className="mb-1 block font-medium">Profile</span>
+                <select
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                  value={selectedProfileId}
+                  onChange={(e) => setSelectedProfileId(e.target.value)}
+                >
+                  {profiles.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <Field label="Profile name">
+                <Input
+                  value={form.name}
+                  onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+                  placeholder="Display name"
+                />
+              </Field>
+              <Field label="Author role">
+                <Input
+                  value={form.authorRole}
+                  onChange={(e) => setForm((f) => ({ ...f, authorRole: e.target.value }))}
+                  placeholder="Role / title"
+                />
+              </Field>
+              <Field label="Audience persona">
+                <Textarea
+                  value={form.audiencePersona}
+                  onChange={(e) => setForm((f) => ({ ...f, audiencePersona: e.target.value }))}
+                  rows={4}
+                  placeholder="Who they write for"
+                />
+              </Field>
+              <Field label="Intent">
+                <select
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                  value={form.intent}
+                  onChange={(e) => setForm((f) => ({ ...f, intent: e.target.value as BlogIntent }))}
+                >
+                  {INTENT_OPTIONS.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+              </Field>
+              <Field label="Tone of voice">
+                <Input
+                  value={form.toneOfVoice}
+                  onChange={(e) => setForm((f) => ({ ...f, toneOfVoice: e.target.value }))}
+                  placeholder="e.g. Direct, warm"
+                />
+              </Field>
+              <Field label="Style guidance (optional)">
+                <Textarea
+                  value={form.voiceNote}
+                  onChange={(e) => setForm((f) => ({ ...f, voiceNote: e.target.value }))}
+                  rows={2}
+                  placeholder="Optional notes"
+                />
+              </Field>
+
+              <Button type="button" disabled={saving || !selectedProfileId} onClick={() => void handleSave()}>
+                {saving ? 'Saving…' : 'Save profile'}
+              </Button>
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/UserSettingsMenu.tsx
+++ b/frontend/src/components/UserSettingsMenu.tsx
@@ -18,7 +18,7 @@ interface Props {
 }
 
 export function UserSettingsMenu({ authState: authStateProp }: Props = {}) {
-  const { user, logout } = useAuth();
+  const { user, role, logout } = useAuth();
   const navigate = useNavigate();
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -62,6 +62,9 @@ export function UserSettingsMenu({ authState: authStateProp }: Props = {}) {
     authState === 'logged_in'
       ? [
           { type: 'link', label: 'Dashboard', onClick: () => navigate('/dashboard') },
+          ...(role === 'admin'
+            ? [{ type: 'link' as const, label: 'Admin', onClick: () => navigate('/admin') }]
+            : []),
           { type: 'link', label: 'My profile', onClick: () => navigate('/profile') },
           {
             type: 'danger',

--- a/frontend/src/pages/AdminDashboardPage.tsx
+++ b/frontend/src/pages/AdminDashboardPage.tsx
@@ -1,0 +1,403 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { AppHeader } from '../components/AppHeader';
+import { AdminUserPanel } from '../components/AdminUserPanel';
+import { Button } from '../components/ui/button';
+import { Toast } from '../components/ui/toast';
+import {
+  listAdminUsers,
+  listAdminBlogs,
+  postAdminUserAction,
+  deleteAdminBlog,
+  type AdminUserRow,
+  type AdminBlogRow,
+} from '../api/admin-api';
+import { useAuth } from '../context/AuthContext';
+
+function fmtDate(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  try {
+    return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(iso));
+  } catch {
+    return String(iso);
+  }
+}
+
+export default function AdminDashboardPage() {
+  const { user } = useAuth();
+  const me = user?.id;
+  const [users, setUsers] = useState<AdminUserRow[]>([]);
+  const [blogs, setBlogs] = useState<AdminBlogRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [notice, setNotice] = useState<{ variant: 'error' | 'success' | 'info'; text: string } | null>(null);
+  const [userFilter, setUserFilter] = useState<string>('all');
+  const [busyUserId, setBusyUserId] = useState<string | null>(null);
+  const [busyBlogId, setBusyBlogId] = useState<string | null>(null);
+  const [managedUserId, setManagedUserId] = useState<string | null>(null);
+  const [managedUserLabel, setManagedUserLabel] = useState<string>('');
+
+  const load = useCallback(async (options?: { keepNotice?: boolean }) => {
+    setLoading(true);
+    if (!options?.keepNotice) {
+      setNotice(null);
+    }
+    try {
+      const [u, b] = await Promise.all([listAdminUsers(), listAdminBlogs()]);
+      setUsers(u);
+      setBlogs(b);
+    } catch (e) {
+      setNotice({ variant: 'error', text: (e as Error).message });
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const blogCounts = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const b of blogs) {
+      m.set(b.user_id, (m.get(b.user_id) ?? 0) + 1);
+    }
+    return m;
+  }, [blogs]);
+
+  const filteredBlogs = useMemo(() => {
+    if (userFilter === 'all') return blogs;
+    return blogs.filter((b) => b.user_id === userFilter);
+  }, [blogs, userFilter]);
+
+  async function runAction(userId: string, successLabel: string, path: string) {
+    setBusyUserId(userId);
+    try {
+      await postAdminUserAction(path);
+      await load({ keepNotice: true });
+      setNotice({ variant: 'success', text: `${successLabel}` });
+    } catch (e) {
+      setNotice({ variant: 'error', text: (e as Error).message });
+    } finally {
+      setBusyUserId(null);
+    }
+  }
+
+  async function confirmAndRun(userId: string, message: string, successLabel: string, path: string) {
+    if (!window.confirm(message)) return;
+    await runAction(userId, successLabel, path);
+  }
+
+  async function confirmDeleteBlog(blogId: string, titleLabel: string) {
+    if (
+      !window.confirm(
+        `Permanently delete this blog and all related data (brief, outline, draft, references, AI checks)?\n\n${titleLabel}`,
+      )
+    ) {
+      return;
+    }
+    setBusyBlogId(blogId);
+    try {
+      await deleteAdminBlog(blogId);
+      await load({ keepNotice: true });
+      setNotice({ variant: 'success', text: 'Blog deleted.' });
+    } catch (e) {
+      setNotice({ variant: 'error', text: (e as Error).message });
+    } finally {
+      setBusyBlogId(null);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-indigo-50">
+      <AppHeader />
+      <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+        <div className="mb-8 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight text-slate-900">Admin dashboard</h1>
+            <p className="mt-1 text-sm text-slate-600">
+              View every account and blog, adjust roles, and control access.{' '}
+              <Link to="/dashboard" className="font-medium text-indigo-600 hover:text-indigo-500">
+                Back to app
+              </Link>
+            </p>
+          </div>
+          <Button variant="ghost" size="sm" type="button" onClick={() => void load()} disabled={loading}>
+            Refresh data
+          </Button>
+        </div>
+
+        {notice && (
+          <div className="mb-6">
+            <Toast variant={notice.variant}>{notice.text}</Toast>
+          </div>
+        )}
+
+        {loading && users.length === 0 ? (
+          <p className="text-center text-slate-500">Loading admin data…</p>
+        ) : (
+          <>
+            <section className="mb-12 rounded-xl border border-slate-200 bg-white p-4 shadow-sm sm:p-6">
+              <h2 className="text-lg font-semibold text-slate-900">Users and roles</h2>
+              <p className="mb-4 text-sm text-slate-600">
+                Promote or demote administrators, deactivate or reactivate sign-in, or send a password reset email.
+              </p>
+              <div className="overflow-x-auto">
+                <table className="min-w-full divide-y divide-slate-200 text-left text-sm">
+                  <caption className="sr-only">Registered users and administration actions</caption>
+                  <thead className="bg-slate-50 text-xs font-semibold uppercase tracking-wide text-slate-600">
+                    <tr>
+                      <th className="px-3 py-2">Email</th>
+                      <th className="px-3 py-2">Role</th>
+                      <th className="px-3 py-2">Account</th>
+                      <th className="px-3 py-2">Blogs</th>
+                      <th className="px-3 py-2">Created</th>
+                      <th className="px-3 py-2">Last sign-in</th>
+                      <th className="px-3 py-2">Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-slate-100">
+                    {users.map((u) => {
+                      const isDeactivated = Boolean(u.deactivated_at);
+                      const blogCount = blogCounts.get(u.id) ?? 0;
+                      const busy = busyUserId === u.id;
+                      const label = u.email ?? u.id;
+                      return (
+                        <tr key={u.id} className="hover:bg-slate-50/80">
+                          <td className="whitespace-nowrap px-3 py-3 font-medium text-slate-900">{label}</td>
+                          <td className="px-3 py-3">
+                            <span
+                              className={
+                                u.role === 'admin'
+                                  ? 'rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-medium text-indigo-800'
+                                  : 'rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-700'
+                              }
+                            >
+                              {u.role}
+                            </span>
+                          </td>
+                          <td className="px-3 py-3">
+                            {isDeactivated ? (
+                              <span className="text-amber-800">Deactivated</span>
+                            ) : (
+                              <span className="text-emerald-800">Active</span>
+                            )}
+                          </td>
+                          <td className="px-3 py-3 text-slate-600">{blogCount}</td>
+                          <td className="px-3 py-3 text-slate-600">{fmtDate(u.created_at)}</td>
+                          <td className="px-3 py-3 text-slate-600">{fmtDate(u.last_sign_in_at)}</td>
+                          <td className="px-3 py-3">
+                            <div className="flex max-w-md flex-wrap gap-1">
+                              {u.role !== 'admin' && (
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  disabled={busy}
+                                  className="text-indigo-700"
+                                  type="button"
+                                  onClick={() =>
+                                    void confirmAndRun(
+                                      u.id,
+                                      `Grant admin access to ${label}?`,
+                                      'User promoted to admin.',
+                                      `/users/${u.id}/promote`,
+                                    )
+                                  }
+                                >
+                                  Make admin
+                                </Button>
+                              )}
+                              {u.role === 'admin' && u.id !== me && (
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  disabled={busy}
+                                  className="text-slate-700"
+                                  type="button"
+                                  onClick={() =>
+                                    void confirmAndRun(
+                                      u.id,
+                                      `Remove admin role from ${label}?`,
+                                      'Admin role removed.',
+                                      `/users/${u.id}/demote`,
+                                    )
+                                  }
+                                >
+                                  Remove admin
+                                </Button>
+                              )}
+                              {!isDeactivated && (
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  disabled={busy}
+                                  className="text-amber-900"
+                                  type="button"
+                                  onClick={() =>
+                                    void confirmAndRun(
+                                      u.id,
+                                      `Deactivate ${label}? They will not be able to sign in until reactivated.`,
+                                      'Account deactivated.',
+                                      `/users/${u.id}/deactivate`,
+                                    )
+                                  }
+                                >
+                                  Deactivate
+                                </Button>
+                              )}
+                              {isDeactivated && (
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  disabled={busy}
+                                  className="text-emerald-800"
+                                  type="button"
+                                  onClick={() => void runAction(u.id, 'Account reactivated.', `/users/${u.id}/reactivate`)}
+                                >
+                                  Reactivate
+                                </Button>
+                              )}
+                              {u.email ? (
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  disabled={busy}
+                                  type="button"
+                                  onClick={() =>
+                                    void confirmAndRun(
+                                      u.id,
+                                      `Send password reset email to ${u.email}?`,
+                                      'Password reset email sent.',
+                                      `/users/${u.id}/force-reset`,
+                                    )
+                                  }
+                                >
+                                  Reset password email
+                                </Button>
+                              ) : null}
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                type="button"
+                                className="text-indigo-600"
+                                onClick={() => setUserFilter(u.id)}
+                              >
+                                Filter blogs
+                              </Button>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                type="button"
+                                className="font-medium text-indigo-800"
+                                onClick={() => {
+                                  setManagedUserId(u.id);
+                                  setManagedUserLabel(label);
+                                  setUserFilter(u.id);
+                                }}
+                              >
+                                Usage & profiles
+                              </Button>
+                            </div>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+
+            {managedUserId && (
+              <AdminUserPanel
+                userId={managedUserId}
+                userLabel={managedUserLabel}
+                onClose={() => setManagedUserId(null)}
+                onSaved={() => {
+                  void load({ keepNotice: true });
+                  setNotice({ variant: 'success', text: 'Profile saved. Lists refreshed.' });
+                }}
+              />
+            )}
+
+            <section className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm sm:p-6">
+              <div className="mb-4 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <h2 className="text-lg font-semibold text-slate-900">All blogs</h2>
+                  <p className="text-sm text-slate-600">Drafts and progress across every user.</p>
+                </div>
+                <label className="flex flex-col gap-1 text-sm text-slate-700 sm:flex-row sm:items-center sm:gap-2">
+                  <span className="whitespace-nowrap">Filter by owner</span>
+                  <select
+                    className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                    value={userFilter}
+                    onChange={(e) => setUserFilter(e.target.value)}
+                  >
+                    <option value="all">All users</option>
+                    {users.map((u) => (
+                      <option key={u.id} value={u.id}>
+                        {u.email ?? u.id}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+              <div className="overflow-x-auto">
+                <table className="min-w-full divide-y divide-slate-200 text-left text-sm">
+                  <caption className="sr-only">Blog drafts across all accounts</caption>
+                  <thead className="bg-slate-50 text-xs font-semibold uppercase tracking-wide text-slate-600">
+                    <tr>
+                      <th className="px-3 py-2">Title</th>
+                      <th className="px-3 py-2">Owner</th>
+                      <th className="px-3 py-2">Status</th>
+                      <th className="px-3 py-2">Step</th>
+                      <th className="px-3 py-2">Updated</th>
+                      <th className="px-3 py-2">Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-slate-100">
+                    {filteredBlogs.length === 0 ? (
+                      <tr>
+                        <td colSpan={6} className="px-3 py-8 text-center text-slate-500">
+                          No blogs for this filter.
+                        </td>
+                      </tr>
+                    ) : (
+                      filteredBlogs.map((b) => {
+                        const titleLabel = b.title ?? '(no title yet)';
+                        const busy = busyBlogId === b.id;
+                        return (
+                          <tr key={b.id} className="hover:bg-slate-50/80">
+                            <td className="max-w-xs truncate px-3 py-3 font-medium text-slate-900" title={b.title ?? undefined}>
+                              {titleLabel}
+                            </td>
+                            <td className="whitespace-nowrap px-3 py-3 text-slate-600">{b.owner_email}</td>
+                            <td className="px-3 py-3">
+                              <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-700">{b.status}</span>
+                            </td>
+                            <td className="px-3 py-3 text-slate-600">{b.current_step}</td>
+                            <td className="px-3 py-3 text-slate-600">{fmtDate(b.updated_at)}</td>
+                            <td className="px-3 py-3">
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                type="button"
+                                disabled={busy}
+                                className="text-red-700 hover:bg-red-50"
+                                onClick={() => void confirmDeleteBlog(b.id, titleLabel)}
+                              >
+                                Delete
+                              </Button>
+                            </td>
+                          </tr>
+                        );
+                      })
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+          </>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -123,8 +123,8 @@ export default function Dashboard() {
           </p>
           {role === 'admin' && (
             <div className="mt-3">
-              <a href="/admin/users" className="text-sm text-indigo-600 hover:underline">
-                Admin Dashboard
+              <a href="/admin" className="text-sm text-indigo-600 hover:underline">
+                Admin dashboard
               </a>
             </div>
           )}


### PR DESCRIPTION
## Glossary

| Term | Meaning |
|------|---------|
| **Admin route** | Express routes under `/api/admin/*` gated by `requireAuth` + `requireAdmin`. |
| **Author profile** | Row in `author_profiles` tied to `user_id`; used by the blog wizard for voice/context. |
| **Usage metrics** | Counts derived from `blogs`, `author_profiles`, `blog_ai_checks`, and `blog_references` for the selected user. |
| **Service role** | Backend Supabase client uses the service role key so admin handlers can call `auth.admin` and bypass RLS; end users still only get their JWT on normal API routes. |

## What

Adds an **admin dashboard** at `/admin` for users with `role = admin` in `public.users`: list users and blogs, promote/demote/deactivate/reactivate, password-reset email, delete any blog, and a **Usage & profiles** panel with aggregate usage plus editing of that user’s **author profiles** (non-predefined rows only).

## Why

Operators need a single place to inspect accounts, moderate content, and adjust author profile data without database access.

## How to test

1. Run backend + frontend (`npm run dev` from repo root or compose).
2. Ensure your user has `admin` in `public.users.role`.
3. Open `/admin`, exercise user actions, open **Usage & profiles** for a user, edit a profile and **Save**.
4. Confirm `npm run build --workspace=backend && npm run build --workspace=frontend && npm test` passes locally.

Related: https://github.com/mohamednaseramein/blog-generator/issues/142
