### PR TITLE
feat(GH-146): admin user and blog detail pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,7 +20,9 @@ import AiDetectorRulesPage from './pages/AiDetectorRulesPage';
 import AdminLayout from './pages/admin/AdminLayout';
 import AdminOverviewPage from './pages/admin/AdminOverviewPage';
 import AdminUsersPage from './pages/admin/AdminUsersPage';
+import AdminUserDetailPage from './pages/admin/AdminUserDetailPage';
 import AdminBlogsPage from './pages/admin/AdminBlogsPage';
+import AdminBlogDetailPage from './pages/admin/AdminBlogDetailPage';
 
 export function App() {
   return (
@@ -68,7 +70,9 @@ export function App() {
               <Route path="/admin" element={<AdminLayout />}>
                 <Route index element={<AdminOverviewPage />} />
                 <Route path="users" element={<AdminUsersPage />} />
+                <Route path="users/:userId" element={<AdminUserDetailPage />} />
                 <Route path="blogs" element={<AdminBlogsPage />} />
+                <Route path="blogs/:blogId" element={<AdminBlogDetailPage />} />
               </Route>
               <Route path="/admin/profiles" element={<Navigate to="/admin/users" replace />} />
             </Route>

--- a/frontend/src/components/AdminUserActions.tsx
+++ b/frontend/src/components/AdminUserActions.tsx
@@ -1,0 +1,144 @@
+import type { NavigateFunction } from 'react-router-dom';
+import type { AdminUserRow } from '../api/admin-api';
+import { Button } from './ui/button';
+
+export type AdminUserActionsMode = 'overlay' | 'inline';
+
+export interface AdminUserActionsProps {
+  u: AdminUserRow;
+  me: string | undefined;
+  busyUserId: string | null;
+  confirmAndRun: (userId: string, message: string, successLabel: string, path: string) => Promise<void>;
+  runAction: (userId: string, successLabel: string, path: string) => Promise<void>;
+  navigate: NavigateFunction;
+  setUserFilter: (id: string) => void;
+  setManagedUser: (id: string | null, label?: string) => void;
+  /** List page opens the slide-down panel; detail page scrolls to usage & profiles. */
+  mode?: AdminUserActionsMode;
+}
+
+const PROFILES_SECTION_ID = 'admin-user-profiles';
+
+export function AdminUserActions({
+  u,
+  me,
+  busyUserId,
+  confirmAndRun,
+  runAction,
+  navigate,
+  setUserFilter,
+  setManagedUser,
+  mode = 'overlay',
+}: AdminUserActionsProps) {
+  const isDeactivated = Boolean(u.deactivated_at);
+  const busy = busyUserId === u.id;
+  const label = u.email ?? u.id;
+
+  function openUsageProfiles() {
+    if (mode === 'inline') {
+      document.getElementById(PROFILES_SECTION_ID)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      return;
+    }
+    setManagedUser(u.id, label);
+    setUserFilter(u.id);
+  }
+
+  return (
+    <div className="flex max-w-2xl flex-wrap gap-1">
+      {u.role !== 'admin' && (
+        <Button
+          variant="ghost"
+          size="sm"
+          disabled={busy}
+          className="text-indigo-700"
+          type="button"
+          onClick={() =>
+            void confirmAndRun(u.id, `Grant admin access to ${label}?`, 'User promoted to admin.', `/users/${u.id}/promote`)
+          }
+        >
+          Make admin
+        </Button>
+      )}
+      {u.role === 'admin' && u.id !== me && (
+        <Button
+          variant="ghost"
+          size="sm"
+          disabled={busy}
+          className="text-slate-700"
+          type="button"
+          onClick={() =>
+            void confirmAndRun(u.id, `Remove admin role from ${label}?`, 'Admin role removed.', `/users/${u.id}/demote`)
+          }
+        >
+          Remove admin
+        </Button>
+      )}
+      {!isDeactivated && (
+        <Button
+          variant="ghost"
+          size="sm"
+          disabled={busy}
+          className="text-amber-900"
+          type="button"
+          onClick={() =>
+            void confirmAndRun(
+              u.id,
+              `Deactivate ${label}? They will not be able to sign in until reactivated.`,
+              'Account deactivated.',
+              `/users/${u.id}/deactivate`,
+            )
+          }
+        >
+          Deactivate
+        </Button>
+      )}
+      {isDeactivated && (
+        <Button
+          variant="ghost"
+          size="sm"
+          disabled={busy}
+          className="text-emerald-800"
+          type="button"
+          onClick={() => void runAction(u.id, 'Account reactivated.', `/users/${u.id}/reactivate`)}
+        >
+          Reactivate
+        </Button>
+      )}
+      {u.email ? (
+        <Button
+          variant="ghost"
+          size="sm"
+          disabled={busy}
+          type="button"
+          onClick={() =>
+            void confirmAndRun(
+              u.id,
+              `Send password reset email to ${u.email}?`,
+              'Password reset email sent.',
+              `/users/${u.id}/force-reset`,
+            )
+          }
+        >
+          Reset password email
+        </Button>
+      ) : null}
+      <Button
+        variant="ghost"
+        size="sm"
+        type="button"
+        className="text-indigo-600"
+        onClick={() => {
+          setUserFilter(u.id);
+          navigate('/admin/blogs');
+        }}
+      >
+        Filter blogs
+      </Button>
+      <Button variant="ghost" size="sm" type="button" className="font-medium text-indigo-800" onClick={openUsageProfiles}>
+        Usage & profiles
+      </Button>
+    </div>
+  );
+}
+
+export { PROFILES_SECTION_ID };

--- a/frontend/src/components/AdminUserPanel.tsx
+++ b/frontend/src/components/AdminUserPanel.tsx
@@ -24,6 +24,8 @@ interface Props {
   userLabel: string;
   onClose: () => void;
   onSaved?: () => void;
+  /** Anchor for in-page navigation (e.g. admin user detail). */
+  sectionId?: string;
 }
 
 function profileToForm(p: AuthorProfile) {
@@ -37,7 +39,7 @@ function profileToForm(p: AuthorProfile) {
   };
 }
 
-export function AdminUserPanel({ userId, userLabel, onClose, onSaved }: Props) {
+export function AdminUserPanel({ userId, userLabel, onClose, onSaved, sectionId = 'admin-user-profiles' }: Props) {
   const [usage, setUsage] = useState<AdminUserUsage | null>(null);
   const [profiles, setProfiles] = useState<AuthorProfile[]>([]);
   const [detailLoading, setDetailLoading] = useState(true);
@@ -111,7 +113,8 @@ export function AdminUserPanel({ userId, userLabel, onClose, onSaved }: Props) {
 
   return (
     <section
-      className="mb-10 rounded-xl border border-indigo-200 bg-indigo-50/40 p-4 shadow-sm sm:p-6"
+      id={sectionId}
+      className="mb-10 scroll-mt-24 rounded-xl border border-indigo-200 bg-indigo-50/40 p-4 shadow-sm sm:p-6"
       aria-labelledby="admin-user-panel-title"
     >
       <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">

--- a/frontend/src/pages/admin/AdminBlogDetailPage.tsx
+++ b/frontend/src/pages/admin/AdminBlogDetailPage.tsx
@@ -1,0 +1,137 @@
+import { Link, Navigate, useNavigate, useParams } from 'react-router-dom';
+import { useAdminDashboard } from './admin-context';
+import { Button } from '../../components/ui/button';
+
+function fmtDate(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  try {
+    return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(iso));
+  } catch {
+    return String(iso);
+  }
+}
+
+export default function AdminBlogDetailPage() {
+  const { blogId } = useParams<{ blogId: string }>();
+  const navigate = useNavigate();
+  const { blogs, loading, busyBlogId, confirmDeleteBlog, setUserFilter } = useAdminDashboard();
+
+  if (!blogId) {
+    return <Navigate to="/admin/blogs" replace />;
+  }
+
+  const b = blogs.find((row) => row.id === blogId);
+  const titleLabel = b?.title ?? '(no title yet)';
+
+  if (!b) {
+    if (loading) {
+      return <p className="text-center text-slate-500">Loading blog…</p>;
+    }
+    return (
+      <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h1 className="text-lg font-semibold text-slate-900">Blog not found</h1>
+        <p className="mt-2 text-sm text-slate-600">This draft may have been deleted or the link is invalid.</p>
+        <Link to="/admin/blogs" className="mt-4 inline-flex text-sm font-medium text-indigo-600 hover:text-indigo-500">
+          Back to all blogs
+        </Link>
+      </div>
+    );
+  }
+
+  const blog = b;
+  const busy = busyBlogId === blog.id;
+
+  return (
+    <div>
+      <div className="mb-6">
+        <Link
+          to="/admin/blogs"
+          className="-ml-2 mb-2 inline-flex h-8 items-center rounded-lg px-3 text-xs font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900"
+        >
+          ← All blogs
+        </Link>
+        <h1 className="text-2xl font-bold tracking-tight text-slate-900">Blog details</h1>
+        <p className="mt-1 text-sm text-slate-600">Draft metadata, owner, and administration actions.</p>
+      </div>
+
+      <section className="mb-8 rounded-xl border border-slate-200 bg-white p-4 shadow-sm sm:p-6">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-600">Draft</h2>
+        <dl className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <div className="sm:col-span-2">
+            <dt className="text-xs font-medium text-slate-500">Title</dt>
+            <dd className="mt-1 text-sm font-medium text-slate-900">{titleLabel}</dd>
+          </div>
+          <div>
+            <dt className="text-xs font-medium text-slate-500">Blog ID</dt>
+            <dd className="mt-1 break-all font-mono text-xs text-slate-800">{blog.id}</dd>
+          </div>
+          <div>
+            <dt className="text-xs font-medium text-slate-500">Status</dt>
+            <dd className="mt-1">
+              <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-700">{blog.status}</span>
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs font-medium text-slate-500">Wizard step</dt>
+            <dd className="mt-1 text-sm text-slate-900">{blog.current_step}</dd>
+          </div>
+          <div>
+            <dt className="text-xs font-medium text-slate-500">Owner email</dt>
+            <dd className="mt-1 text-sm text-slate-900">{blog.owner_email}</dd>
+          </div>
+          <div>
+            <dt className="text-xs font-medium text-slate-500">Owner user ID</dt>
+            <dd className="mt-1 break-all font-mono text-xs text-slate-800">{blog.user_id}</dd>
+          </div>
+          <div>
+            <dt className="text-xs font-medium text-slate-500">Created</dt>
+            <dd className="mt-1 text-sm text-slate-900">{fmtDate(blog.created_at)}</dd>
+          </div>
+          <div>
+            <dt className="text-xs font-medium text-slate-500">Updated</dt>
+            <dd className="mt-1 text-sm text-slate-900">{fmtDate(blog.updated_at)}</dd>
+          </div>
+        </dl>
+
+        <div className="mt-8 border-t border-slate-100 pt-6">
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-600">Actions</h2>
+          <div className="flex max-w-xl flex-wrap gap-1">
+            <Button
+              variant="ghost"
+              size="sm"
+              type="button"
+              disabled={busy}
+              className="text-red-700 hover:bg-red-50"
+              onClick={async () => {
+                const deleted = await confirmDeleteBlog(blog.id, titleLabel);
+                if (deleted) {
+                  navigate('/admin/blogs');
+                }
+              }}
+            >
+              Delete blog
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              type="button"
+              className="text-indigo-600"
+              onClick={() => {
+                setUserFilter(blog.user_id);
+                navigate('/admin/blogs');
+              }}
+            >
+              Filter blogs by this owner
+            </Button>
+            <Link
+              to={`/admin/users/${blog.user_id}`}
+              className="inline-flex h-8 items-center rounded-lg px-3 text-xs font-medium text-indigo-800 hover:bg-indigo-50"
+            >
+              Open owner account
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/AdminBlogsPage.tsx
+++ b/frontend/src/pages/admin/AdminBlogsPage.tsx
@@ -64,13 +64,14 @@ export default function AdminBlogsPage() {
                   <th className="px-3 py-2">Status</th>
                   <th className="px-3 py-2">Step</th>
                   <th className="px-3 py-2">Updated</th>
+                  <th className="px-3 py-2">View</th>
                   <th className="px-3 py-2">Actions</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-slate-100">
                 {filteredBlogs.length === 0 ? (
                   <tr>
-                    <td colSpan={6} className="px-3 py-8 text-center text-slate-500">
+                    <td colSpan={7} className="px-3 py-8 text-center text-slate-500">
                       No blogs for this filter.
                     </td>
                   </tr>
@@ -89,6 +90,14 @@ export default function AdminBlogsPage() {
                         </td>
                         <td className="px-3 py-3 text-slate-600">{b.current_step}</td>
                         <td className="px-3 py-3 text-slate-600">{fmtDate(b.updated_at)}</td>
+                        <td className="px-3 py-3">
+                          <Link
+                            to={`/admin/blogs/${b.id}`}
+                            className="text-sm font-medium text-indigo-600 hover:text-indigo-500"
+                          >
+                            Details
+                          </Link>
+                        </td>
                         <td className="px-3 py-3">
                           <Button
                             variant="ghost"

--- a/frontend/src/pages/admin/AdminUserDetailPage.tsx
+++ b/frontend/src/pages/admin/AdminUserDetailPage.tsx
@@ -1,0 +1,155 @@
+import { Link, Navigate, useNavigate, useParams } from 'react-router-dom';
+import { useAdminDashboard } from './admin-context';
+import { AdminUserPanel } from '../../components/AdminUserPanel';
+import { AdminUserActions } from '../../components/AdminUserActions';
+
+function fmtDate(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  try {
+    return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(iso));
+  } catch {
+    return String(iso);
+  }
+}
+
+export default function AdminUserDetailPage() {
+  const { userId } = useParams<{ userId: string }>();
+  const navigate = useNavigate();
+  const {
+    me,
+    users,
+    loading,
+    blogCounts,
+    busyUserId,
+    confirmAndRun,
+    runAction,
+    load,
+    setUserFilter,
+    setManagedUser,
+    setNotice,
+  } = useAdminDashboard();
+
+  if (!userId) {
+    return <Navigate to="/admin/users" replace />;
+  }
+
+  const u = users.find((row) => row.id === userId);
+  const label = u?.email ?? u?.id ?? 'User';
+  const blogCount = u ? (blogCounts.get(u.id) ?? 0) : 0;
+
+  if (!u) {
+    if (loading) {
+      return <p className="text-center text-slate-500">Loading user…</p>;
+    }
+    return (
+      <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h1 className="text-lg font-semibold text-slate-900">User not found</h1>
+        <p className="mt-2 text-sm text-slate-600">No account matches this link, or the user was removed.</p>
+        <Link
+          to="/admin/users"
+          className="mt-4 inline-flex text-sm font-medium text-indigo-600 hover:text-indigo-500"
+        >
+          Back to all users
+        </Link>
+      </div>
+    );
+  }
+
+  const isDeactivated = Boolean(u.deactivated_at);
+
+  return (
+    <div>
+      <div className="mb-6">
+        <Link
+          to="/admin/users"
+          className="-ml-2 mb-2 inline-flex h-8 items-center rounded-lg px-3 text-xs font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900"
+        >
+          ← All users
+        </Link>
+        <h1 className="text-2xl font-bold tracking-tight text-slate-900">User details</h1>
+        <p className="mt-1 text-sm text-slate-600">Account metadata, administration actions, and author profiles.</p>
+      </div>
+
+      <section className="mb-8 rounded-xl border border-slate-200 bg-white p-4 shadow-sm sm:p-6">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-600">Account</h2>
+        <dl className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <div>
+            <dt className="text-xs font-medium text-slate-500">Email</dt>
+            <dd className="mt-1 text-sm font-medium text-slate-900">{u.email ?? '—'}</dd>
+          </div>
+          <div>
+            <dt className="text-xs font-medium text-slate-500">User ID</dt>
+            <dd className="mt-1 break-all font-mono text-xs text-slate-800">{u.id}</dd>
+          </div>
+          <div>
+            <dt className="text-xs font-medium text-slate-500">Role</dt>
+            <dd className="mt-1">
+              <span
+                className={
+                  u.role === 'admin'
+                    ? 'rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-medium text-indigo-800'
+                    : 'rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-700'
+                }
+              >
+                {u.role}
+              </span>
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs font-medium text-slate-500">Sign-in status</dt>
+            <dd className="mt-1 text-sm text-slate-900">
+              {isDeactivated ? <span className="text-amber-800">Deactivated</span> : <span className="text-emerald-800">Active</span>}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs font-medium text-slate-500">Email verified</dt>
+            <dd className="mt-1 text-sm text-slate-900">{fmtDate(u.email_verified_at)}</dd>
+          </div>
+          <div>
+            <dt className="text-xs font-medium text-slate-500">Blogs</dt>
+            <dd className="mt-1 text-sm text-slate-900">{blogCount}</dd>
+          </div>
+          <div>
+            <dt className="text-xs font-medium text-slate-500">Created</dt>
+            <dd className="mt-1 text-sm text-slate-900">{fmtDate(u.created_at)}</dd>
+          </div>
+          <div>
+            <dt className="text-xs font-medium text-slate-500">Last sign-in</dt>
+            <dd className="mt-1 text-sm text-slate-900">{fmtDate(u.last_sign_in_at)}</dd>
+          </div>
+          {u.deactivated_at ? (
+            <div>
+              <dt className="text-xs font-medium text-slate-500">Deactivated at</dt>
+              <dd className="mt-1 text-sm text-slate-900">{fmtDate(u.deactivated_at)}</dd>
+            </div>
+          ) : null}
+        </dl>
+
+        <div className="mt-8 border-t border-slate-100 pt-6">
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-600">Actions</h2>
+          <AdminUserActions
+            u={u}
+            me={me}
+            busyUserId={busyUserId}
+            confirmAndRun={confirmAndRun}
+            runAction={runAction}
+            navigate={navigate}
+            setUserFilter={setUserFilter}
+            setManagedUser={setManagedUser}
+            mode="inline"
+          />
+        </div>
+      </section>
+
+      <AdminUserPanel
+        userId={u.id}
+        userLabel={label}
+        onClose={() => navigate('/admin/users')}
+        onSaved={() => {
+          void load({ keepNotice: true });
+          setNotice({ variant: 'success', text: 'Profile saved. Lists refreshed.' });
+        }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/AdminUsersPage.tsx
+++ b/frontend/src/pages/admin/AdminUsersPage.tsx
@@ -1,6 +1,7 @@
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useAdminDashboard } from './admin-context';
 import { AdminUserPanel } from '../../components/AdminUserPanel';
+import { AdminUserActions } from '../../components/AdminUserActions';
 import { Button } from '../../components/ui/button';
 
 function fmtDate(iso: string | null | undefined): string {
@@ -59,6 +60,7 @@ export default function AdminUsersPage() {
                   <th className="px-3 py-2">Blogs</th>
                   <th className="px-3 py-2">Created</th>
                   <th className="px-3 py-2">Last sign-in</th>
+                  <th className="px-3 py-2">View</th>
                   <th className="px-3 py-2">Actions</th>
                 </tr>
               </thead>
@@ -66,7 +68,6 @@ export default function AdminUsersPage() {
                 {users.map((u) => {
                   const isDeactivated = Boolean(u.deactivated_at);
                   const blogCount = blogCounts.get(u.id) ?? 0;
-                  const busy = busyUserId === u.id;
                   const label = u.email ?? u.id;
                   return (
                     <tr key={u.id} className="hover:bg-slate-50/80">
@@ -93,119 +94,25 @@ export default function AdminUsersPage() {
                       <td className="px-3 py-3 text-slate-600">{fmtDate(u.created_at)}</td>
                       <td className="px-3 py-3 text-slate-600">{fmtDate(u.last_sign_in_at)}</td>
                       <td className="px-3 py-3">
-                        <div className="flex max-w-md flex-wrap gap-1">
-                          {u.role !== 'admin' && (
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              disabled={busy}
-                              className="text-indigo-700"
-                              type="button"
-                              onClick={() =>
-                                void confirmAndRun(
-                                  u.id,
-                                  `Grant admin access to ${label}?`,
-                                  'User promoted to admin.',
-                                  `/users/${u.id}/promote`,
-                                )
-                              }
-                            >
-                              Make admin
-                            </Button>
-                          )}
-                          {u.role === 'admin' && u.id !== me && (
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              disabled={busy}
-                              className="text-slate-700"
-                              type="button"
-                              onClick={() =>
-                                void confirmAndRun(
-                                  u.id,
-                                  `Remove admin role from ${label}?`,
-                                  'Admin role removed.',
-                                  `/users/${u.id}/demote`,
-                                )
-                              }
-                            >
-                              Remove admin
-                            </Button>
-                          )}
-                          {!isDeactivated && (
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              disabled={busy}
-                              className="text-amber-900"
-                              type="button"
-                              onClick={() =>
-                                void confirmAndRun(
-                                  u.id,
-                                  `Deactivate ${label}? They will not be able to sign in until reactivated.`,
-                                  'Account deactivated.',
-                                  `/users/${u.id}/deactivate`,
-                                )
-                              }
-                            >
-                              Deactivate
-                            </Button>
-                          )}
-                          {isDeactivated && (
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              disabled={busy}
-                              className="text-emerald-800"
-                              type="button"
-                              onClick={() => void runAction(u.id, 'Account reactivated.', `/users/${u.id}/reactivate`)}
-                            >
-                              Reactivate
-                            </Button>
-                          )}
-                          {u.email ? (
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              disabled={busy}
-                              type="button"
-                              onClick={() =>
-                                void confirmAndRun(
-                                  u.id,
-                                  `Send password reset email to ${u.email}?`,
-                                  'Password reset email sent.',
-                                  `/users/${u.id}/force-reset`,
-                                )
-                              }
-                            >
-                              Reset password email
-                            </Button>
-                          ) : null}
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            type="button"
-                            className="text-indigo-600"
-                            onClick={() => {
-                              setUserFilter(u.id);
-                              navigate('/admin/blogs');
-                            }}
-                          >
-                            Filter blogs
-                          </Button>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            type="button"
-                            className="font-medium text-indigo-800"
-                            onClick={() => {
-                              setManagedUser(u.id, label);
-                              setUserFilter(u.id);
-                            }}
-                          >
-                            Usage & profiles
-                          </Button>
-                        </div>
+                        <Link
+                          to={`/admin/users/${u.id}`}
+                          className="text-sm font-medium text-indigo-600 hover:text-indigo-500"
+                        >
+                          Details
+                        </Link>
+                      </td>
+                      <td className="px-3 py-3">
+                        <AdminUserActions
+                          u={u}
+                          me={me}
+                          busyUserId={busyUserId}
+                          confirmAndRun={confirmAndRun}
+                          runAction={runAction}
+                          navigate={navigate}
+                          setUserFilter={setUserFilter}
+                          setManagedUser={setManagedUser}
+                          mode="overlay"
+                        />
                       </td>
                     </tr>
                   );

--- a/frontend/src/pages/admin/admin-context.tsx
+++ b/frontend/src/pages/admin/admin-context.tsx
@@ -34,7 +34,7 @@ export interface AdminDashboardContextValue {
   busyBlogId: string | null;
   runAction: (userId: string, successLabel: string, path: string) => Promise<void>;
   confirmAndRun: (userId: string, message: string, successLabel: string, path: string) => Promise<void>;
-  confirmDeleteBlog: (blogId: string, titleLabel: string) => Promise<void>;
+  confirmDeleteBlog: (blogId: string, titleLabel: string) => Promise<boolean>;
   managedUserId: string | null;
   managedUserLabel: string;
   setManagedUser: (id: string | null, label?: string) => void;
@@ -123,21 +123,23 @@ export function AdminDashboardProvider({ children }: { children: ReactNode }) {
   );
 
   const confirmDeleteBlog = useCallback(
-    async (blogId: string, titleLabel: string) => {
+    async (blogId: string, titleLabel: string): Promise<boolean> => {
       if (
         !window.confirm(
           `Permanently delete this blog and all related data (brief, outline, draft, references, AI checks)?\n\n${titleLabel}`,
         )
       ) {
-        return;
+        return false;
       }
       setBusyBlogId(blogId);
       try {
         await deleteAdminBlog(blogId);
         await load({ keepNotice: true });
         setNotice({ variant: 'success', text: 'Blog deleted.' });
+        return true;
       } catch (e) {
         setNotice({ variant: 'error', text: (e as Error).message });
+        return false;
       } finally {
         setBusyBlogId(null);
       }


### PR DESCRIPTION
## Summary
Adds dedicated admin routes for one user and one blog, with the same administration actions as the list views plus full metadata on the page.

## Changes
- `/admin/users/:userId` — account fields, `AdminUserActions` (inline mode scrolls to usage & profiles), always-visible `AdminUserPanel`.
- `/admin/blogs/:blogId` — draft metadata, delete, filter blogs by owner, link to owner account.
- `confirmDeleteBlog` returns `Promise<boolean>` so the blog detail view only redirects after a successful delete.
- List pages: **Details** links; user actions extracted to `AdminUserActions.tsx`.

## Testing
- `cd frontend && npm run typecheck`

## Glossary
| Term | Meaning |
|------|---------|
| Admin dashboard | Staff-only UI backed by `/api/admin/*` |
| `AdminUserActions` | Shared promote/demote/deactivate/reset/filter/usage controls |
| `confirmDeleteBlog` | Confirms then calls DELETE `/api/admin/blogs/:id`; returns whether deletion ran |

Closes #146

Made with [Cursor](https://cursor.com)