### PR TITLE
feat(#155): subscriptions schema, plan + subscription repositories

### DIFF
--- a/backend/src/db/migrations/migrate-016-subscriptions-schema.sql
+++ b/backend/src/db/migrations/migrate-016-subscriptions-schema.sql
@@ -1,0 +1,55 @@
+-- Migration 016: Subscription plans + per-user subscriptions
+-- Ticket:  https://github.com/mohamednaseramein/blog-generator/issues/155
+-- Epic:    https://github.com/mohamednaseramein/blog-generator/issues/149
+-- AgDR:    docs/agdr/AgDR-0035-migration-subscriptions-schema.md
+-- Rollback: DROP TABLE IF EXISTS subscriptions; DROP TABLE IF EXISTS plans;
+--           (also restore handle_new_user() — see migrate-017 rollback in AgDR-0035)
+
+-- Plan catalogue. Limit columns are nullable; NULL = unlimited for that metric.
+CREATE TABLE plans (
+  id                          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  slug                        VARCHAR(50)  NOT NULL UNIQUE,
+  name                        VARCHAR(120) NOT NULL,
+  description                 TEXT         NOT NULL DEFAULT '',
+  price_cents                 INTEGER      NOT NULL DEFAULT 0 CHECK (price_cents >= 0),
+  currency                    CHAR(3)      NOT NULL DEFAULT 'USD',
+  billing_period              VARCHAR(20)  NOT NULL DEFAULT 'monthly'
+                              CHECK (billing_period IN ('monthly')),
+  blog_quota                  INTEGER      CHECK (blog_quota IS NULL OR blog_quota >= 0),
+  ai_check_quota              INTEGER      CHECK (ai_check_quota IS NULL OR ai_check_quota >= 0),
+  author_profile_limit        INTEGER      CHECK (author_profile_limit IS NULL OR author_profile_limit >= 0),
+  reference_extraction_quota  INTEGER      CHECK (reference_extraction_quota IS NULL OR reference_extraction_quota >= 0),
+  is_public                   BOOLEAN      NOT NULL DEFAULT false,
+  is_default                  BOOLEAN      NOT NULL DEFAULT false,
+  archived_at                 TIMESTAMPTZ,
+  sort_order                  SMALLINT     NOT NULL DEFAULT 0,
+  created_at                  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  updated_at                  TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+-- At most one default plan among non-archived plans.
+CREATE UNIQUE INDEX uniq_plans_single_default
+  ON plans (is_default) WHERE is_default = true AND archived_at IS NULL;
+
+-- Listing index for the public landing page + admin catalogue.
+CREATE INDEX idx_plans_sort_order ON plans (sort_order);
+
+-- Per-user subscription. Exactly one active row per user (the invariant the feature rests on).
+CREATE TABLE subscriptions (
+  id                      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id                 UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  plan_id                 UUID NOT NULL REFERENCES plans(id),
+  status                  VARCHAR(20) NOT NULL DEFAULT 'active'
+                          CHECK (status IN ('active')),  -- 'past_due','canceled' reserved for Stripe
+  current_period_start    TIMESTAMPTZ NOT NULL,
+  current_period_end      TIMESTAMPTZ NOT NULL,
+  stripe_subscription_id  VARCHAR(255) UNIQUE,            -- Stripe seam, NULL in v1
+  changed_by              UUID REFERENCES users(id) ON DELETE SET NULL,  -- admin id, or NULL = self-serve
+  created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at              TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX uniq_subscriptions_one_active_per_user
+  ON subscriptions (user_id) WHERE status = 'active';
+
+CREATE INDEX idx_subscriptions_plan_id ON subscriptions (plan_id);

--- a/backend/src/db/migrations/migrate-017-seed-plans-and-backfill.sql
+++ b/backend/src/db/migrations/migrate-017-seed-plans-and-backfill.sql
@@ -1,0 +1,64 @@
+-- Migration 017: Seed 3 plans, backfill existing users to Free, extend new-user trigger
+-- Ticket:  https://github.com/mohamednaseramein/blog-generator/issues/155
+-- Epic:    https://github.com/mohamednaseramein/blog-generator/issues/149
+-- AgDR:    docs/agdr/AgDR-0035-migration-subscriptions-schema.md
+-- Rollback:
+--   1. Restore handle_new_user() to its migrate-013 body (users insert only).
+--   2. DELETE FROM subscriptions;  DELETE FROM plans WHERE slug IN ('free','pro','team');
+--   (or DROP both tables per migrate-016 rollback)
+
+-- Seed the three launch plans. All values are admin-editable post-launch.
+-- price_cents is display-only in v1 (no payment provider integrated).
+INSERT INTO plans (slug, name, description, price_cents, currency,
+                   blog_quota, ai_check_quota, author_profile_limit, reference_extraction_quota,
+                   is_public, is_default, sort_order) VALUES
+  ('free', 'Free', 'Get started at no cost.',           0,    'USD', 3,    5,    1,    10,   true, true,  1),
+  ('pro',  'Pro',  'For regular content creators.',     1900, 'USD', 50,   200,  10,   300,  true, false, 2),
+  ('team', 'Team', 'For teams shipping at volume.',     9900, 'USD', NULL, NULL, 50,   NULL, true, false, 3);
+
+-- Backfill: every existing user gets an active Free subscription.
+-- Idempotent — skips users who already have an active subscription.
+INSERT INTO subscriptions (user_id, plan_id, status, current_period_start, current_period_end)
+SELECT u.id,
+       (SELECT id FROM plans WHERE slug = 'free'),
+       'active',
+       date_trunc('month', NOW()),
+       date_trunc('month', NOW()) + INTERVAL '1 month'
+FROM users u
+WHERE NOT EXISTS (
+  SELECT 1 FROM subscriptions s WHERE s.user_id = u.id AND s.status = 'active'
+);
+
+-- Extend the existing auth-sync function (migrate-013) to also create a default
+-- subscription for every new user. SECURITY DEFINER + search_path + REVOKE are
+-- re-declared to match migrate-013 exactly (CREATE OR REPLACE does not preserve them).
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER AS $$
+DECLARE
+  default_plan_id UUID;
+BEGIN
+  INSERT INTO public.users (id, role, email_verified_at)
+  VALUES (new.id, 'user', new.email_confirmed_at);
+
+  SELECT id INTO default_plan_id
+  FROM public.plans
+  WHERE is_default = true AND archived_at IS NULL
+  LIMIT 1;
+
+  IF default_plan_id IS NOT NULL THEN
+    INSERT INTO public.subscriptions (user_id, plan_id, status,
+                                      current_period_start, current_period_end)
+    VALUES (new.id, default_plan_id, 'active',
+            date_trunc('month', NOW()),
+            date_trunc('month', NOW()) + INTERVAL '1 month');
+  END IF;
+
+  RETURN new;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+ALTER FUNCTION public.handle_new_user() SET search_path = public;
+REVOKE ALL ON FUNCTION public.handle_new_user() FROM PUBLIC;
+
+-- The on_auth_user_created trigger (migrate-013) already points at this function;
+-- CREATE OR REPLACE updates the body in place, so no trigger change is needed.

--- a/backend/src/db/migrations/migrate-017-seed-plans-and-backfill.sql
+++ b/backend/src/db/migrations/migrate-017-seed-plans-and-backfill.sql
@@ -14,7 +14,8 @@ INSERT INTO plans (slug, name, description, price_cents, currency,
                    is_public, is_default, sort_order) VALUES
   ('free', 'Free', 'Get started at no cost.',           0,    'USD', 3,    5,    1,    10,   true, true,  1),
   ('pro',  'Pro',  'For regular content creators.',     1900, 'USD', 50,   200,  10,   300,  true, false, 2),
-  ('team', 'Team', 'For teams shipping at volume.',     9900, 'USD', NULL, NULL, 50,   NULL, true, false, 3);
+  ('team', 'Team', 'For teams shipping at volume.',     9900, 'USD', NULL, NULL, 50,   NULL, true, false, 3)
+ON CONFLICT (slug) DO NOTHING;  -- idempotent: re-runnable after a partial-failure retry
 
 -- Backfill: every existing user gets an active Free subscription.
 -- Idempotent — skips users who already have an active subscription.

--- a/backend/src/domain/subscription-types.ts
+++ b/backend/src/domain/subscription-types.ts
@@ -1,0 +1,65 @@
+/**
+ * Domain types for the Subscription Plans epic (#149).
+ * Schema: AgDR-0035 (migration) + AgDR-0036 (data-model decisions).
+ */
+
+/** The four metered capabilities a plan can cap. */
+export type QuotaMetric =
+  | 'blogs' // monthly creation quota
+  | 'ai_checks' // monthly creation quota
+  | 'reference_extractions' // monthly creation quota
+  | 'author_profiles'; // standing total cap
+
+/** Only `monthly` in v1; the column exists so Stripe can add others without a reshape. */
+export type BillingPeriod = 'monthly';
+
+/** Only `active` in v1; `past_due` / `canceled` are reserved for the Stripe integration. */
+export type SubscriptionStatus = 'active';
+
+/** A limit value of `null` means unlimited for that metric. */
+export interface PlanLimits {
+  blogQuota: number | null;
+  aiCheckQuota: number | null;
+  authorProfileLimit: number | null;
+  referenceExtractionQuota: number | null;
+}
+
+export interface Plan {
+  id: string;
+  /** Stable identifier — immutable once the plan has subscribers. */
+  slug: string;
+  name: string;
+  description: string;
+  /** Display-only in v1 — no payment provider is integrated. */
+  priceCents: number;
+  /** ISO 4217 currency code. */
+  currency: string;
+  billingPeriod: BillingPeriod;
+  limits: PlanLimits;
+  /** Shown on the landing page and in the user self-serve picker. */
+  isPublic: boolean;
+  /** Exactly one non-archived plan is the default (new users land here). */
+  isDefault: boolean;
+  /** Soft-delete marker — non-null means archived. */
+  archivedAt: Date | null;
+  sortOrder: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface Subscription {
+  id: string;
+  userId: string;
+  planId: string;
+  status: SubscriptionStatus;
+  /** Inclusive start of the current usage period. */
+  currentPeriodStart: Date;
+  /** Exclusive end of the current usage period — when the monthly quotas reset. */
+  currentPeriodEnd: Date;
+  /** Stripe seam — unused in v1. */
+  stripeSubscriptionId: string | null;
+  /** Admin user id when the last change was admin-initiated; null for self-serve. */
+  changedBy: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/backend/src/repositories/__tests__/plan-repository.test.ts
+++ b/backend/src/repositories/__tests__/plan-repository.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { planRowToModel, type PlanRow } from '../plan-repository.js';
+
+const baseRow: PlanRow = {
+  id: 'plan-1',
+  slug: 'pro',
+  name: 'Pro',
+  description: 'For regular content creators.',
+  price_cents: 1900,
+  currency: 'USD',
+  billing_period: 'monthly',
+  blog_quota: 50,
+  ai_check_quota: 200,
+  author_profile_limit: 10,
+  reference_extraction_quota: 300,
+  is_public: true,
+  is_default: false,
+  archived_at: null,
+  sort_order: 2,
+  created_at: '2026-05-14T00:00:00Z',
+  updated_at: '2026-05-14T00:00:00Z',
+};
+
+describe('planRowToModel', () => {
+  it('assembles the four flat limit columns into a nested PlanLimits object', () => {
+    expect(planRowToModel(baseRow).limits).toEqual({
+      blogQuota: 50,
+      aiCheckQuota: 200,
+      authorProfileLimit: 10,
+      referenceExtractionQuota: 300,
+    });
+  });
+
+  it('preserves null limit columns as null (unlimited)', () => {
+    const plan = planRowToModel({
+      ...baseRow,
+      blog_quota: null,
+      ai_check_quota: null,
+      reference_extraction_quota: null,
+    });
+    expect(plan.limits).toEqual({
+      blogQuota: null,
+      aiCheckQuota: null,
+      authorProfileLimit: 10,
+      referenceExtractionQuota: null,
+    });
+  });
+
+  it('maps archived_at null to null and a timestamp to a Date', () => {
+    expect(planRowToModel(baseRow).archivedAt).toBeNull();
+    expect(planRowToModel({ ...baseRow, archived_at: '2026-05-14T12:00:00Z' }).archivedAt).toEqual(
+      new Date('2026-05-14T12:00:00Z'),
+    );
+  });
+
+  it('maps snake_case row fields to camelCase domain fields', () => {
+    const plan = planRowToModel(baseRow);
+    expect(plan.priceCents).toBe(1900);
+    expect(plan.isPublic).toBe(true);
+    expect(plan.isDefault).toBe(false);
+    expect(plan.sortOrder).toBe(2);
+    expect(plan.createdAt).toEqual(new Date('2026-05-14T00:00:00Z'));
+  });
+});

--- a/backend/src/repositories/__tests__/subscription-repository.test.ts
+++ b/backend/src/repositories/__tests__/subscription-repository.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeCurrentPeriod,
+  needsPeriodRoll,
+  subscriptionRowToModel,
+  type SubscriptionRow,
+} from '../subscription-repository.js';
+
+describe('computeCurrentPeriod', () => {
+  it('returns the calendar-month bounds (UTC) containing a mid-month date', () => {
+    const { start, end } = computeCurrentPeriod(new Date('2026-05-14T10:30:00Z'));
+    expect(start).toEqual(new Date('2026-05-01T00:00:00Z'));
+    expect(end).toEqual(new Date('2026-06-01T00:00:00Z'));
+  });
+
+  it('rolls the year over for a December date', () => {
+    const { start, end } = computeCurrentPeriod(new Date('2026-12-20T08:00:00Z'));
+    expect(start).toEqual(new Date('2026-12-01T00:00:00Z'));
+    expect(end).toEqual(new Date('2027-01-01T00:00:00Z'));
+  });
+
+  it('treats an exact period-start instant as inside that period', () => {
+    const { start, end } = computeCurrentPeriod(new Date('2026-01-01T00:00:00Z'));
+    expect(start).toEqual(new Date('2026-01-01T00:00:00Z'));
+    expect(end).toEqual(new Date('2026-02-01T00:00:00Z'));
+  });
+});
+
+describe('needsPeriodRoll', () => {
+  const periodEnd = new Date('2026-06-01T00:00:00Z');
+
+  it('is false before the period end', () => {
+    expect(needsPeriodRoll(periodEnd, new Date('2026-05-31T23:59:59Z'))).toBe(false);
+  });
+
+  it('is true at the exact period end (end is exclusive)', () => {
+    expect(needsPeriodRoll(periodEnd, new Date('2026-06-01T00:00:00Z'))).toBe(true);
+  });
+
+  it('is true after the period end', () => {
+    expect(needsPeriodRoll(periodEnd, new Date('2026-06-02T12:00:00Z'))).toBe(true);
+  });
+});
+
+describe('subscriptionRowToModel', () => {
+  const row: SubscriptionRow = {
+    id: 'sub-1',
+    user_id: 'user-1',
+    plan_id: 'plan-1',
+    status: 'active',
+    current_period_start: '2026-05-01T00:00:00Z',
+    current_period_end: '2026-06-01T00:00:00Z',
+    stripe_subscription_id: null,
+    changed_by: null,
+    created_at: '2026-05-14T00:00:00Z',
+    updated_at: '2026-05-14T00:00:00Z',
+  };
+
+  it('maps snake_case columns to camelCase domain fields with Date conversion', () => {
+    const sub = subscriptionRowToModel(row);
+    expect(sub.userId).toBe('user-1');
+    expect(sub.planId).toBe('plan-1');
+    expect(sub.currentPeriodStart).toEqual(new Date('2026-05-01T00:00:00Z'));
+    expect(sub.currentPeriodEnd).toEqual(new Date('2026-06-01T00:00:00Z'));
+  });
+
+  it('preserves the null Stripe seam and null self-serve attribution', () => {
+    const sub = subscriptionRowToModel(row);
+    expect(sub.stripeSubscriptionId).toBeNull();
+    expect(sub.changedBy).toBeNull();
+  });
+
+  it('keeps admin attribution when changed_by is set', () => {
+    expect(subscriptionRowToModel({ ...row, changed_by: 'admin-9' }).changedBy).toBe('admin-9');
+  });
+});

--- a/backend/src/repositories/plan-repository.ts
+++ b/backend/src/repositories/plan-repository.ts
@@ -1,0 +1,125 @@
+import { getSupabase } from '../db/supabase.js';
+import type { BillingPeriod, Plan, PlanLimits } from '../domain/subscription-types.js';
+
+export interface PlanRow {
+  id: string;
+  slug: string;
+  name: string;
+  description: string;
+  price_cents: number;
+  currency: string;
+  billing_period: string;
+  blog_quota: number | null;
+  ai_check_quota: number | null;
+  author_profile_limit: number | null;
+  reference_extraction_quota: number | null;
+  is_public: boolean;
+  is_default: boolean;
+  archived_at: string | null;
+  sort_order: number;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Map a `plans` row to the domain model — assembles the four flat limit columns into `PlanLimits`. */
+export function planRowToModel(row: PlanRow): Plan {
+  const limits: PlanLimits = {
+    blogQuota: row.blog_quota,
+    aiCheckQuota: row.ai_check_quota,
+    authorProfileLimit: row.author_profile_limit,
+    referenceExtractionQuota: row.reference_extraction_quota,
+  };
+
+  return {
+    id: row.id,
+    slug: row.slug,
+    name: row.name,
+    description: row.description,
+    priceCents: row.price_cents,
+    currency: row.currency,
+    billingPeriod: row.billing_period as BillingPeriod,
+    limits,
+    isPublic: row.is_public,
+    isDefault: row.is_default,
+    archivedAt: row.archived_at ? new Date(row.archived_at) : null,
+    sortOrder: row.sort_order,
+    createdAt: new Date(row.created_at),
+    updatedAt: new Date(row.updated_at),
+  };
+}
+
+export async function getPlanById(id: string): Promise<Plan | null> {
+  const { data, error } = await getSupabase()
+    .from('plans')
+    .select()
+    .eq('id', id)
+    .single<PlanRow>();
+
+  if (error?.code === 'PGRST116') return null; // row not found
+  if (error) throw new Error(error.message);
+  return planRowToModel(data);
+}
+
+export async function getPlanBySlug(slug: string): Promise<Plan | null> {
+  const { data, error } = await getSupabase()
+    .from('plans')
+    .select()
+    .eq('slug', slug)
+    .single<PlanRow>();
+
+  if (error?.code === 'PGRST116') return null;
+  if (error) throw new Error(error.message);
+  return planRowToModel(data);
+}
+
+/** The plan new users are subscribed to. Exactly one non-archived plan carries this flag. */
+export async function getDefaultPlan(): Promise<Plan | null> {
+  const { data, error } = await getSupabase()
+    .from('plans')
+    .select()
+    .eq('is_default', true)
+    .is('archived_at', null)
+    .single<PlanRow>();
+
+  if (error?.code === 'PGRST116') return null;
+  if (error) throw new Error(error.message);
+  return planRowToModel(data);
+}
+
+/** Every plan, including private and archived — for the admin catalogue. */
+export async function listAllPlans(): Promise<Plan[]> {
+  const { data, error } = await getSupabase()
+    .from('plans')
+    .select()
+    .order('sort_order', { ascending: true })
+    .returns<PlanRow[]>();
+
+  if (error) throw new Error(error.message);
+  return (data ?? []).map(planRowToModel);
+}
+
+/** Public, non-archived plans ordered for display — for the landing page + self-serve picker. */
+export async function listPublicPlans(): Promise<Plan[]> {
+  const { data, error } = await getSupabase()
+    .from('plans')
+    .select()
+    .eq('is_public', true)
+    .is('archived_at', null)
+    .order('sort_order', { ascending: true })
+    .returns<PlanRow[]>();
+
+  if (error) throw new Error(error.message);
+  return (data ?? []).map(planRowToModel);
+}
+
+/** Count of users currently on a plan — used by the archive guard (US-SUB-03). */
+export async function countActiveSubscribersForPlan(planId: string): Promise<number> {
+  const { count, error } = await getSupabase()
+    .from('subscriptions')
+    .select('*', { count: 'exact', head: true })
+    .eq('plan_id', planId)
+    .eq('status', 'active');
+
+  if (error) throw new Error(error.message);
+  return count ?? 0;
+}

--- a/backend/src/repositories/subscription-repository.ts
+++ b/backend/src/repositories/subscription-repository.ts
@@ -1,0 +1,93 @@
+import { getSupabase } from '../db/supabase.js';
+import type { Subscription, SubscriptionStatus } from '../domain/subscription-types.js';
+
+export interface SubscriptionRow {
+  id: string;
+  user_id: string;
+  plan_id: string;
+  status: string;
+  current_period_start: string;
+  current_period_end: string;
+  stripe_subscription_id: string | null;
+  changed_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export function subscriptionRowToModel(row: SubscriptionRow): Subscription {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    planId: row.plan_id,
+    status: row.status as SubscriptionStatus,
+    currentPeriodStart: new Date(row.current_period_start),
+    currentPeriodEnd: new Date(row.current_period_end),
+    stripeSubscriptionId: row.stripe_subscription_id,
+    changedBy: row.changed_by,
+    createdAt: new Date(row.created_at),
+    updatedAt: new Date(row.updated_at),
+  };
+}
+
+/**
+ * Calendar-month period bounds (UTC) containing `now` — the v1 usage window (AgDR-0035 KD-2).
+ * `start` is inclusive, `end` is exclusive. `Date.UTC` with month+1 handles the year rollover.
+ */
+export function computeCurrentPeriod(now: Date): { start: Date; end: Date } {
+  const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+  const end = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1));
+  return { start, end };
+}
+
+/** True once `now` has reached or passed the end of the subscription's current period. */
+export function needsPeriodRoll(currentPeriodEnd: Date, now: Date): boolean {
+  return now.getTime() >= currentPeriodEnd.getTime();
+}
+
+/**
+ * Fetch the user's active subscription, lazily rolling the period window forward if it has
+ * elapsed. Plan changes never reset the period — only the calendar advancing does.
+ */
+export async function getActiveSubscriptionByUserId(
+  userId: string,
+  now: Date = new Date(),
+): Promise<Subscription | null> {
+  const { data, error } = await getSupabase()
+    .from('subscriptions')
+    .select()
+    .eq('user_id', userId)
+    .eq('status', 'active')
+    .single<SubscriptionRow>();
+
+  if (error?.code === 'PGRST116') return null; // no active subscription
+  if (error) throw new Error(error.message);
+
+  const subscription = subscriptionRowToModel(data);
+  if (!needsPeriodRoll(subscription.currentPeriodEnd, now)) {
+    return subscription;
+  }
+  return rollSubscriptionPeriod(subscription.id, now);
+}
+
+/** Advance a subscription's period window to the calendar month containing `now`. */
+export async function rollSubscriptionPeriod(
+  subscriptionId: string,
+  now: Date = new Date(),
+): Promise<Subscription> {
+  const { start, end } = computeCurrentPeriod(now);
+
+  const { data, error } = await getSupabase()
+    .from('subscriptions')
+    .update({
+      current_period_start: start.toISOString(),
+      current_period_end: end.toISOString(),
+      updated_at: now.toISOString(),
+    })
+    .eq('id', subscriptionId)
+    .select()
+    .single<SubscriptionRow>();
+
+  if (error) throw new Error(error.message);
+  console.log(`[subscription-repository] rolled period for subscription id=${subscriptionId}`);
+  return subscriptionRowToModel(data);
+}

--- a/docs/agdr/AgDR-0035-migration-subscriptions-schema.md
+++ b/docs/agdr/AgDR-0035-migration-subscriptions-schema.md
@@ -1,0 +1,121 @@
+---
+id: AgDR-0035
+timestamp: 2026-05-14T00:00:00Z
+agent: claude-opus-4-7 (Tech Lead role)
+model: claude-opus-4-7
+session: subscriptions-migration
+trigger: user-prompt
+status: draft
+ticket: mohamednaseramein/blog-generator#155
+---
+
+# AgDR-0035 — Migration: Create Subscription Plans Schema (`plans` + `subscriptions`)
+
+> In the context of building the Subscription Plans epic ([#149](https://github.com/mohamednaseramein/blog-generator/issues/149), [PRD](../../projects/blog-generator/prd-subscriptions.md), [tech design](../../projects/blog-generator/technical-design-subscriptions.md)), facing the need for an admin-managed plan catalogue, one active subscription per user, and a zero-orphan cutover for every existing user, I decided to execute a schema migration in two files — `migrate-016` (DDL for `plans` + `subscriptions`) and `migrate-017` (seed 3 plans + backfill existing users to Free + extend the `handle_new_user()` trigger) — to achieve a correct starting state for the epic, accepting the tradeoff of monotonic `subscriptions` growth (one row per user, permanently) and a one-time function replacement that must be reverted as part of rollback.
+
+**Migration type**: schema
+**Affected tables / entities**: `plans` (new), `subscriptions` (new), `users` (read-only — backfill source + FK target), `public.handle_new_user()` (function replaced)
+**Estimated downtime**: none — `CREATE TABLE` on two brand-new tables (no locks on existing tables), an idempotent `INSERT … SELECT` backfill, and a `CREATE OR REPLACE FUNCTION`. No `ALTER TABLE` on an existing hot table, no column rewrite, no index build on a large table.
+**Data volume**: `plans` — 3 seed rows. `subscriptions` — one row per existing `users` row (exact count unknown from the design seat; early-stage product, expected < a few hundred). A size check is included in the testing plan.
+**Target environment(s)**: staging → prod
+
+## Context
+
+The Subscription Plans epic ([#149](https://github.com/mohamednaseramein/blog-generator/issues/149)) introduces admin-managed plans, self-serve upgrade/downgrade, and server-side quota enforcement. The entire epic rests on two invariants this migration establishes:
+
+1. **A plan catalogue exists** — `plans`, with four numeric limit columns, a single-default constraint, and a soft-delete (`archived_at`).
+2. **Every user has exactly one active subscription** — `subscriptions`, with a partial unique index on `(user_id) WHERE status = 'active'`. Existing users are backfilled onto **Free**; new users auto-subscribe to the default plan via the existing `handle_new_user()` auth-sync trigger.
+
+This is the first story (US-SUB-10) of the epic and is gated by `require-migration-ticket.sh` — no migration files can be edited without this AgDR plus a labelled tracker issue. The schema shape, the seed values, and the trigger extension are all specified in the [technical design](../../projects/blog-generator/technical-design-subscriptions.md) (§ Data Model, KD-2/KD-4).
+
+## Options Considered
+
+| Option | Pros | Cons |
+|---|---|---|
+| **Two files — `migrate-016` (DDL) + `migrate-017` (seed + backfill + trigger)** (chosen) | Separates pure DDL from data/seed/function changes; matches the project's established convention (`migrate-008-author-profiles` then `migrate-009-seed-predefined-profiles`); rollback reasons cleanly per concern; the numbered runner guarantees `016` (creates `plans`) applies before `017` (the new function references `plans`) | Two files to review instead of one |
+| Single combined migration file | Atomic in one file | Mixes DDL + DML + function replacement in one blob; harder to reason about rollback per-concern; diverges from the table-then-seed convention already in the repo |
+| App-boot `CREATE TABLE IF NOT EXISTS` + seed-on-start | No migration file to add | Diverges from the `backend/src/db/migrations/migrate-NNN-*.sql` convention; no version pinning; not auditable; defeats the migration-gate hook's intent; seed/backfill on every boot is fragile |
+
+A sub-decision — **how new users get a subscription** — was settled in the tech design (KD-4): extend the existing `handle_new_user()` trigger rather than add app-layer code in the registration handler. Rationale: the trigger already fires on `auth.users` INSERT to create the `public.users` row, so extending it guarantees no orphaned user regardless of code path (admin-created, trigger-created, or future OAuth signups). App-layer creation would miss those paths.
+
+## Decision
+
+**Chosen: two migration files**, exactly as specified in the technical design § Data Model.
+
+**`migrate-016-subscriptions-schema.sql`** — DDL only:
+
+- `plans` — `slug` (unique, stable), `name`, `description`, `price_cents` + `currency` (display-only in v1; Stripe seam), `billing_period` (`monthly` only), four nullable limit columns (`blog_quota`, `ai_check_quota`, `author_profile_limit`, `reference_extraction_quota`; NULL = unlimited) each with a `>= 0` CHECK, `is_public`, `is_default`, `archived_at` (soft delete), `sort_order`, timestamps. Partial unique index `uniq_plans_single_default ON plans (is_default) WHERE is_default = true AND archived_at IS NULL` enforces at most one default.
+- `subscriptions` — `user_id` FK → `users(id) ON DELETE CASCADE`, `plan_id` FK → `plans(id)`, `status` (`active` only in v1; enum reserves `past_due`/`canceled` for Stripe), `current_period_start` / `current_period_end`, `stripe_subscription_id` (nullable UNIQUE — Stripe seam), `changed_by` (nullable admin FK), timestamps. Partial unique index `uniq_subscriptions_one_active_per_user ON subscriptions (user_id) WHERE status = 'active'` is the invariant the whole feature rests on.
+
+**`migrate-017-seed-plans-and-backfill.sql`** — data + function:
+
+- Seed 3 plans: **Free** (default, public, `price_cents = 0`, limits 3/5/1/10), **Pro** (public, `price_cents = 1900`, limits 50/200/10/300), **Team** (public, `price_cents = 9900`, limits NULL/NULL/50/NULL).
+- Backfill: `INSERT INTO subscriptions … SELECT … FROM users u WHERE NOT EXISTS (SELECT 1 FROM subscriptions s WHERE s.user_id = u.id AND s.status = 'active')` — **idempotent**, current period set to calendar-month bounds (UTC).
+- `CREATE OR REPLACE FUNCTION public.handle_new_user()` — the original body (insert the `public.users` row) plus: look up the default plan and insert an `active` subscription for the new user.
+
+Seed values are admin-editable post-launch (PRD US-SUB-10 AC2). The verification query — `SELECT COUNT(*) FROM users u WHERE NOT EXISTS (SELECT 1 FROM subscriptions s WHERE s.user_id = u.id AND s.status = 'active')` — must return `0` (PRD US-SUB-10 AC4).
+
+## Rollback Plan
+
+**Explicit rollback steps** (run in order — both migrations are purely additive, so rollback is clean and destroys only subscription assignments, all of which point at Free immediately post-backfill):
+
+1. **Restore the trigger function.** `CREATE OR REPLACE FUNCTION public.handle_new_user()` with its original `migrate-013` body (insert the `public.users` row only — no subscription insert). This must run first so no new signup tries to write to a `subscriptions` table that step 3 is about to drop.
+2. **Drop `subscriptions`.** `DROP TABLE IF EXISTS subscriptions;` — drops the table, both partial unique indexes, and all FKs. Must precede step 3 because `subscriptions.plan_id` FK-references `plans`.
+3. **Drop `plans`.** `DROP TABLE IF EXISTS plans;`
+4. **Un-record the migrations.** `DELETE FROM schema_migrations WHERE filename IN ('migrate-016-subscriptions-schema.sql', 'migrate-017-seed-plans-and-backfill.sql');` so the runner will re-apply them on the next forward run.
+5. No data restoration is needed on existing tables — `users`, `blogs`, `author_profiles`, etc. are never altered by this migration (only read for the backfill, and referenced as FK targets). Re-applying both files restores the post-apply state.
+
+**Rollback tested against**: **not tested yet** — will be exercised against **staging** before prod apply (apply → verification query → run steps 1–4 → confirm tables gone + function restored → re-apply). This is a hard prerequisite for the prod-apply step and will be called out as a blocker on the implementation PR.
+
+**Rollback window**: Indefinite for schema integrity — no existing table is mutated, so rollback is structurally safe at any time. The only loss is subscription state (plan assignments + period windows); within the v1 preview (display-only billing) that is low-fidelity data and re-derivable by re-running the backfill.
+
+## Cross-Service Consumers
+
+- **None at migration time.** `plans` and `subscriptions` are brand-new tables. The blog-generator backend is the only service and has no code reading or writing these tables until later stories in epic #149 add the repositories.
+- No external services, ETL jobs, or analytics pipelines reference the affected tables. The `users` table is only read (backfill `SELECT`) and used as an FK target.
+- **Deploy-order constraint**: the migration must apply before any backend code that reads `plans` / `subscriptions` is deployed — standard "migrate before app start" sequencing, handled by the existing `npm run db:migrate` deploy step. Within the migration set, `migrate-016` must apply before `migrate-017` (the replaced `handle_new_user()` references `plans`) — guaranteed by the numbered, lexically-sorted migration runner (`migrate.ts`).
+
+## Testing Plan
+
+- **Dev smoke**:
+  - `npm run db:migrate --workspace=backend` — apply `016` + `017` against a dev Supabase
+  - `psql $SUPABASE_DB_URL -c "\d plans"` / `"\d subscriptions"` — verify columns, types, defaults, FKs, partial unique indexes
+  - `SELECT slug, price_cents, blog_quota, ai_check_quota, author_profile_limit, reference_extraction_quota, is_default FROM plans ORDER BY sort_order;` — verify the 3 seed rows and that exactly one is `is_default`
+  - Run the verification query — must return `0`
+  - Insert a row into `auth.users` (or use the Supabase test signup) — confirm the trigger creates both a `users` row and an `active` Free `subscriptions` row
+- **Staging verify**:
+  - Apply both migrations to staging Supabase
+  - Verification query returns `0`; `SELECT COUNT(*) FROM subscriptions` equals `SELECT COUNT(*) FROM users` (size check)
+  - Confirm the 3 plans seeded with the exact values from the tech design
+  - Create a test signup on staging — confirm a Free subscription is auto-created by the trigger
+  - **Exercise the rollback runbook** (steps 1–4 above), confirm `plans` + `subscriptions` are gone and `handle_new_user()` is back to its `migrate-013` body, then re-apply — this validates the runbook before prod
+- **Canary / phased rollout**: N/A — additive schema, applied all-at-once per the PRD launch plan. The behaviour change users feel (quota enforcement) ships in a separate, later story (US-SUB-08), not in this migration.
+
+## Observability
+
+- **During apply**: `migrate.ts` logs each file as it applies (`▶️ Applying … / ✅ … applied`) and exits non-zero on failure. `CREATE TABLE` on new tables completes in well under a second; no locks on existing tables → no impact on live traffic. The backfill is a single `INSERT … SELECT` over `users` — bounded by the (small) user count.
+- **Post-apply**:
+  - Verification query = `0` orphaned users (release gate)
+  - `plans` row count = 3; `subscriptions` row count = `users` row count
+  - Watch backend error logs after the US-SUB-10 code deploy for any subscription-lookup failures (there should be none — no code reads these tables until later stories)
+- **Alerts armed**: no DB dashboards exist for this project today (noted as a gap). For this migration the verification query + row-count checks serve as the explicit post-apply gate; ongoing `subscriptions` growth is bounded 1:1 with user count and needs no alert.
+
+## Consequences
+
+- **Enables** the entire Subscription Plans epic — every later story (admin catalogue, landing, self-serve, enforcement) reads from these two tables.
+- **Establishes** the "exactly one active subscription per user" invariant at the database level via a partial unique index — enforcement code can rely on it rather than defensively handling the multi-row case.
+- **Adds** one permanent `subscriptions` row per user (grows 1:1 with the user base; negligible storage).
+- **Adds** a second responsibility to `handle_new_user()` — it now creates a subscription as well as a user row. Rollback must remember to revert the function, not just drop the tables (captured in the rollback plan).
+- **Builds the Stripe seam** without integrating Stripe: `price_cents` + `currency`, the `status` enum, `stripe_subscription_id`, and the `current_period_*` columns all exist now; a later Stripe epic changes only how those columns are populated.
+- **No impact** on existing tables, queries, or services — purely additive.
+
+## Artifacts
+
+- Ticket: [mohamednaseramein/blog-generator#155](https://github.com/mohamednaseramein/blog-generator/issues/155)
+- Epic: [mohamednaseramein/blog-generator#149](https://github.com/mohamednaseramein/blog-generator/issues/149)
+- Tech design: [`projects/blog-generator/technical-design-subscriptions.md`](../../projects/blog-generator/technical-design-subscriptions.md) § Data Model, KD-2, KD-4
+- PRD: [`projects/blog-generator/prd-subscriptions.md`](../../projects/blog-generator/prd-subscriptions.md) § US-SUB-10
+- Related: [`docs/agdr/AgDR-0025-role-column-vs-table.md`](./AgDR-0025-role-column-vs-table.md) (the `users` table this FK-references)
+- Migration files: `backend/src/db/migrations/migrate-016-subscriptions-schema.sql`, `migrate-017-seed-plans-and-backfill.sql` (to be created during implementation)
+- Staging-run log: filled in once applied
+- Post-apply verification-query result: filled in once applied

--- a/docs/agdr/AgDR-0036-subscription-data-model-and-enforcement.md
+++ b/docs/agdr/AgDR-0036-subscription-data-model-and-enforcement.md
@@ -1,0 +1,89 @@
+---
+id: AgDR-0036
+timestamp: 2026-05-14T00:00:00Z
+agent: claude-opus-4-7 (Tech Lead role)
+model: claude-opus-4-7
+session: subscriptions-architecture
+trigger: user-prompt
+status: accepted
+ticket: mohamednaseramein/blog-generator#149
+---
+
+# AgDR-0036 — Subscription Plans: Data-Model & Enforcement Architecture
+
+> In the context of the Subscription Plans epic ([#149](https://github.com/mohamednaseramein/blog-generator/issues/149), [PRD](../../projects/blog-generator/prd-subscriptions.md), [tech design](../../projects/blog-generator/technical-design-subscriptions.md)), facing four design choices that shape every story in the epic — how plan limits are stored, how usage is counted, how enforcement is wired into existing handlers, and what HTTP status a quota block returns — I decided on typed limit columns, `created_at`-window counting with no counter table, a shared `assertWithinQuota` service helper called explicitly, and `402 Payment Required` with a typed `QUOTA_EXCEEDED` code, to achieve type-safety, minimal new infrastructure, and a clean independently-revertible enforcement layer, accepting that a fifth limit later needs a migration and that quota counts are eventually-consistent under deletes.
+
+This AgDR records the four non-migration key decisions (KD-1, KD-3, KD-5, KD-6) from the technical design. The two remaining decisions — KD-2 (period tracking via `current_period_*` columns) and KD-4 (new-user subscription via the `handle_new_user()` trigger) — are recorded in [AgDR-0035](./AgDR-0035-migration-subscriptions-schema.md) because they are realised in the migration itself.
+
+## Context
+
+The epic introduces plans with four numeric limits (blogs/month, AI checks/month, author profiles total, reference extractions/month), self-serve plan switching, and server-side enforcement on four existing handlers (`handleCreateBlog`, `handleRunAiCheck`, the profile-create path, `handleAddReference`). Billing is display-only in v1. These four choices were made up-front because they constrain the schema (US-SUB-10), the services (US-SUB-05/06/07), and the enforcement story (US-SUB-08) — deciding them per-story would risk rework.
+
+## Decision 1 (KD-1) — Plan limits: four typed columns, not JSONB
+
+### Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Four explicit integer columns** (chosen) | Type-safe end-to-end (DB → repository → domain → handler); `CHECK (… >= 0)` constraints at the DB; queryable (`WHERE blog_quota IS NULL`); matches the codebase's typed/DDD lean | Adding a 5th limit later requires a migration |
+| Single JSONB `limits` column | Add a limit with no migration; flexible | Loses DB-level type safety and constraints; every read needs runtime shape validation; awkward to query; invites silently-malformed limit objects |
+
+### Decision
+
+**Chosen: four nullable integer columns** — `blog_quota`, `ai_check_quota`, `author_profile_limit`, `reference_extraction_quota`, each `CHECK (col IS NULL OR col >= 0)`, `NULL` meaning unlimited. v1 has exactly four known limits; the flexibility JSONB buys is flexibility we do not need, and the type-safety loss is real. JSONB is the documented upgrade path if limits ever proliferate beyond what columns comfortably express.
+
+## Decision 2 (KD-3) — Usage counting: `created_at` window, no counter table
+
+### Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Count live rows by `created_at` within the period** (chosen) | No new table; all four metrics already have `created_at`; "deleting an item frees a slot this period" is acceptable per the PRD; trivially correct after a period roll | A deleted row stops counting — usage is not a permanent ledger; a high-churn user could create/delete to exceed the intended cap within a period |
+| Dedicated `usage_counters` table, incremented per action | Usage is a permanent ledger; deletes don't refund slots; supports strict "creation events" semantics | New table + new write on every gated action; needs its own period-roll/reset logic; more to keep consistent |
+
+### Decision
+
+**Chosen: count live rows by `created_at`** within `[current_period_start, current_period_end)` for the three monthly metrics (blogs, AI checks, reference extractions), and a standing `COUNT(*)` of live non-predefined rows for author profiles. The PRD (Edge Cases) explicitly accepts "deleting an item frees a slot this period" — it even gives users a clear path to fit a downgrade. A `usage_counters` table is the documented upgrade path if a strict permanent-ledger model is later required. The churn-abuse risk is acceptable in a display-only-billing v1 and is called out for revisit when Stripe lands.
+
+## Decision 3 (KD-5) — Enforcement: a shared service helper, not Express middleware
+
+### Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Shared `assertWithinQuota(userId, metric)` service helper, called explicitly** (chosen) | One tested unit; each call-site is one explicit line; works across the four endpoints which live on different routers; composes with `handleRunAiCheck`'s ordered pre-checks (language, cache, rate-limit); trivial to revert per call-site | The four call-sites must each remember to call it (mitigated by tests + the isolated enforcement PR) |
+| Express middleware per route | "Set once on the route" feel | The four endpoints are on different routers; param-plumbing "which metric does this route consume" is awkward; can't easily sit *after* the AI-check handler's own pre-checks; harder to unit-test in isolation |
+
+### Decision
+
+**Chosen: a shared service helper** `assertWithinQuota(userId, metric)` in `quota-service.ts`, throwing `AppError(402, 'QUOTA_EXCEEDED', …)` when at/over limit and no-op when under limit or unlimited. Called as one explicit line at the top of each of the four gated handlers (for `handleRunAiCheck`, after its existing pre-checks). This is also why US-SUB-08 ships last and isolated — the four call-sites are added in one PR that can be reverted on its own if enforcement misfires.
+
+## Decision 4 (KD-6) — Quota-exceeded response: `402 Payment Required` + typed code
+
+### Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **`402 Payment Required` + `code: 'QUOTA_EXCEEDED'`** (chosen) | Semantically signals "an upgrade unlocks this"; lets the frontend branch cleanly on status to show the upgrade prompt; distinct from `403` (auth/permission) and `401` (unauthenticated) | `402` is historically under-used; some proxies/clients treat it as unusual (low risk for a same-origin SPA API) |
+| `403 Forbidden` | Conventional, universally understood | Conflates "you lack permission" with "you've hit your plan limit" — the frontend would need to inspect the body to tell them apart |
+
+### Decision
+
+**Chosen: `402 Payment Required`** with a typed payload `{ code: 'QUOTA_EXCEEDED', message, metric, limit, usage }`, carried through the existing `AppError` envelope (extended with structured `details`, or the gated handlers respond directly — an implementation-time call that preserves the envelope shape either way). Resolves PRD OQ-5. The frontend keys off the `402` + `QUOTA_EXCEEDED` code to surface `QuotaBlockPrompt` and fire the `quota_blocked` analytics event.
+
+## Consequences
+
+- **Type-safety** holds from the `plans` columns through the `PlanLimits` domain value object to the handlers — no runtime limit-shape validation needed.
+- **No new infrastructure** for usage tracking — usage is derived from data that already exists; the only new tables are `plans` and `subscriptions` (AgDR-0035).
+- **Enforcement is one revertible PR** — the four `assertWithinQuota` call-sites land together in US-SUB-08 and can be removed together if enforcement misbehaves in production.
+- **A fifth limit later costs a migration** — accepted; if limits proliferate, the JSONB path is documented.
+- **Usage is eventually-consistent under deletes** — not a permanent ledger; revisit with a `usage_counters` table if/when Stripe billing makes strict accounting necessary.
+- **`402` becomes a meaningful status in this API** — the frontend's error handling must recognise it; documented for the US-SUB-08 frontend work.
+
+## Artifacts
+
+- Epic: [mohamednaseramein/blog-generator#149](https://github.com/mohamednaseramein/blog-generator/issues/149)
+- Tech design: [`projects/blog-generator/technical-design-subscriptions.md`](../../projects/blog-generator/technical-design-subscriptions.md) § Key Technical Decisions (KD-1, KD-3, KD-5, KD-6)
+- PRD: [`projects/blog-generator/prd-subscriptions.md`](../../projects/blog-generator/prd-subscriptions.md) (resolves OQ-5)
+- Migration AgDR (KD-2, KD-4): [`docs/agdr/AgDR-0035-migration-subscriptions-schema.md`](./AgDR-0035-migration-subscriptions-schema.md)
+- Stories affected: #155 (US-SUB-10), #152 (US-SUB-05/06/07), #154 (US-SUB-08)


### PR DESCRIPTION
## Summary

US-SUB-10 — the data foundation for the Subscription Plans epic (#149).

- **`migrate-016`** — creates `plans` (catalogue with four nullable limit columns; partial unique index enforcing one default among non-archived plans) and `subscriptions` (partial unique index enforcing one active subscription per user; nullable `stripe_subscription_id` + `status` enum as the Stripe seam).
- **`migrate-017`** — seeds Free / Pro / Team; backfills every existing user onto Free (idempotent `INSERT … SELECT`); extends `handle_new_user()` so new signups auto-subscribe to the default plan.
- **`subscription-types.ts`** — `Plan`, `Subscription`, `PlanLimits`, and the `QuotaMetric` / `BillingPeriod` / `SubscriptionStatus` enums.
- **`plan-repository.ts`** — row→model mapper + read queries (by id / slug, default, all, public, active-subscriber count).
- **`subscription-repository.ts`** — row→model mapper, calendar-month period computation, and lazy period-roll on read.
- **AgDR-0035** (migration) + **AgDR-0036** (data-model & enforcement decisions).

No behaviour change for users — this PR only adds tables, seed data, types, and repositories. Nothing reads the new tables yet; later epic stories wire them in. Quota enforcement ships separately and last (US-SUB-08 / #154).

## Testing

- `npm run typecheck --workspace=backend` — clean
- `npm run test --workspace=backend` — **145 passed** (13 new across `plan-repository.test.ts` + `subscription-repository.test.ts`: row mappers, `computeCurrentPeriod`, `needsPeriodRoll`)
- `npm run build --workspace=backend` — succeeds
- **Migration not yet applied.** Per AgDR-0035 the migration runs on staging next, with the verification query (`0` users without an active subscription) as the release gate and the rollback runbook exercised on staging before prod apply.

Refs #155 · Epic #149

## Glossary

| Term | Definition |
|------|------------|
| Quota metric | One of the four metered capabilities a plan caps: blogs/month, AI checks/month, reference extractions/month, author profiles (standing total). |
| Period roll | Advancing a subscription's `current_period_start/end` window to the calendar month containing "now". Done lazily on read — no cron job. |
| Partial unique index | A Postgres unique index with a `WHERE` clause. Used here so "one default plan" and "one active subscription per user" are enforced by the database, not application code. |
| Stripe seam | Columns present now but unused in v1 (`price_cents`, `stripe_subscription_id`, `status` enum, period columns) so a later Stripe integration changes only how they are populated — no schema reshape. |
| Backfill | The one-time `INSERT … SELECT` that gives every pre-existing user a Free subscription, so there are no orphaned users. |
| `handle_new_user()` | The existing `auth.users` INSERT trigger function (from migrate-013); extended here to also create the default subscription. |
| AgDR | Agent Decision Record — ApexYard's lightweight ADR variant capturing options / decision / consequences. |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
