### PR TITLE
feat(GH-155): admin subscription plans catalogue

### DIFF
--- a/backend/src/handlers/plan-admin-handler.ts
+++ b/backend/src/handlers/plan-admin-handler.ts
@@ -1,0 +1,314 @@
+import type { Request, Response, NextFunction } from 'express';
+import type { Plan } from '../domain/subscription-types.js';
+import { AppError } from '../middleware/error-handler.js';
+import {
+  countActiveSubscribersForPlan,
+  getPlanById,
+  getPlanBySlug,
+  insertPlan,
+  listAllPlans,
+  setPlanDefault as setDefaultPlanInDb,
+  updatePlanById,
+  type InsertPlanRow,
+  type PatchPlanRow,
+} from '../repositories/plan-repository.js';
+
+function routeParam(value: string | string[] | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function planToJson(plan: Plan, activeSubscriberCount: number) {
+  return {
+    id: plan.id,
+    slug: plan.slug,
+    name: plan.name,
+    description: plan.description,
+    priceCents: plan.priceCents,
+    currency: plan.currency,
+    billingPeriod: plan.billingPeriod,
+    limits: plan.limits,
+    isPublic: plan.isPublic,
+    isDefault: plan.isDefault,
+    archivedAt: plan.archivedAt?.toISOString() ?? null,
+    sortOrder: plan.sortOrder,
+    createdAt: plan.createdAt.toISOString(),
+    updatedAt: plan.updatedAt.toISOString(),
+    activeSubscriberCount,
+  };
+}
+
+function slugify(name: string): string {
+  const s = name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 50);
+  return s.length > 0 ? s : 'plan';
+}
+
+async function allocateUniqueSlug(base: string): Promise<string> {
+  let candidate = base;
+  for (let n = 0; n < 50; n += 1) {
+    const existing = await getPlanBySlug(candidate);
+    if (!existing) return candidate;
+    const suffix = n === 0 ? '-2' : `-${n + 2}`;
+    candidate = `${base.slice(0, Math.max(1, 50 - suffix.length))}${suffix}`;
+  }
+  throw new AppError(500, 'SLUG_ALLOCATION_FAILED', 'Could not allocate a unique plan slug');
+}
+
+function parseOptionalLimit(v: unknown, field: string): number | null {
+  if (v === undefined || v === null || v === '') return null;
+  if (typeof v !== 'number' || !Number.isFinite(v) || !Number.isInteger(v)) {
+    throw new AppError(400, 'VALIDATION', `${field} must be a whole number or empty for unlimited`);
+  }
+  if (v < 0) throw new AppError(400, 'VALIDATION', `${field} cannot be negative`);
+  return v;
+}
+
+function parseRequiredName(v: unknown): string {
+  if (typeof v !== 'string' || v.trim().length === 0) {
+    throw new AppError(400, 'VALIDATION', 'Name is required');
+  }
+  if (v.length > 120) throw new AppError(400, 'VALIDATION', 'Name must be at most 120 characters');
+  return v.trim();
+}
+
+function parseDescription(v: unknown): string {
+  if (v === undefined || v === null) return '';
+  if (typeof v !== 'string') throw new AppError(400, 'VALIDATION', 'Description must be a string');
+  return v;
+}
+
+function parsePriceCents(v: unknown): number {
+  if (typeof v !== 'number' || !Number.isFinite(v) || !Number.isInteger(v)) {
+    throw new AppError(400, 'VALIDATION', 'priceCents must be a whole number');
+  }
+  if (v < 0) throw new AppError(400, 'VALIDATION', 'priceCents cannot be negative');
+  return v;
+}
+
+function parseCurrency(v: unknown): string {
+  const c = typeof v === 'string' && v.length === 3 ? v.toUpperCase() : 'USD';
+  if (!/^[A-Z]{3}$/.test(c)) throw new AppError(400, 'VALIDATION', 'currency must be a 3-letter ISO code');
+  return c;
+}
+
+function parseSortOrder(v: unknown, fallback: number): number {
+  if (v === undefined || v === null) return fallback;
+  if (typeof v !== 'number' || !Number.isFinite(v) || !Number.isInteger(v)) {
+    throw new AppError(400, 'VALIDATION', 'sortOrder must be an integer');
+  }
+  if (v < 0 || v > 32767) throw new AppError(400, 'VALIDATION', 'sortOrder out of range');
+  return v;
+}
+
+export async function listAdminPlans(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const plans = await listAllPlans();
+    const rows = await Promise.all(
+      plans.map(async (plan) => {
+        const activeSubscriberCount = await countActiveSubscribersForPlan(plan.id);
+        return planToJson(plan, activeSubscriberCount);
+      }),
+    );
+    res.json({ plans: rows });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function createAdminPlan(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const body = req.body as Record<string, unknown>;
+    const name = parseRequiredName(body.name);
+    const description = parseDescription(body.description);
+    const priceCents = parsePriceCents(body.priceCents ?? body.price_cents ?? 0);
+    const currency = parseCurrency(body.currency);
+
+    const blogQuota = parseOptionalLimit(body.blogQuota ?? body.blog_quota, 'blogQuota');
+    const aiCheckQuota = parseOptionalLimit(body.aiCheckQuota ?? body.ai_check_quota, 'aiCheckQuota');
+    const authorProfileLimit = parseOptionalLimit(
+      body.authorProfileLimit ?? body.author_profile_limit,
+      'authorProfileLimit',
+    );
+    const referenceExtractionQuota = parseOptionalLimit(
+      body.referenceExtractionQuota ?? body.reference_extraction_quota,
+      'referenceExtractionQuota',
+    );
+
+    const isPublic = Boolean(body.isPublic ?? body.is_public);
+
+    const plans = await listAllPlans();
+    const maxSort = plans.reduce((m, p) => Math.max(m, p.sortOrder), 0);
+    const sortOrder = parseSortOrder(body.sortOrder ?? body.sort_order, maxSort + 1);
+
+    let slug: string;
+    if (typeof body.slug === 'string' && body.slug.trim().length > 0) {
+      slug = body.slug.trim().toLowerCase().slice(0, 50);
+      if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug)) {
+        throw new AppError(400, 'VALIDATION', 'slug must be lowercase letters, digits, and single hyphens');
+      }
+      if (await getPlanBySlug(slug)) throw new AppError(409, 'SLUG_TAKEN', 'That slug is already in use');
+    } else {
+      slug = await allocateUniqueSlug(slugify(name));
+    }
+
+    const row: InsertPlanRow = {
+      slug,
+      name,
+      description,
+      price_cents: priceCents,
+      currency,
+      blog_quota: blogQuota,
+      ai_check_quota: aiCheckQuota,
+      author_profile_limit: authorProfileLimit,
+      reference_extraction_quota: referenceExtractionQuota,
+      is_public: isPublic,
+      is_default: false,
+      sort_order: sortOrder,
+    };
+
+    const plan = await insertPlan(row);
+    const activeSubscriberCount = await countActiveSubscribersForPlan(plan.id);
+    res.status(201).json({ plan: planToJson(plan, activeSubscriberCount) });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function patchAdminPlan(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const id = routeParam(req.params.id);
+    if (!id) throw new AppError(400, 'VALIDATION', 'Missing plan id');
+
+    const existing = await getPlanById(id);
+    if (!existing) throw new AppError(404, 'NOT_FOUND', 'Plan not found');
+    if (existing.archivedAt) throw new AppError(400, 'ARCHIVED', 'Cannot edit an archived plan');
+
+    const body = req.body as Record<string, unknown>;
+    const subscribers = await countActiveSubscribersForPlan(id);
+
+    const patch: PatchPlanRow = {};
+
+    if (body.slug !== undefined || body.name !== undefined) {
+      const nextSlug =
+        typeof body.slug === 'string' && body.slug.trim().length > 0
+          ? body.slug.trim().toLowerCase().slice(0, 50)
+          : existing.slug;
+      if (nextSlug !== existing.slug) {
+        if (subscribers > 0) {
+          throw new AppError(
+            409,
+            'SLUG_LOCKED',
+            'Cannot change slug while the plan has active subscribers',
+          );
+        }
+        if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(nextSlug)) {
+          throw new AppError(400, 'VALIDATION', 'slug must be lowercase letters, digits, and single hyphens');
+        }
+        const taken = await getPlanBySlug(nextSlug);
+        if (taken && taken.id !== id) throw new AppError(409, 'SLUG_TAKEN', 'That slug is already in use');
+        patch.slug = nextSlug;
+      }
+    }
+
+    if (body.name !== undefined) patch.name = parseRequiredName(body.name);
+    if (body.description !== undefined) patch.description = parseDescription(body.description);
+    if (body.priceCents !== undefined || body.price_cents !== undefined) {
+      patch.price_cents = parsePriceCents(body.priceCents ?? body.price_cents);
+    }
+    if (body.currency !== undefined) patch.currency = parseCurrency(body.currency);
+    if (body.blogQuota !== undefined || body.blog_quota !== undefined) {
+      patch.blog_quota = parseOptionalLimit(body.blogQuota ?? body.blog_quota, 'blogQuota');
+    }
+    if (body.aiCheckQuota !== undefined || body.ai_check_quota !== undefined) {
+      patch.ai_check_quota = parseOptionalLimit(body.aiCheckQuota ?? body.ai_check_quota, 'aiCheckQuota');
+    }
+    if (body.authorProfileLimit !== undefined || body.author_profile_limit !== undefined) {
+      patch.author_profile_limit = parseOptionalLimit(
+        body.authorProfileLimit ?? body.author_profile_limit,
+        'authorProfileLimit',
+      );
+    }
+    if (body.referenceExtractionQuota !== undefined || body.reference_extraction_quota !== undefined) {
+      patch.reference_extraction_quota = parseOptionalLimit(
+        body.referenceExtractionQuota ?? body.reference_extraction_quota,
+        'referenceExtractionQuota',
+      );
+    }
+    if (body.isPublic !== undefined || body.is_public !== undefined) {
+      patch.is_public = Boolean(body.isPublic ?? body.is_public);
+    }
+    if (body.sortOrder !== undefined || body.sort_order !== undefined) {
+      patch.sort_order = parseSortOrder(body.sortOrder ?? body.sort_order, existing.sortOrder);
+    }
+
+    if (Object.keys(patch).length === 0) {
+      const activeSubscriberCount = await countActiveSubscribersForPlan(id);
+      res.json({ plan: planToJson(existing, activeSubscriberCount) });
+      return;
+    }
+
+    const plan = await updatePlanById(id, patch);
+    const activeSubscriberCount = await countActiveSubscribersForPlan(plan.id);
+    res.json({ plan: planToJson(plan, activeSubscriberCount) });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function archiveAdminPlan(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const id = routeParam(req.params.id);
+    if (!id) throw new AppError(400, 'VALIDATION', 'Missing plan id');
+
+    const plan = await getPlanById(id);
+    if (!plan) throw new AppError(404, 'NOT_FOUND', 'Plan not found');
+    if (plan.archivedAt) throw new AppError(400, 'ALREADY_ARCHIVED', 'Plan is already archived');
+    if (plan.isDefault) {
+      throw new AppError(
+        409,
+        'DEFAULT_PLAN',
+        'Cannot archive the default plan. Designate another plan as default first.',
+      );
+    }
+    const n = await countActiveSubscribersForPlan(id);
+    if (n > 0) {
+      throw new AppError(
+        409,
+        'HAS_SUBSCRIBERS',
+        `Cannot archive: ${n} active subscriber(s). Move them to another plan first.`,
+      );
+    }
+
+    const archived = await updatePlanById(id, {
+      archived_at: new Date().toISOString(),
+      is_public: false,
+      is_default: false,
+    });
+    const activeSubscriberCount = await countActiveSubscribersForPlan(archived.id);
+    res.json({ plan: planToJson(archived, activeSubscriberCount) });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function setDefaultAdminPlan(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const id = routeParam(req.params.id);
+    if (!id) throw new AppError(400, 'VALIDATION', 'Missing plan id');
+
+    const plan = await getPlanById(id);
+    if (!plan) throw new AppError(404, 'NOT_FOUND', 'Plan not found');
+    if (plan.archivedAt) throw new AppError(400, 'ARCHIVED', 'Cannot set an archived plan as default');
+
+    const updated = await setDefaultPlanInDb(id);
+    const activeSubscriberCount = await countActiveSubscribersForPlan(updated.id);
+    res.json({ plan: planToJson(updated, activeSubscriberCount) });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/backend/src/repositories/plan-repository.ts
+++ b/backend/src/repositories/plan-repository.ts
@@ -123,3 +123,75 @@ export async function countActiveSubscribersForPlan(planId: string): Promise<num
   if (error) throw new Error(error.message);
   return count ?? 0;
 }
+
+export interface InsertPlanRow {
+  slug: string;
+  name: string;
+  description: string;
+  price_cents: number;
+  currency: string;
+  blog_quota: number | null;
+  ai_check_quota: number | null;
+  author_profile_limit: number | null;
+  reference_extraction_quota: number | null;
+  is_public: boolean;
+  is_default: boolean;
+  sort_order: number;
+}
+
+export async function insertPlan(row: InsertPlanRow): Promise<Plan> {
+  const now = new Date().toISOString();
+  const { data, error } = await getSupabase()
+    .from('plans')
+    .insert({
+      ...row,
+      billing_period: 'monthly',
+      created_at: now,
+      updated_at: now,
+    })
+    .select()
+    .single<PlanRow>();
+
+  if (error) throw new Error(error.message);
+  return planRowToModel(data);
+}
+
+export type PatchPlanRow = Partial<{
+  slug: string;
+  name: string;
+  description: string;
+  price_cents: number;
+  currency: string;
+  blog_quota: number | null;
+  ai_check_quota: number | null;
+  author_profile_limit: number | null;
+  reference_extraction_quota: number | null;
+  is_public: boolean;
+  sort_order: number;
+  archived_at: string | null;
+  is_default: boolean;
+}>;
+
+export async function updatePlanById(id: string, patch: PatchPlanRow): Promise<Plan> {
+  const { data, error } = await getSupabase()
+    .from('plans')
+    .update({ ...patch, updated_at: new Date().toISOString() })
+    .eq('id', id)
+    .select()
+    .single<PlanRow>();
+
+  if (error) throw new Error(error.message);
+  return planRowToModel(data);
+}
+
+/** Clear default flag on every non-archived plan except `exceptId` (pass `null` to clear all). */
+export async function clearDefaultPlans(exceptId: string | null): Promise<void> {
+  const q = getSupabase().from('plans').update({ is_default: false, updated_at: new Date().toISOString() }).is('archived_at', null);
+  const { error } = exceptId ? await q.neq('id', exceptId) : await q;
+  if (error) throw new Error(error.message);
+}
+
+export async function setPlanDefault(planId: string): Promise<Plan> {
+  await clearDefaultPlans(planId);
+  return updatePlanById(planId, { is_default: true });
+}

--- a/backend/src/routes/admin-routes.ts
+++ b/backend/src/routes/admin-routes.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { requireAuth, requireAdmin } from '../middleware/auth.js';
 import * as adminHandler from '../handlers/admin-handler.js';
+import * as planAdminHandler from '../handlers/plan-admin-handler.js';
 
 const router = Router();
 
@@ -20,5 +21,11 @@ router.post('/users/:id/force-reset', adminHandler.forceResetUser);
 router.get('/blogs', adminHandler.listAllBlogs);
 router.delete('/blogs/:id', adminHandler.deleteAnyBlog);
 router.get('/blogs/:id', adminHandler.getAnyBlog);
+
+router.get('/plans', planAdminHandler.listAdminPlans);
+router.post('/plans', planAdminHandler.createAdminPlan);
+router.patch('/plans/:id', planAdminHandler.patchAdminPlan);
+router.post('/plans/:id/archive', planAdminHandler.archiveAdminPlan);
+router.post('/plans/:id/set-default', planAdminHandler.setDefaultAdminPlan);
 
 export const adminRoutes = router;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,6 +23,7 @@ import AdminUsersPage from './pages/admin/AdminUsersPage';
 import AdminUserDetailPage from './pages/admin/AdminUserDetailPage';
 import AdminBlogsPage from './pages/admin/AdminBlogsPage';
 import AdminBlogDetailPage from './pages/admin/AdminBlogDetailPage';
+import AdminPlansPage from './pages/admin/AdminPlansPage';
 
 export function App() {
   return (
@@ -73,6 +74,7 @@ export function App() {
                 <Route path="users/:userId" element={<AdminUserDetailPage />} />
                 <Route path="blogs" element={<AdminBlogsPage />} />
                 <Route path="blogs/:blogId" element={<AdminBlogDetailPage />} />
+                <Route path="plans" element={<AdminPlansPage />} />
               </Route>
               <Route path="/admin/profiles" element={<Navigate to="/admin/users" replace />} />
             </Route>

--- a/frontend/src/api/admin-api.ts
+++ b/frontend/src/api/admin-api.ts
@@ -109,3 +109,81 @@ export async function deleteAdminBlog(blogId: string): Promise<{ success: boolea
   const res = await authedFetch(`${BASE}/blogs/${encodeURIComponent(blogId)}`, { method: 'DELETE' });
   return parseJson<{ success: boolean }>(res);
 }
+
+export interface AdminPlanLimits {
+  blogQuota: number | null;
+  aiCheckQuota: number | null;
+  authorProfileLimit: number | null;
+  referenceExtractionQuota: number | null;
+}
+
+export interface AdminPlanRow {
+  id: string;
+  slug: string;
+  name: string;
+  description: string;
+  priceCents: number;
+  currency: string;
+  billingPeriod: string;
+  limits: AdminPlanLimits;
+  isPublic: boolean;
+  isDefault: boolean;
+  archivedAt: string | null;
+  sortOrder: number;
+  createdAt: string;
+  updatedAt: string;
+  activeSubscriberCount: number;
+}
+
+export async function listAdminPlans(): Promise<{ plans: AdminPlanRow[] }> {
+  const res = await authedFetch(`${BASE}/plans`);
+  return parseJson<{ plans: AdminPlanRow[] }>(res);
+}
+
+export type AdminPlanCreatePayload = {
+  name: string;
+  description?: string;
+  priceCents: number;
+  currency?: string;
+  slug?: string;
+  blogQuota?: number | null;
+  aiCheckQuota?: number | null;
+  authorProfileLimit?: number | null;
+  referenceExtractionQuota?: number | null;
+  isPublic?: boolean;
+  sortOrder?: number;
+};
+
+export async function createAdminPlan(payload: AdminPlanCreatePayload): Promise<{ plan: AdminPlanRow }> {
+  const res = await authedFetch(`${BASE}/plans`, { method: 'POST', body: JSON.stringify(payload) });
+  return parseJson<{ plan: AdminPlanRow }>(res);
+}
+
+export type AdminPlanPatchPayload = Partial<AdminPlanCreatePayload>;
+
+export async function patchAdminPlan(
+  planId: string,
+  payload: AdminPlanPatchPayload,
+): Promise<{ plan: AdminPlanRow }> {
+  const res = await authedFetch(`${BASE}/plans/${encodeURIComponent(planId)}`, {
+    method: 'PATCH',
+    body: JSON.stringify(payload),
+  });
+  return parseJson<{ plan: AdminPlanRow }>(res);
+}
+
+export async function archiveAdminPlan(planId: string): Promise<{ plan: AdminPlanRow }> {
+  const res = await authedFetch(`${BASE}/plans/${encodeURIComponent(planId)}/archive`, {
+    method: 'POST',
+    body: '{}',
+  });
+  return parseJson<{ plan: AdminPlanRow }>(res);
+}
+
+export async function setDefaultAdminPlan(planId: string): Promise<{ plan: AdminPlanRow }> {
+  const res = await authedFetch(`${BASE}/plans/${encodeURIComponent(planId)}/set-default`, {
+    method: 'POST',
+    body: '{}',
+  });
+  return parseJson<{ plan: AdminPlanRow }>(res);
+}

--- a/frontend/src/pages/admin/AdminLayout.tsx
+++ b/frontend/src/pages/admin/AdminLayout.tsx
@@ -1,4 +1,4 @@
-import { LayoutDashboard, Users, BookOpen } from 'lucide-react';
+import { LayoutDashboard, Users, BookOpen, Layers } from 'lucide-react';
 import { NavLink, Outlet } from 'react-router-dom';
 import { AppHeader } from '../../components/AppHeader';
 import { Button } from '../../components/ui/button';
@@ -40,6 +40,10 @@ function AdminLayoutInner() {
             <NavLink to="/admin/blogs" className={navLinkClass}>
               <BookOpen className={iconClass} aria-hidden />
               Blogs
+            </NavLink>
+            <NavLink to="/admin/plans" className={navLinkClass}>
+              <Layers className={iconClass} aria-hidden />
+              Plans
             </NavLink>
           </nav>
           <div className="mt-6 hidden border-t border-slate-100 pt-4 lg:block">

--- a/frontend/src/pages/admin/AdminOverviewPage.tsx
+++ b/frontend/src/pages/admin/AdminOverviewPage.tsx
@@ -39,6 +39,14 @@ export default function AdminOverviewPage() {
             <p className="mt-1 text-sm text-slate-600">All drafts and published posts</p>
           </Link>
           <Link
+            to="/admin/plans"
+            className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm transition-shadow hover:shadow-md"
+          >
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Plans</p>
+            <p className="mt-2 text-lg font-semibold text-slate-900">Subscription tiers</p>
+            <p className="mt-1 text-sm text-slate-600">Prices, limits, public & default flags</p>
+          </Link>
+          <Link
             to="/help/ai-detector-rules"
             className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm transition-shadow hover:shadow-md sm:col-span-2 lg:col-span-1"
           >

--- a/frontend/src/pages/admin/AdminPlansPage.tsx
+++ b/frontend/src/pages/admin/AdminPlansPage.tsx
@@ -1,0 +1,383 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  type AdminPlanCreatePayload,
+  type AdminPlanPatchPayload,
+  type AdminPlanRow,
+  archiveAdminPlan,
+  createAdminPlan,
+  listAdminPlans,
+  patchAdminPlan,
+  setDefaultAdminPlan,
+} from '../../api/admin-api';
+import { Button } from '../../components/ui/button';
+import { Field } from '../../components/ui/field';
+import { Input } from '../../components/ui/input';
+import { Textarea } from '../../components/ui/textarea';
+import { Toast } from '../../components/ui/toast';
+
+function fmtLimit(n: number | null): string {
+  if (n === null) return 'Unlimited';
+  return String(n);
+}
+
+function dollarsToCents(s: string): number {
+  const t = s.trim();
+  if (t === '') return 0;
+  const n = Number.parseFloat(t);
+  if (!Number.isFinite(n) || n < 0) throw new Error('Enter a valid price (0 or more)');
+  return Math.round(n * 100);
+}
+
+function centsToDollars(cents: number): string {
+  return (cents / 100).toFixed(2);
+}
+
+function parseLimitInput(raw: string): number | null {
+  const t = raw.trim();
+  if (t === '') return null;
+  const n = Number.parseInt(t, 10);
+  if (!Number.isFinite(n) || n < 0) throw new Error('Limits must be non-negative whole numbers or blank for unlimited');
+  return n;
+}
+
+type ModalState = null | { mode: 'create' } | { mode: 'edit'; plan: AdminPlanRow };
+
+export default function AdminPlansPage() {
+  const [plans, setPlans] = useState<AdminPlanRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [modal, setModal] = useState<ModalState>(null);
+
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [priceDollars, setPriceDollars] = useState('0');
+  const [currency, setCurrency] = useState('USD');
+  const [slug, setSlug] = useState('');
+  const [blogQuota, setBlogQuota] = useState('');
+  const [aiCheckQuota, setAiCheckQuota] = useState('');
+  const [authorProfileLimit, setAuthorProfileLimit] = useState('');
+  const [referenceQuota, setReferenceQuota] = useState('');
+  const [isPublic, setIsPublic] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setError(null);
+    setLoading(true);
+    try {
+      const { plans: rows } = await listAdminPlans();
+      setPlans(rows);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  function openCreate() {
+    setFormError(null);
+    setName('');
+    setDescription('');
+    setPriceDollars('0');
+    setCurrency('USD');
+    setSlug('');
+    setBlogQuota('');
+    setAiCheckQuota('');
+    setAuthorProfileLimit('');
+    setReferenceQuota('');
+    setIsPublic(false);
+    setModal({ mode: 'create' });
+  }
+
+  function openEdit(plan: AdminPlanRow) {
+    setFormError(null);
+    setName(plan.name);
+    setDescription(plan.description);
+    setPriceDollars(centsToDollars(plan.priceCents));
+    setCurrency(plan.currency);
+    setSlug(plan.slug);
+    setBlogQuota(plan.limits.blogQuota === null ? '' : String(plan.limits.blogQuota));
+    setAiCheckQuota(plan.limits.aiCheckQuota === null ? '' : String(plan.limits.aiCheckQuota));
+    setAuthorProfileLimit(plan.limits.authorProfileLimit === null ? '' : String(plan.limits.authorProfileLimit));
+    setReferenceQuota(plan.limits.referenceExtractionQuota === null ? '' : String(plan.limits.referenceExtractionQuota));
+    setIsPublic(plan.isPublic);
+    setModal({ mode: 'edit', plan });
+  }
+
+  function buildPayload(): AdminPlanCreatePayload {
+    const priceCents = dollarsToCents(priceDollars);
+    return {
+      name: name.trim(),
+      description,
+      priceCents,
+      currency: currency.toUpperCase(),
+      slug: slug.trim() || undefined,
+      blogQuota: parseLimitInput(blogQuota),
+      aiCheckQuota: parseLimitInput(aiCheckQuota),
+      authorProfileLimit: parseLimitInput(authorProfileLimit),
+      referenceExtractionQuota: parseLimitInput(referenceQuota),
+      isPublic,
+    };
+  }
+
+  async function handleSubmit() {
+    if (!modal) return;
+    setFormError(null);
+    try {
+      const payload = buildPayload();
+      if (modal?.mode === 'create') {
+        const { plan } = await createAdminPlan(payload);
+        setPlans((prev) => [...prev, plan].sort((a, b) => a.sortOrder - b.sortOrder));
+      } else if (modal?.mode === 'edit') {
+        const patch: AdminPlanPatchPayload = { ...payload };
+        delete (patch as { slug?: string }).slug;
+        if (slug.trim() && slug.trim() !== modal.plan.slug) {
+          (patch as AdminPlanPatchPayload).slug = slug.trim().toLowerCase();
+        }
+        const { plan } = await patchAdminPlan(modal.plan.id, patch);
+        setPlans((prev) => prev.map((p) => (p.id === plan.id ? plan : p)));
+      }
+      setModal(null);
+    } catch (e) {
+      setFormError((e as Error).message);
+    }
+  }
+
+  async function handleArchive(plan: AdminPlanRow) {
+    if (
+      !window.confirm(
+        `Archive plan "${plan.name}"? It will be hidden from the landing page and cannot be subscribed to.`,
+      )
+    ) {
+      return;
+    }
+    setBusyId(plan.id);
+    setError(null);
+    try {
+      const { plan: updated } = await archiveAdminPlan(plan.id);
+      setPlans((prev) => prev.map((p) => (p.id === updated.id ? updated : p)));
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function handleSetDefault(plan: AdminPlanRow) {
+    if (!window.confirm(`Set "${plan.name}" as the default plan for new signups?`)) return;
+    setBusyId(plan.id);
+    setError(null);
+    try {
+      const { plan: updated } = await setDefaultAdminPlan(plan.id);
+      setPlans((prev) =>
+        prev.map((p) => ({
+          ...p,
+          isDefault: p.id === updated.id,
+        })),
+      );
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  return (
+    <div>
+      <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight text-slate-900">Subscription plans</h1>
+          <p className="mt-1 text-sm text-slate-600">
+            Create and edit tiers, limits, and visibility.{' '}
+            <Link to="/admin" className="font-medium text-indigo-600 hover:text-indigo-500">
+              Admin home
+            </Link>
+          </p>
+        </div>
+        <Button type="button" size="sm" onClick={openCreate}>
+          New plan
+        </Button>
+      </div>
+
+      {error && (
+        <div className="mb-4">
+          <Toast variant="error">{error}</Toast>
+        </div>
+      )}
+
+      {loading && plans.length === 0 ? (
+        <p className="text-center text-slate-500">Loading plans…</p>
+      ) : (
+        <section className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm sm:p-6">
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-slate-200 text-left text-sm">
+              <caption className="sr-only">Subscription plans</caption>
+              <thead className="bg-slate-50 text-xs font-semibold uppercase tracking-wide text-slate-600">
+                <tr>
+                  <th className="px-3 py-2">Plan</th>
+                  <th className="px-3 py-2">Slug</th>
+                  <th className="px-3 py-2">Price</th>
+                  <th className="px-3 py-2">Limits</th>
+                  <th className="px-3 py-2">Flags</th>
+                  <th className="px-3 py-2">Subscribers</th>
+                  <th className="px-3 py-2">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100">
+                {plans.map((p) => {
+                  const archived = Boolean(p.archivedAt);
+                  const busy = busyId === p.id;
+                  return (
+                    <tr key={p.id} className={archived ? 'bg-slate-50 text-slate-500' : 'hover:bg-slate-50/80'}>
+                      <td className="px-3 py-3 font-medium text-slate-900">{p.name}</td>
+                      <td className="px-3 py-3 font-mono text-xs text-slate-600">{p.slug}</td>
+                      <td className="px-3 py-3 text-slate-600">
+                        {(p.priceCents / 100).toFixed(2)} {p.currency}
+                      </td>
+                      <td className="max-w-[220px] px-3 py-3 text-xs text-slate-600">
+                        blogs {fmtLimit(p.limits.blogQuota)}, AI {fmtLimit(p.limits.aiCheckQuota)}, profiles{' '}
+                        {fmtLimit(p.limits.authorProfileLimit)}, refs {fmtLimit(p.limits.referenceExtractionQuota)}
+                      </td>
+                      <td className="px-3 py-3">
+                        <div className="flex flex-wrap gap-1">
+                          {p.isDefault && (
+                            <span className="rounded-full bg-indigo-100 px-2 py-0.5 text-xs text-indigo-800">
+                              Default
+                            </span>
+                          )}
+                          {p.isPublic && !archived && (
+                            <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-xs text-emerald-800">
+                              Public
+                            </span>
+                          )}
+                          {archived && (
+                            <span className="rounded-full bg-slate-200 px-2 py-0.5 text-xs text-slate-700">
+                              Archived
+                            </span>
+                          )}
+                        </div>
+                      </td>
+                      <td className="px-3 py-3 text-slate-600">{p.activeSubscriberCount}</td>
+                      <td className="px-3 py-3">
+                        <div className="flex flex-wrap gap-2">
+                          {!archived && (
+                            <Button variant="ghost" size="sm" type="button" onClick={() => openEdit(p)} disabled={busy}>
+                              Edit
+                            </Button>
+                          )}
+                          {!archived && !p.isDefault && (
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              type="button"
+                              onClick={() => void handleSetDefault(p)}
+                              disabled={busy}
+                            >
+                              Set default
+                            </Button>
+                          )}
+                          {!archived && !p.isDefault && (
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              type="button"
+                              className="text-red-600 hover:text-red-700"
+                              onClick={() => void handleArchive(p)}
+                              disabled={busy}
+                            >
+                              Archive
+                            </Button>
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+
+      {modal && (
+        <div
+          className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 p-4 sm:items-center"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="plan-form-title"
+        >
+          <div className="max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-2xl bg-white p-6 shadow-xl">
+            <h2 id="plan-form-title" className="text-lg font-semibold text-slate-900">
+              {modal.mode === 'create' ? 'New plan' : `Edit plan`}
+            </h2>
+            {formError && (
+              <div className="mt-3">
+                <Toast variant="error">{formError}</Toast>
+              </div>
+            )}
+            <div className="mt-4 space-y-4">
+              <Field label="Name">
+                <Input value={name} onChange={(e) => setName(e.target.value)} autoComplete="off" />
+              </Field>
+              <Field label="Description">
+                <Textarea value={description} onChange={(e) => setDescription(e.target.value)} rows={3} />
+              </Field>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <Field label="Price (per month, display only)">
+                  <Input
+                    value={priceDollars}
+                    onChange={(e) => setPriceDollars(e.target.value)}
+                    inputMode="decimal"
+                    placeholder="0.00"
+                  />
+                </Field>
+                <Field label="Currency (ISO)">
+                  <Input value={currency} onChange={(e) => setCurrency(e.target.value)} maxLength={3} />
+                </Field>
+              </div>
+              <Field label="Slug (optional — auto from name if empty on create)">
+                <Input value={slug} onChange={(e) => setSlug(e.target.value)} className="font-mono text-sm" />
+              </Field>
+              <p className="text-xs text-slate-500">Leave limits blank for unlimited. Whole numbers only.</p>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <Field label="Blogs / month">
+                  <Input value={blogQuota} onChange={(e) => setBlogQuota(e.target.value)} inputMode="numeric" />
+                </Field>
+                <Field label="AI checks / month">
+                  <Input value={aiCheckQuota} onChange={(e) => setAiCheckQuota(e.target.value)} inputMode="numeric" />
+                </Field>
+                <Field label="Author profiles (total)">
+                  <Input
+                    value={authorProfileLimit}
+                    onChange={(e) => setAuthorProfileLimit(e.target.value)}
+                    inputMode="numeric"
+                  />
+                </Field>
+                <Field label="Reference extractions / month">
+                  <Input value={referenceQuota} onChange={(e) => setReferenceQuota(e.target.value)} inputMode="numeric" />
+                </Field>
+              </div>
+              <label className="flex items-center gap-2 text-sm text-slate-700">
+                <input type="checkbox" checked={isPublic} onChange={(e) => setIsPublic(e.target.checked)} />
+                Public (shown on landing & self-serve when wired)
+              </label>
+            </div>
+            <div className="mt-6 flex justify-end gap-2">
+              <Button variant="ghost" type="button" onClick={() => setModal(null)}>
+                Cancel
+              </Button>
+              <Button type="button" onClick={() => void handleSubmit()}>
+                Save
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Implements **US-SUB-01 / US-SUB-02 / US-SUB-03**: admin-managed subscription plan catalogue (API + UI).

### Backend
- `GET /api/admin/plans` — list all plans with active subscriber counts
- `POST /api/admin/plans` — create plan (optional slug; defaults private; limits nullable = unlimited)
- `PATCH /api/admin/plans/:id` — edit fields; slug change blocked when plan has active subscribers
- `POST /api/admin/plans/:id/archive` — soft-archive (blocks default plan & plans with subscribers)
- `POST /api/admin/plans/:id/set-default` — move default flag
- Extended `plan-repository` with insert, update, clear/set default helpers

### Frontend
- **Admin → Plans** sidebar + `/admin/plans` route
- `AdminPlansPage` — table, create/edit modal, archive & set-default actions
- Overview dashboard card

### Testing
- `npm run typecheck` + `npm run test` (backend)
- `npm run build` (frontend)

### Tracker
- https://github.com/mohamednaseramein/blog-generator/issues/155

## Glossary

| Term | Definition |
|------|------------|
| Plan catalogue | Admin-editable rows in `plans`: price (display-only), four nullable limit columns (null = unlimited), public/default/archived flags |
| Soft-archive | Set `archived_at`; plan hidden from public list; row retained for history |
| Default plan | Exactly one non-archived plan with `is_default`; new signups subscribe via existing DB trigger |
| Active subscriber | `subscriptions` row with `status = active` for that `plan_id` |

Made with [Cursor](https://cursor.com)