### PR TITLE
feat(#150): admin plan catalogue UX, tests, and user plan column

### DIFF
--- a/backend/src/handlers/__tests__/plan-admin-handler.test.ts
+++ b/backend/src/handlers/__tests__/plan-admin-handler.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Request, Response, NextFunction } from 'express';
+import type { Plan } from '../../domain/subscription-types.js';
+import {
+  createAdminPlan,
+  archiveAdminPlan,
+  patchAdminPlan,
+  setDefaultAdminPlan,
+} from '../plan-admin-handler.js';
+import * as repo from '../../repositories/plan-repository.js';
+
+vi.mock('../../repositories/plan-repository.js');
+
+const BASE_PLAN: Plan = {
+  id: 'plan-1',
+  slug: 'pro',
+  name: 'Pro',
+  description: 'For creators',
+  priceCents: 1900,
+  currency: 'USD',
+  billingPeriod: 'monthly',
+  limits: {
+    blogQuota: 50,
+    aiCheckQuota: 200,
+    authorProfileLimit: 10,
+    referenceExtractionQuota: 300,
+  },
+  isPublic: true,
+  isDefault: false,
+  archivedAt: null,
+  sortOrder: 2,
+  createdAt: new Date('2026-05-14T00:00:00Z'),
+  updatedAt: new Date('2026-05-14T00:00:00Z'),
+};
+
+function makeReq(body: unknown = {}, params: Record<string, string> = {}): Request {
+  return { body, params } as unknown as Request;
+}
+
+function makeRes(): { res: Response; json: ReturnType<typeof vi.fn>; status: ReturnType<typeof vi.fn> } {
+  const json = vi.fn();
+  const status = vi.fn().mockReturnThis();
+  const res = { json, status, send: vi.fn() } as unknown as Response;
+  return { res, json, status };
+}
+
+const next: NextFunction = vi.fn();
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('createAdminPlan', () => {
+  it('rejects missing name', async () => {
+    const { res } = makeRes();
+    await createAdminPlan(makeReq({ priceCents: 0 }), res, next);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 400 }));
+  });
+
+  it('creates a plan with 201', async () => {
+    vi.mocked(repo.listAllPlans).mockResolvedValue([BASE_PLAN]);
+    vi.mocked(repo.getPlanBySlug).mockResolvedValue(null);
+    vi.mocked(repo.insertPlan).mockResolvedValue({ ...BASE_PLAN, id: 'new-id', slug: 'new-plan' });
+    vi.mocked(repo.countActiveSubscribersForPlan).mockResolvedValue(0);
+
+    const { res, status, json } = makeRes();
+    await createAdminPlan(
+      makeReq({
+        name: 'Starter',
+        description: 'Hi',
+        priceCents: 0,
+        blogQuota: null,
+        aiCheckQuota: 10,
+      }),
+      res,
+      next,
+    );
+
+    expect(status).toHaveBeenCalledWith(201);
+    expect(repo.insertPlan).toHaveBeenCalled();
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        plan: expect.objectContaining({ slug: 'new-plan', activeSubscriberCount: 0 }),
+      }),
+    );
+  });
+});
+
+describe('archiveAdminPlan', () => {
+  it('refuses when plan is default', async () => {
+    vi.mocked(repo.getPlanById).mockResolvedValue({ ...BASE_PLAN, isDefault: true });
+    await archiveAdminPlan(makeReq({}, { id: 'plan-1' }), makeRes().res, next);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 409, code: 'DEFAULT_PLAN' }));
+  });
+
+  it('refuses when there are active subscribers', async () => {
+    vi.mocked(repo.getPlanById).mockResolvedValue(BASE_PLAN);
+    vi.mocked(repo.countActiveSubscribersForPlan).mockResolvedValue(2);
+    await archiveAdminPlan(makeReq({}, { id: 'plan-1' }), makeRes().res, next);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 409, code: 'HAS_SUBSCRIBERS' }));
+  });
+
+  it('archives when allowed', async () => {
+    vi.mocked(repo.getPlanById).mockResolvedValue(BASE_PLAN);
+    vi.mocked(repo.countActiveSubscribersForPlan).mockResolvedValue(0);
+    const archived = {
+      ...BASE_PLAN,
+      archivedAt: new Date('2026-05-14T12:00:00Z'),
+      isPublic: false,
+      isDefault: false,
+    };
+    vi.mocked(repo.updatePlanById).mockResolvedValue(archived);
+    vi.mocked(repo.countActiveSubscribersForPlan).mockResolvedValueOnce(0).mockResolvedValueOnce(0);
+
+    const { res, json } = makeRes();
+    await archiveAdminPlan(makeReq({}, { id: 'plan-1' }), res, next);
+
+    expect(repo.updatePlanById).toHaveBeenCalledWith(
+      'plan-1',
+      expect.objectContaining({ archived_at: expect.any(String), is_public: false, is_default: false }),
+    );
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({ plan: expect.objectContaining({ archivedAt: expect.any(String) }) }),
+    );
+  });
+});
+
+describe('patchAdminPlan', () => {
+  it('blocks slug change when there are active subscribers', async () => {
+    vi.mocked(repo.getPlanById).mockResolvedValue(BASE_PLAN);
+    vi.mocked(repo.countActiveSubscribersForPlan).mockResolvedValue(1);
+
+    await patchAdminPlan(
+      makeReq({ slug: 'new-slug', name: 'Pro' }, { id: 'plan-1' }),
+      makeRes().res,
+      next,
+    );
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 409, code: 'SLUG_LOCKED' }));
+  });
+});
+
+describe('setDefaultAdminPlan', () => {
+  it('sets default and returns JSON', async () => {
+    vi.mocked(repo.getPlanById).mockResolvedValue(BASE_PLAN);
+    const updated = { ...BASE_PLAN, isDefault: true };
+    vi.mocked(repo.setPlanDefault).mockResolvedValue(updated);
+    vi.mocked(repo.countActiveSubscribersForPlan).mockResolvedValue(3);
+
+    const { res, json } = makeRes();
+    await setDefaultAdminPlan(makeReq({}, { id: 'plan-1' }), res, next);
+
+    expect(repo.setPlanDefault).toHaveBeenCalledWith('plan-1');
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        plan: expect.objectContaining({ id: 'plan-1', isDefault: true, activeSubscriberCount: 3 }),
+      }),
+    );
+  });
+});

--- a/backend/src/handlers/admin-handler.ts
+++ b/backend/src/handlers/admin-handler.ts
@@ -37,6 +37,30 @@ export async function listUsers(req: Request, res: Response) {
 
     const userMap = new Map((publicUsers as { id: string }[]).map((u) => [u.id, u]));
 
+    const { data: activeSubs, error: subsError } = await supabase
+      .from('subscriptions')
+      .select('user_id, plan_id')
+      .eq('status', 'active');
+    if (subsError) throw subsError;
+
+    const planIds = [...new Set((activeSubs ?? []).map((s) => (s as { plan_id: string }).plan_id))];
+    const planNameById = new Map<string, string>();
+    if (planIds.length > 0) {
+      const { data: planRows, error: plansError } = await supabase.from('plans').select('id, name').in('id', planIds);
+      if (plansError) throw plansError;
+      for (const row of planRows ?? []) {
+        const pr = row as { id: string; name: string };
+        planNameById.set(pr.id, pr.name);
+      }
+    }
+
+    const planNameByUserId = new Map<string, string>();
+    for (const row of activeSubs ?? []) {
+      const s = row as { user_id: string; plan_id: string };
+      const name = planNameById.get(s.plan_id);
+      if (name) planNameByUserId.set(s.user_id, name);
+    }
+
     const users = authUsers.map((u) => {
       const p = (userMap.get(u.id) ?? {}) as Record<string, unknown>;
       return {
@@ -47,6 +71,7 @@ export async function listUsers(req: Request, res: Response) {
         deactivated_at: (p['deactivated_at'] as string | null) ?? null,
         created_at: (p['created_at'] as string | null) ?? u.created_at,
         last_sign_in_at: u.last_sign_in_at ?? null,
+        plan_name: planNameByUserId.get(u.id) ?? null,
       };
     });
 

--- a/frontend/src/api/admin-api.ts
+++ b/frontend/src/api/admin-api.ts
@@ -11,6 +11,8 @@ export interface AdminUserRow {
   deactivated_at: string | null;
   created_at: string | null;
   last_sign_in_at: string | null;
+  /** Display name of the user's active subscription plan, or null if none. */
+  plan_name: string | null;
 }
 
 export interface AdminBlogRow {

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -2,7 +2,7 @@ import { type ButtonHTMLAttributes } from 'react';
 import { clsx } from 'clsx';
 
 interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: 'primary' | 'ghost';
+  variant?: 'primary' | 'ghost' | 'google';
   size?: 'sm' | 'md';
 }
 
@@ -11,9 +11,12 @@ export function Button({ variant = 'primary', size = 'md', className, children, 
     <button
       {...props}
       className={clsx(
-        'inline-flex items-center justify-center rounded-lg font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 disabled:pointer-events-none disabled:opacity-50',
-        variant === 'primary' && 'bg-indigo-600 text-white hover:bg-indigo-700 active:bg-indigo-800',
-        variant === 'ghost' && 'text-slate-600 hover:bg-slate-100 hover:text-slate-900',
+        'inline-flex items-center justify-center rounded-lg font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50',
+        variant === 'primary' &&
+          'bg-indigo-600 text-white hover:bg-indigo-700 active:bg-indigo-800 focus-visible:ring-indigo-500',
+        variant === 'ghost' && 'text-slate-600 hover:bg-slate-100 hover:text-slate-900 focus-visible:ring-indigo-500',
+        variant === 'google' &&
+          'border border-[#EA8600] bg-[#FBBC05] text-[#202124] shadow-sm hover:bg-[#F5A623] hover:border-[#D97706] active:bg-[#EA8600] focus-visible:ring-amber-500',
         size === 'md' && 'h-10 px-5 text-sm',
         size === 'sm' && 'h-8 px-3 text-xs',
         className,

--- a/frontend/src/pages/admin/AdminPlansPage.tsx
+++ b/frontend/src/pages/admin/AdminPlansPage.tsx
@@ -41,6 +41,51 @@ function parseLimitInput(raw: string): number | null {
   return n;
 }
 
+/** `null` = unlimited. Higher rank means a more permissive cap for comparison. */
+function limitRank(value: number | null): number {
+  return value === null ? Number.POSITIVE_INFINITY : value;
+}
+
+function isStrictlyLowerLimit(prev: number | null, next: number | null): boolean {
+  return limitRank(next) < limitRank(prev);
+}
+
+function tryParseLimitInput(raw: string): number | null | undefined {
+  const t = raw.trim();
+  if (t === '') return null;
+  const n = Number.parseInt(t, 10);
+  if (!Number.isFinite(n) || n < 0) return undefined;
+  return n;
+}
+
+function parseSortOrderStr(raw: string): number | undefined {
+  const t = raw.trim();
+  if (t === '') return undefined;
+  const n = Number.parseInt(t, 10);
+  if (!Number.isFinite(n) || n < 0 || n > 32767) {
+    throw new Error('Display order must be a whole number from 0 to 32767');
+  }
+  return n;
+}
+
+function loweredLimitLabels(plan: AdminPlanRow, fields: { blog: string; ai: string; profiles: string; refs: string }): string[] {
+  if (plan.activeSubscriberCount <= 0) return [];
+  const nextBlog = tryParseLimitInput(fields.blog);
+  const nextAi = tryParseLimitInput(fields.ai);
+  const nextProfiles = tryParseLimitInput(fields.profiles);
+  const nextRefs = tryParseLimitInput(fields.refs);
+  const out: string[] = [];
+  if (nextBlog !== undefined && isStrictlyLowerLimit(plan.limits.blogQuota, nextBlog)) out.push('blogs per month');
+  if (nextAi !== undefined && isStrictlyLowerLimit(plan.limits.aiCheckQuota, nextAi)) out.push('AI checks per month');
+  if (nextProfiles !== undefined && isStrictlyLowerLimit(plan.limits.authorProfileLimit, nextProfiles)) {
+    out.push('author profiles');
+  }
+  if (nextRefs !== undefined && isStrictlyLowerLimit(plan.limits.referenceExtractionQuota, nextRefs)) {
+    out.push('reference extractions per month');
+  }
+  return out;
+}
+
 type ModalState = null | { mode: 'create' } | { mode: 'edit'; plan: AdminPlanRow };
 
 export default function AdminPlansPage() {
@@ -60,6 +105,7 @@ export default function AdminPlansPage() {
   const [authorProfileLimit, setAuthorProfileLimit] = useState('');
   const [referenceQuota, setReferenceQuota] = useState('');
   const [isPublic, setIsPublic] = useState(false);
+  const [sortOrderStr, setSortOrderStr] = useState('');
   const [formError, setFormError] = useState<string | null>(null);
 
   const load = useCallback(async () => {
@@ -91,6 +137,7 @@ export default function AdminPlansPage() {
     setAuthorProfileLimit('');
     setReferenceQuota('');
     setIsPublic(false);
+    setSortOrderStr('');
     setModal({ mode: 'create' });
   }
 
@@ -106,11 +153,13 @@ export default function AdminPlansPage() {
     setAuthorProfileLimit(plan.limits.authorProfileLimit === null ? '' : String(plan.limits.authorProfileLimit));
     setReferenceQuota(plan.limits.referenceExtractionQuota === null ? '' : String(plan.limits.referenceExtractionQuota));
     setIsPublic(plan.isPublic);
+    setSortOrderStr(String(plan.sortOrder));
     setModal({ mode: 'edit', plan });
   }
 
   function buildPayload(): AdminPlanCreatePayload {
     const priceCents = dollarsToCents(priceDollars);
+    const sortOrder = parseSortOrderStr(sortOrderStr);
     return {
       name: name.trim(),
       description,
@@ -122,6 +171,7 @@ export default function AdminPlansPage() {
       authorProfileLimit: parseLimitInput(authorProfileLimit),
       referenceExtractionQuota: parseLimitInput(referenceQuota),
       isPublic,
+      ...(sortOrder !== undefined ? { sortOrder } : {}),
     };
   }
 
@@ -130,13 +180,27 @@ export default function AdminPlansPage() {
     setFormError(null);
     try {
       const payload = buildPayload();
+      if (modal.mode === 'edit') {
+        const lowered = loweredLimitLabels(modal.plan, {
+          blog: blogQuota,
+          ai: aiCheckQuota,
+          profiles: authorProfileLimit,
+          refs: referenceQuota,
+        });
+        if (lowered.length > 0) {
+          const ok = window.confirm(
+            `You are lowering: ${lowered.join(', ')}. Subscribers on this plan keep grandfathered limits until the next billing period; higher limits still apply immediately. Continue?`,
+          );
+          if (!ok) return;
+        }
+      }
       if (modal?.mode === 'create') {
         const { plan } = await createAdminPlan(payload);
         setPlans((prev) => [...prev, plan].sort((a, b) => a.sortOrder - b.sortOrder));
       } else if (modal?.mode === 'edit') {
         const patch: AdminPlanPatchPayload = { ...payload };
         delete (patch as { slug?: string }).slug;
-        if (slug.trim() && slug.trim() !== modal.plan.slug) {
+        if (slug.trim() && slug.trim().toLowerCase() !== modal.plan.slug) {
           (patch as AdminPlanPatchPayload).slug = slug.trim().toLowerCase();
         }
         const { plan } = await patchAdminPlan(modal.plan.id, patch);
@@ -180,12 +244,23 @@ export default function AdminPlansPage() {
           isDefault: p.id === updated.id,
         })),
       );
+      void load();
     } catch (e) {
       setError((e as Error).message);
     } finally {
       setBusyId(null);
     }
   }
+
+  const loweredSubscriberLabels =
+    modal?.mode === 'edit'
+      ? loweredLimitLabels(modal.plan, {
+          blog: blogQuota,
+          ai: aiCheckQuota,
+          profiles: authorProfileLimit,
+          refs: referenceQuota,
+        })
+      : [];
 
   return (
     <div>
@@ -320,6 +395,14 @@ export default function AdminPlansPage() {
                 <Toast variant="error">{formError}</Toast>
               </div>
             )}
+            {loweredSubscriberLabels.length > 0 && (
+              <div className="mt-3">
+                <Toast variant="info">
+                  You are lowering: {loweredSubscriberLabels.join(', ')}. Current subscribers keep grandfathered limits
+                  until the next billing period; higher limits still apply immediately.
+                </Toast>
+              </div>
+            )}
             <div className="mt-4 space-y-4">
               <Field label="Name">
                 <Input value={name} onChange={(e) => setName(e.target.value)} autoComplete="off" />
@@ -341,8 +424,28 @@ export default function AdminPlansPage() {
                 </Field>
               </div>
               <Field label="Slug (optional — auto from name if empty on create)">
-                <Input value={slug} onChange={(e) => setSlug(e.target.value)} className="font-mono text-sm" />
+                <Input
+                  value={slug}
+                  onChange={(e) => setSlug(e.target.value)}
+                  className="font-mono text-sm"
+                  readOnly={modal.mode === 'edit' && modal.plan.activeSubscriberCount > 0}
+                  aria-readonly={modal.mode === 'edit' && modal.plan.activeSubscriberCount > 0 ? true : undefined}
+                />
               </Field>
+              {modal.mode === 'edit' && modal.plan.activeSubscriberCount > 0 && (
+                <p className="text-xs text-slate-600">Slug cannot change while this plan has active subscribers.</p>
+              )}
+              <Field label="Display order">
+                <Input
+                  value={sortOrderStr}
+                  onChange={(e) => setSortOrderStr(e.target.value)}
+                  inputMode="numeric"
+                  placeholder={modal.mode === 'create' ? 'Auto when blank' : undefined}
+                />
+              </Field>
+              <p className="text-xs text-slate-500">
+                Lower numbers sort first (0–32767). Leave blank on create to append after existing plans.
+              </p>
               <p className="text-xs text-slate-500">Leave limits blank for unlimited. Whole numbers only.</p>
               <div className="grid gap-4 sm:grid-cols-2">
                 <Field label="Blogs / month">

--- a/frontend/src/pages/admin/AdminUsersPage.tsx
+++ b/frontend/src/pages/admin/AdminUsersPage.tsx
@@ -1,7 +1,5 @@
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { useAdminDashboard } from './admin-context';
-import { AdminUserPanel } from '../../components/AdminUserPanel';
-import { AdminUserActions } from '../../components/AdminUserActions';
 import { Button } from '../../components/ui/button';
 
 function fmtDate(iso: string | null | undefined): string {
@@ -14,29 +12,14 @@ function fmtDate(iso: string | null | undefined): string {
 }
 
 export default function AdminUsersPage() {
-  const navigate = useNavigate();
-  const {
-    me,
-    users,
-    loading,
-    blogCounts,
-    busyUserId,
-    confirmAndRun,
-    runAction,
-    load,
-    setUserFilter,
-    setManagedUser,
-    setNotice,
-    managedUserId,
-    managedUserLabel,
-  } = useAdminDashboard();
+  const { users, loading, blogCounts, load } = useAdminDashboard();
 
   return (
     <div>
       <div className="mb-8">
         <h1 className="text-2xl font-bold tracking-tight text-slate-900">Users and roles</h1>
         <p className="mt-1 text-sm text-slate-600">
-          Promote or demote administrators, deactivate or reactivate sign-in, or send a password reset email.
+          View subscription plans per user. Open user details to promote or demote admins, deactivate accounts, or send a password reset.
         </p>
       </div>
 
@@ -51,27 +34,26 @@ export default function AdminUsersPage() {
           </div>
           <div className="overflow-x-auto">
             <table className="min-w-full divide-y divide-slate-200 text-left text-sm">
-              <caption className="sr-only">Registered users and administration actions</caption>
+              <caption className="sr-only">Registered users and subscription plans</caption>
               <thead className="bg-slate-50 text-xs font-semibold uppercase tracking-wide text-slate-600">
                 <tr>
                   <th className="px-3 py-2">Email</th>
                   <th className="px-3 py-2">Role</th>
                   <th className="px-3 py-2">Account</th>
+                  <th className="px-3 py-2">Plan</th>
                   <th className="px-3 py-2">Blogs</th>
                   <th className="px-3 py-2">Created</th>
                   <th className="px-3 py-2">Last sign-in</th>
                   <th className="px-3 py-2">View</th>
-                  <th className="px-3 py-2">Actions</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-slate-100">
                 {users.map((u) => {
                   const isDeactivated = Boolean(u.deactivated_at);
                   const blogCount = blogCounts.get(u.id) ?? 0;
-                  const label = u.email ?? u.id;
                   return (
                     <tr key={u.id} className="hover:bg-slate-50/80">
-                      <td className="whitespace-nowrap px-3 py-3 font-medium text-slate-900">{label}</td>
+                      <td className="whitespace-nowrap px-3 py-3 font-medium text-slate-900">{u.email ?? u.id}</td>
                       <td className="px-3 py-3">
                         <span
                           className={
@@ -90,6 +72,7 @@ export default function AdminUsersPage() {
                           <span className="text-emerald-800">Active</span>
                         )}
                       </td>
+                      <td className="px-3 py-3 text-slate-700">{u.plan_name ?? '—'}</td>
                       <td className="px-3 py-3 text-slate-600">{blogCount}</td>
                       <td className="px-3 py-3 text-slate-600">{fmtDate(u.created_at)}</td>
                       <td className="px-3 py-3 text-slate-600">{fmtDate(u.last_sign_in_at)}</td>
@@ -101,19 +84,6 @@ export default function AdminUsersPage() {
                           Details
                         </Link>
                       </td>
-                      <td className="px-3 py-3">
-                        <AdminUserActions
-                          u={u}
-                          me={me}
-                          busyUserId={busyUserId}
-                          confirmAndRun={confirmAndRun}
-                          runAction={runAction}
-                          navigate={navigate}
-                          setUserFilter={setUserFilter}
-                          setManagedUser={setManagedUser}
-                          mode="overlay"
-                        />
-                      </td>
                     </tr>
                   );
                 })}
@@ -121,18 +91,6 @@ export default function AdminUsersPage() {
             </table>
           </div>
         </section>
-      )}
-
-      {managedUserId && (
-        <AdminUserPanel
-          userId={managedUserId}
-          userLabel={managedUserLabel}
-          onClose={() => setManagedUser(null)}
-          onSaved={() => {
-            void load({ keepNotice: true });
-            setNotice({ variant: 'success', text: 'Profile saved. Lists refreshed.' });
-          }}
-        />
       )}
     </div>
   );

--- a/frontend/src/pages/auth/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage.tsx
@@ -129,7 +129,7 @@ export default function LoginPage() {
             </div>
 
             <div className="mt-6 space-y-3">
-              <Button type="button" className="w-full" variant="ghost" disabled={loading} onClick={() => void handleGoogleLogin()}>
+              <Button type="button" className="w-full" variant="google" disabled={loading} onClick={() => void handleGoogleLogin()}>
                 Continue with Google
               </Button>
 

--- a/frontend/src/pages/auth/RegisterPage.tsx
+++ b/frontend/src/pages/auth/RegisterPage.tsx
@@ -152,7 +152,7 @@ export default function RegisterPage() {
               <Button
                 type="button"
                 className="w-full"
-                variant="ghost"
+                variant="google"
                 disabled={loading}
                 onClick={() => void handleGoogleSignUp()}
               >


### PR DESCRIPTION
## Summary

Completes the admin subscription plan catalogue work for [issue #150](https://github.com/mohamednaseramein/blog-generator/issues/150): richer **AdminPlans** modal (display order, grandfathering notice + confirm when lowering limits for subscribed plans, slug read-only when subscribers exist), **Vitest** coverage for plan admin handlers, **admin users** table shows active **plan name** with row actions consolidated on the user detail page, and a dedicated **Google** button variant on login/register.

## Testing

- `npm run test --workspace=backend -- --run` (152 tests)
- `npm run typecheck --workspace=frontend` and `npm run typecheck --workspace=backend`

## Glossary

- **Grandfathering**: When a plan limit is lowered, existing subscribers keep the prior cap until the next billing period; increases apply immediately.
- **Plan slug**: Stable identifier for a plan; immutable in the API once the plan has active subscribers.
- **Rex / CEO markers**: Local session files used by merge gates to bind approval to a specific commit SHA.

Made with [Cursor](https://cursor.com)