### PR TITLE
test(#150): expand plan admin handler coverage

### DIFF
--- a/backend/src/handlers/__tests__/plan-admin-handler.test.ts
+++ b/backend/src/handlers/__tests__/plan-admin-handler.test.ts
@@ -53,7 +53,12 @@ describe('createAdminPlan', () => {
   it('rejects missing name', async () => {
     const { res } = makeRes();
     await createAdminPlan(makeReq({ priceCents: 0 }), res, next);
-    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 400 }));
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 400, code: 'VALIDATION' }));
+  });
+
+  it('rejects non-integer priceCents', async () => {
+    await createAdminPlan(makeReq({ name: 'Bad', priceCents: 9.99 }), makeRes().res, next);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 400, code: 'VALIDATION' }));
   });
 
   it('rejects negative priceCents', async () => {

--- a/backend/src/handlers/__tests__/plan-admin-handler.test.ts
+++ b/backend/src/handlers/__tests__/plan-admin-handler.test.ts
@@ -4,6 +4,7 @@ import type { Plan } from '../../domain/subscription-types.js';
 import {
   createAdminPlan,
   archiveAdminPlan,
+  listAdminPlans,
   patchAdminPlan,
   setDefaultAdminPlan,
 } from '../plan-admin-handler.js';
@@ -53,6 +54,21 @@ describe('createAdminPlan', () => {
     const { res } = makeRes();
     await createAdminPlan(makeReq({ priceCents: 0 }), res, next);
     expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 400 }));
+  });
+
+  it('rejects negative priceCents', async () => {
+    await createAdminPlan(makeReq({ name: 'Bad', priceCents: -1 }), makeRes().res, next);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 400, code: 'VALIDATION' }));
+  });
+
+  it('rejects non-integer blogQuota', async () => {
+    await createAdminPlan(makeReq({ name: 'Bad', priceCents: 0, blogQuota: 1.5 }), makeRes().res, next);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 400, code: 'VALIDATION' }));
+  });
+
+  it('rejects negative blogQuota', async () => {
+    await createAdminPlan(makeReq({ name: 'Bad', priceCents: 0, blogQuota: -1 }), makeRes().res, next);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 400, code: 'VALIDATION' }));
   });
 
   it('creates a plan with 201', async () => {
@@ -123,7 +139,31 @@ describe('archiveAdminPlan', () => {
   });
 });
 
+describe('listAdminPlans', () => {
+  it('returns plans with subscriber counts', async () => {
+    vi.mocked(repo.listAllPlans).mockResolvedValue([BASE_PLAN]);
+    vi.mocked(repo.countActiveSubscribersForPlan).mockResolvedValue(4);
+
+    const { res, json } = makeRes();
+    await listAdminPlans(makeReq(), res, next);
+
+    expect(json).toHaveBeenCalledWith({
+      plans: [expect.objectContaining({ id: 'plan-1', activeSubscriberCount: 4 })],
+    });
+  });
+});
+
 describe('patchAdminPlan', () => {
+  it('rejects edits to an archived plan', async () => {
+    vi.mocked(repo.getPlanById).mockResolvedValue({
+      ...BASE_PLAN,
+      archivedAt: new Date('2026-05-14T12:00:00Z'),
+    });
+
+    await patchAdminPlan(makeReq({ name: 'Renamed' }, { id: 'plan-1' }), makeRes().res, next);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 400, code: 'ARCHIVED' }));
+  });
+
   it('blocks slug change when there are active subscribers', async () => {
     vi.mocked(repo.getPlanById).mockResolvedValue(BASE_PLAN);
     vi.mocked(repo.countActiveSubscribersForPlan).mockResolvedValue(1);
@@ -138,6 +178,16 @@ describe('patchAdminPlan', () => {
 });
 
 describe('setDefaultAdminPlan', () => {
+  it('refuses when plan is archived', async () => {
+    vi.mocked(repo.getPlanById).mockResolvedValue({
+      ...BASE_PLAN,
+      archivedAt: new Date('2026-05-14T12:00:00Z'),
+    });
+
+    await setDefaultAdminPlan(makeReq({}, { id: 'plan-1' }), makeRes().res, next);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 400, code: 'ARCHIVED' }));
+  });
+
   it('sets default and returns JSON', async () => {
     vi.mocked(repo.getPlanById).mockResolvedValue(BASE_PLAN);
     const updated = { ...BASE_PLAN, isDefault: true };


### PR DESCRIPTION
## Summary

Completes remaining test coverage for the admin plan catalogue handlers ([#150](https://github.com/mohamednaseramein/blog-generator/issues/150)):

- Validation tests for negative and non-integer limits on create
- `listAdminPlans` returns plans with subscriber counts
- Guards for editing or setting default on archived plans

## Test plan

- [x] `npm run test --workspace=backend -- --run plan-admin` (13 tests)
- [x] `npm run test --workspace=backend -- --run`
- [x] `npm run typecheck --workspace=backend`

## Glossary

- **Plan admin handler**: Express handlers backing `GET/POST/PATCH /admin/plans` and archive/set-default actions.
- **Grandfathering**: When a plan limit is lowered, existing subscribers keep the prior cap until the next billing period (enforced in US-SUB-08, not this PR).


Made with [Cursor](https://cursor.com)