### PR TITLE
feat(#152): user self-serve plan view, upgrade & downgrade

### DIFF
--- a/backend/src/domain/subscription-types.ts
+++ b/backend/src/domain/subscription-types.ts
@@ -63,3 +63,27 @@ export interface Subscription {
   createdAt: Date;
   updatedAt: Date;
 }
+
+/** Per-metric usage vs limit for the active subscription period. */
+export interface UsageSnapshot {
+  metric: QuotaMetric;
+  used: number;
+  /** null = unlimited on the active plan. */
+  limit: number | null;
+  /** true when `limit` is set and `used >= limit`. */
+  exceeded: boolean;
+}
+
+export interface SubscriptionView {
+  subscription: Subscription;
+  plan: Plan;
+  usage: UsageSnapshot[];
+  /** When monthly metered counters reset (= currentPeriodEnd). */
+  periodResetsAt: Date;
+}
+
+export interface DowngradeConflict {
+  metric: QuotaMetric;
+  used: number;
+  limit: number;
+}

--- a/backend/src/handlers/plan-handler.ts
+++ b/backend/src/handlers/plan-handler.ts
@@ -1,0 +1,31 @@
+import type { Request, Response, NextFunction } from 'express';
+import type { Plan } from '../domain/subscription-types.js';
+import { listPublicPlans } from '../repositories/plan-repository.js';
+
+function publicPlanToJson(plan: Plan) {
+  return {
+    id: plan.id,
+    slug: plan.slug,
+    name: plan.name,
+    description: plan.description,
+    priceCents: plan.priceCents,
+    currency: plan.currency,
+    billingPeriod: plan.billingPeriod,
+    limits: plan.limits,
+    sortOrder: plan.sortOrder,
+  };
+}
+
+/** Public catalogue for landing + self-serve plan picker (US-SUB-09 / US-SUB-06). */
+export async function listPublicPlansHandler(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const plans = await listPublicPlans();
+    res.json({ plans: plans.map(publicPlanToJson) });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/backend/src/handlers/subscription-handler.ts
+++ b/backend/src/handlers/subscription-handler.ts
@@ -1,0 +1,75 @@
+import type { Request, Response, NextFunction } from 'express';
+import type { Plan, Subscription, SubscriptionView, UsageSnapshot } from '../domain/subscription-types.js';
+import { AppError } from '../middleware/error-handler.js';
+import { getUserId } from '../middleware/auth.js';
+import { changePlan, getSubscriptionView } from '../services/subscription-service.js';
+
+function planToJson(plan: Plan) {
+  return {
+    id: plan.id,
+    slug: plan.slug,
+    name: plan.name,
+    description: plan.description,
+    priceCents: plan.priceCents,
+    currency: plan.currency,
+    billingPeriod: plan.billingPeriod,
+    limits: plan.limits,
+    isPublic: plan.isPublic,
+    sortOrder: plan.sortOrder,
+  };
+}
+
+function subscriptionToJson(sub: Subscription) {
+  return {
+    id: sub.id,
+    planId: sub.planId,
+    status: sub.status,
+    currentPeriodStart: sub.currentPeriodStart.toISOString(),
+    currentPeriodEnd: sub.currentPeriodEnd.toISOString(),
+    changedBy: sub.changedBy,
+  };
+}
+
+function usageToJson(usage: UsageSnapshot[]) {
+  return usage.map((u) => ({
+    metric: u.metric,
+    used: u.used,
+    limit: u.limit,
+    exceeded: u.exceeded,
+  }));
+}
+
+function viewToJson(view: SubscriptionView) {
+  return {
+    subscription: subscriptionToJson(view.subscription),
+    plan: planToJson(view.plan),
+    usage: usageToJson(view.usage),
+    periodResetsAt: view.periodResetsAt.toISOString(),
+  };
+}
+
+export async function getMySubscription(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const userId = getUserId(req);
+    const view = await getSubscriptionView(userId);
+    res.json(viewToJson(view));
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function changeMyPlan(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const userId = getUserId(req);
+    const body = req.body as Record<string, unknown>;
+    const planId = typeof body.planId === 'string' ? body.planId : typeof body.plan_id === 'string' ? body.plan_id : '';
+    if (!planId.trim()) {
+      throw new AppError(400, 'VALIDATION', 'planId is required');
+    }
+
+    const view = await changePlan(userId, planId.trim(), { actor: null, override: false });
+    res.json(viewToJson(view));
+  } catch (err) {
+    next(err);
+  }
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -4,6 +4,8 @@ import cors from 'cors';
 import blogRoutes from './routes/blog-routes.js';
 import profileRoutes from './routes/profile-routes.js';
 import { adminRoutes } from './routes/admin-routes.js';
+import { subscriptionRoutes } from './routes/subscription-routes.js';
+import { planRoutes } from './routes/plan-routes.js';
 import { errorHandler } from './middleware/error-handler.js';
 import { getAppVersion, getGitSha } from './version.js';
 import { validateAndLogRuntimeEnv } from './config/env.js';
@@ -24,6 +26,8 @@ app.get('/version', (_req, res) =>
 app.use('/api/blogs', blogRoutes);
 app.use('/api/profiles', profileRoutes);
 app.use('/api/admin', adminRoutes);
+app.use('/api/subscription', subscriptionRoutes);
+app.use('/api/plans', planRoutes);
 
 app.use(errorHandler);
 

--- a/backend/src/middleware/error-handler.ts
+++ b/backend/src/middleware/error-handler.ts
@@ -5,6 +5,7 @@ export class AppError extends Error {
     public readonly status: number,
     public readonly code: string,
     message: string,
+    public readonly details?: unknown,
   ) {
     super(message);
     this.name = 'AppError';
@@ -18,7 +19,23 @@ export function errorHandler(
   _next: NextFunction,
 ): void {
   if (err instanceof AppError) {
-    res.status(err.status).json({ error: { code: err.code, message: err.message } });
+    const body: { code: string; message: string; details?: unknown; conflicts?: unknown } = {
+      code: err.code,
+      message: err.message,
+    };
+    if (err.details !== undefined) {
+      if (
+        err.code === 'DOWNGRADE_BLOCKED' &&
+        typeof err.details === 'object' &&
+        err.details !== null &&
+        'conflicts' in err.details
+      ) {
+        body.conflicts = (err.details as { conflicts: unknown }).conflicts;
+      } else {
+        body.details = err.details;
+      }
+    }
+    res.status(err.status).json({ error: body });
     return;
   }
   console.error(err);

--- a/backend/src/repositories/subscription-repository.ts
+++ b/backend/src/repositories/subscription-repository.ts
@@ -91,3 +91,25 @@ export async function rollSubscriptionPeriod(
   console.log(`[subscription-repository] rolled period for subscription id=${subscriptionId}`);
   return subscriptionRowToModel(data);
 }
+
+/** Self-serve or admin plan change — period window is not reset. */
+export async function updateSubscriptionPlan(
+  subscriptionId: string,
+  planId: string,
+  changedBy: string | null,
+): Promise<Subscription> {
+  const now = new Date().toISOString();
+  const { data, error } = await getSupabase()
+    .from('subscriptions')
+    .update({
+      plan_id: planId,
+      changed_by: changedBy,
+      updated_at: now,
+    })
+    .eq('id', subscriptionId)
+    .select()
+    .single<SubscriptionRow>();
+
+  if (error) throw new Error(error.message);
+  return subscriptionRowToModel(data);
+}

--- a/backend/src/routes/plan-routes.ts
+++ b/backend/src/routes/plan-routes.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { listPublicPlansHandler } from '../handlers/plan-handler.js';
+
+const router = Router();
+
+router.get('/', listPublicPlansHandler);
+
+export const planRoutes = router;

--- a/backend/src/routes/subscription-routes.ts
+++ b/backend/src/routes/subscription-routes.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import { requireAuth } from '../middleware/auth.js';
+import * as subscriptionHandler from '../handlers/subscription-handler.js';
+
+const router = Router();
+
+router.use(requireAuth);
+
+router.get('/', subscriptionHandler.getMySubscription);
+router.put('/', subscriptionHandler.changeMyPlan);
+
+export const subscriptionRoutes = router;

--- a/backend/src/services/__tests__/subscription-service.test.ts
+++ b/backend/src/services/__tests__/subscription-service.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Plan, UsageSnapshot } from '../../domain/subscription-types.js';
+import { AppError } from '../../middleware/error-handler.js';
+import * as planRepo from '../../repositories/plan-repository.js';
+import * as subRepo from '../../repositories/subscription-repository.js';
+import * as quotaService from '../quota-service.js';
+import { changePlan, downgradeConflictsForPlan } from '../subscription-service.js';
+
+vi.mock('../../repositories/plan-repository.js');
+vi.mock('../../repositories/subscription-repository.js');
+vi.mock('../quota-service.js');
+
+const FREE_PLAN: Plan = {
+  id: 'plan-free',
+  slug: 'free',
+  name: 'Free',
+  description: '',
+  priceCents: 0,
+  currency: 'USD',
+  billingPeriod: 'monthly',
+  limits: { blogQuota: 3, aiCheckQuota: 5, authorProfileLimit: 1, referenceExtractionQuota: 10 },
+  isPublic: true,
+  isDefault: true,
+  archivedAt: null,
+  sortOrder: 1,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const PRO_PLAN: Plan = {
+  ...FREE_PLAN,
+  id: 'plan-pro',
+  slug: 'pro',
+  name: 'Pro',
+  priceCents: 1900,
+  limits: { blogQuota: 50, aiCheckQuota: 200, authorProfileLimit: 10, referenceExtractionQuota: 300 },
+  isDefault: false,
+  sortOrder: 2,
+};
+
+const SUBSCRIPTION = {
+  id: 'sub-1',
+  userId: 'user-1',
+  planId: 'plan-pro',
+  status: 'active' as const,
+  currentPeriodStart: new Date('2026-05-01T00:00:00Z'),
+  currentPeriodEnd: new Date('2026-06-01T00:00:00Z'),
+  stripeSubscriptionId: null,
+  changedBy: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const USAGE_WITH_PROFILES: UsageSnapshot[] = [
+  { metric: 'blogs', used: 2, limit: 50, exceeded: false },
+  { metric: 'ai_checks', used: 1, limit: 200, exceeded: false },
+  { metric: 'author_profiles', used: 3, limit: 10, exceeded: false },
+  { metric: 'reference_extractions', used: 0, limit: 300, exceeded: false },
+];
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('downgradeConflictsForPlan', () => {
+  it('flags author_profiles when used exceeds target limit', () => {
+    const conflicts = downgradeConflictsForPlan(USAGE_WITH_PROFILES, FREE_PLAN);
+    expect(conflicts).toEqual([{ metric: 'author_profiles', used: 3, limit: 1 }]);
+  });
+
+  it('returns no conflicts when usage fits every capped metric', () => {
+    const usage: UsageSnapshot[] = [
+      { metric: 'blogs', used: 2, limit: 50, exceeded: false },
+      { metric: 'ai_checks', used: 1, limit: 200, exceeded: false },
+      { metric: 'author_profiles', used: 1, limit: 10, exceeded: false },
+      { metric: 'reference_extractions', used: 5, limit: 300, exceeded: false },
+    ];
+    expect(downgradeConflictsForPlan(usage, FREE_PLAN)).toEqual([]);
+  });
+
+  it('ignores unlimited target limits', () => {
+    const teamPlan: Plan = {
+      ...PRO_PLAN,
+      limits: { blogQuota: null, aiCheckQuota: null, authorProfileLimit: 50, referenceExtractionQuota: null },
+    };
+    const usage: UsageSnapshot[] = [
+      { metric: 'blogs', used: 100, limit: 50, exceeded: true },
+      { metric: 'ai_checks', used: 0, limit: 200, exceeded: false },
+      { metric: 'author_profiles', used: 2, limit: 10, exceeded: false },
+      { metric: 'reference_extractions', used: 0, limit: 300, exceeded: false },
+    ];
+    expect(downgradeConflictsForPlan(usage, teamPlan)).toEqual([]);
+  });
+});
+
+describe('changePlan', () => {
+  it('blocks downgrade when usage exceeds target limits', async () => {
+    vi.mocked(subRepo.getActiveSubscriptionByUserId).mockResolvedValue(SUBSCRIPTION);
+    vi.mocked(planRepo.getPlanById).mockImplementation(async (id: string) => {
+      if (id === 'plan-pro') return PRO_PLAN;
+      if (id === 'plan-free') return FREE_PLAN;
+      return null;
+    });
+    vi.mocked(quotaService.computeUsage).mockResolvedValue(USAGE_WITH_PROFILES);
+
+    await expect(changePlan('user-1', 'plan-free')).rejects.toMatchObject({
+      status: 409,
+      code: 'DOWNGRADE_BLOCKED',
+    });
+    expect(subRepo.updateSubscriptionPlan).not.toHaveBeenCalled();
+  });
+
+  it('allows upgrade and preserves subscription period (no period reset)', async () => {
+    vi.mocked(subRepo.getActiveSubscriptionByUserId)
+      .mockResolvedValueOnce({ ...SUBSCRIPTION, planId: 'plan-free' })
+      .mockResolvedValueOnce({ ...SUBSCRIPTION, planId: 'plan-pro' });
+    vi.mocked(planRepo.getPlanById).mockImplementation(async (id: string) => {
+      if (id === 'plan-free') return FREE_PLAN;
+      if (id === 'plan-pro') return PRO_PLAN;
+      return null;
+    });
+    vi.mocked(quotaService.computeUsage).mockResolvedValue([
+      { metric: 'blogs', used: 2, limit: 3, exceeded: false },
+      { metric: 'ai_checks', used: 1, limit: 5, exceeded: false },
+      { metric: 'author_profiles', used: 1, limit: 1, exceeded: true },
+      { metric: 'reference_extractions', used: 0, limit: 10, exceeded: false },
+    ]);
+    vi.mocked(subRepo.updateSubscriptionPlan).mockResolvedValue({ ...SUBSCRIPTION, planId: 'plan-pro' });
+
+    const view = await changePlan('user-1', 'plan-pro');
+    expect(subRepo.updateSubscriptionPlan).toHaveBeenCalledWith('sub-1', 'plan-pro', null);
+    expect(view.plan.id).toBe('plan-pro');
+    expect(view.usage).toHaveLength(4);
+  });
+});

--- a/backend/src/services/quota-service.ts
+++ b/backend/src/services/quota-service.ts
@@ -1,0 +1,70 @@
+import { getSupabase } from '../db/supabase.js';
+import type { PlanLimits, QuotaMetric, UsageSnapshot } from '../domain/subscription-types.js';
+
+function snapshot(metric: QuotaMetric, used: number, limit: number | null): UsageSnapshot {
+  const exceeded = limit !== null && used >= limit;
+  return { metric, used, limit, exceeded };
+}
+
+/**
+ * Count metered usage for the subscription's current period window.
+ * Monthly metrics filter by `created_at` in [periodStart, periodEnd); author profiles are a standing total.
+ */
+export async function computeUsage(
+  userId: string,
+  periodStart: Date,
+  periodEnd: Date,
+  limits: PlanLimits,
+): Promise<UsageSnapshot[]> {
+  const supabase = getSupabase();
+  const startIso = periodStart.toISOString();
+  const endIso = periodEnd.toISOString();
+
+  const { count: blogCount, error: blogErr } = await supabase
+    .from('blogs')
+    .select('*', { count: 'exact', head: true })
+    .eq('user_id', userId)
+    .gte('created_at', startIso)
+    .lt('created_at', endIso);
+  if (blogErr) throw new Error(blogErr.message);
+
+  const { count: profileCount, error: profileErr } = await supabase
+    .from('author_profiles')
+    .select('*', { count: 'exact', head: true })
+    .eq('user_id', userId)
+    .eq('is_predefined', false);
+  if (profileErr) throw new Error(profileErr.message);
+
+  const { data: blogRows, error: blogListErr } = await supabase.from('blogs').select('id').eq('user_id', userId);
+  if (blogListErr) throw new Error(blogListErr.message);
+  const blogIds = (blogRows ?? []).map((r: { id: string }) => r.id);
+
+  let aiCheckCount = 0;
+  let referenceCount = 0;
+  if (blogIds.length > 0) {
+    const { count: ac, error: acErr } = await supabase
+      .from('blog_ai_checks')
+      .select('*', { count: 'exact', head: true })
+      .in('blog_id', blogIds)
+      .gte('created_at', startIso)
+      .lt('created_at', endIso);
+    if (acErr) throw new Error(acErr.message);
+    aiCheckCount = ac ?? 0;
+
+    const { count: rc, error: rcErr } = await supabase
+      .from('blog_references')
+      .select('*', { count: 'exact', head: true })
+      .in('blog_id', blogIds)
+      .gte('created_at', startIso)
+      .lt('created_at', endIso);
+    if (rcErr) throw new Error(rcErr.message);
+    referenceCount = rc ?? 0;
+  }
+
+  return [
+    snapshot('blogs', blogCount ?? 0, limits.blogQuota),
+    snapshot('ai_checks', aiCheckCount, limits.aiCheckQuota),
+    snapshot('author_profiles', profileCount ?? 0, limits.authorProfileLimit),
+    snapshot('reference_extractions', referenceCount, limits.referenceExtractionQuota),
+  ];
+}

--- a/backend/src/services/subscription-service.ts
+++ b/backend/src/services/subscription-service.ts
@@ -1,0 +1,124 @@
+import type {
+  DowngradeConflict,
+  Plan,
+  PlanLimits,
+  SubscriptionView,
+  UsageSnapshot,
+} from '../domain/subscription-types.js';
+import { AppError } from '../middleware/error-handler.js';
+import { getPlanById } from '../repositories/plan-repository.js';
+import {
+  getActiveSubscriptionByUserId,
+  updateSubscriptionPlan,
+} from '../repositories/subscription-repository.js';
+import { computeUsage } from './quota-service.js';
+
+export const METRIC_LABELS: Record<string, string> = {
+  blogs: 'blogs this month',
+  ai_checks: 'AI checks this month',
+  author_profiles: 'author profiles',
+  reference_extractions: 'reference extractions this month',
+};
+
+function findDowngradeConflicts(usage: UsageSnapshot[], targetLimits: PlanLimits): DowngradeConflict[] {
+  const limitByMetric: Record<string, number | null> = {
+    blogs: targetLimits.blogQuota,
+    ai_checks: targetLimits.aiCheckQuota,
+    author_profiles: targetLimits.authorProfileLimit,
+    reference_extractions: targetLimits.referenceExtractionQuota,
+  };
+
+  const conflicts: DowngradeConflict[] = [];
+  for (const row of usage) {
+    const targetLimit = limitByMetric[row.metric];
+    if (targetLimit === null) continue;
+    if (row.used > targetLimit) {
+      conflicts.push({ metric: row.metric, used: row.used, limit: targetLimit });
+    }
+  }
+  return conflicts;
+}
+
+export async function getSubscriptionView(userId: string): Promise<SubscriptionView> {
+  const subscription = await getActiveSubscriptionByUserId(userId);
+  if (!subscription) {
+    throw new AppError(404, 'NO_SUBSCRIPTION', 'No active subscription found for this account');
+  }
+
+  const plan = await getPlanById(subscription.planId);
+  if (!plan) {
+    throw new AppError(500, 'PLAN_MISSING', 'Subscription references a plan that no longer exists');
+  }
+
+  const usage = await computeUsage(
+    userId,
+    subscription.currentPeriodStart,
+    subscription.currentPeriodEnd,
+    plan.limits,
+  );
+
+  return {
+    subscription,
+    plan,
+    usage,
+    periodResetsAt: subscription.currentPeriodEnd,
+  };
+}
+
+export interface ChangePlanOptions {
+  /** Admin user id when admin-initiated; null for self-serve. */
+  actor?: string | null;
+  /** Admin override — bypass downgrade block (US-SUB-04; not used in self-serve). */
+  override?: boolean;
+}
+
+export async function changePlan(
+  userId: string,
+  targetPlanId: string,
+  options: ChangePlanOptions = {},
+): Promise<SubscriptionView> {
+  const subscription = await getActiveSubscriptionByUserId(userId);
+  if (!subscription) {
+    throw new AppError(404, 'NO_SUBSCRIPTION', 'No active subscription found for this account');
+  }
+
+  if (subscription.planId === targetPlanId) {
+    return getSubscriptionView(userId);
+  }
+
+  const targetPlan = await getPlanById(targetPlanId);
+  if (!targetPlan || targetPlan.archivedAt || !targetPlan.isPublic) {
+    throw new AppError(404, 'NOT_FOUND', 'Plan not found or not available for self-serve');
+  }
+
+  const currentPlan = await getPlanById(subscription.planId);
+  if (!currentPlan) {
+    throw new AppError(500, 'PLAN_MISSING', 'Current subscription plan could not be loaded');
+  }
+
+  const usage = await computeUsage(
+    userId,
+    subscription.currentPeriodStart,
+    subscription.currentPeriodEnd,
+    currentPlan.limits,
+  );
+
+  const conflicts = findDowngradeConflicts(usage, targetPlan.limits);
+  if (conflicts.length > 0 && !options.override) {
+    const parts = conflicts.map(
+      (c) => `${METRIC_LABELS[c.metric] ?? c.metric}: ${c.used} used, plan allows ${c.limit}`,
+    );
+    throw new AppError(409, 'DOWNGRADE_BLOCKED', `Cannot switch to this plan: ${parts.join('; ')}`, {
+      conflicts,
+    });
+  }
+
+  const changedBy = options.actor ?? null;
+  await updateSubscriptionPlan(subscription.id, targetPlanId, changedBy);
+  return getSubscriptionView(userId);
+}
+
+/** Exposed for tests — compares usage against target plan limits. */
+export function downgradeConflictsForPlan(usage: UsageSnapshot[], targetPlan: Plan): DowngradeConflict[] {
+  return findDowngradeConflicts(usage, targetPlan.limits);
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ import AdminUserDetailPage from './pages/admin/AdminUserDetailPage';
 import AdminBlogsPage from './pages/admin/AdminBlogsPage';
 import AdminBlogDetailPage from './pages/admin/AdminBlogDetailPage';
 import AdminPlansPage from './pages/admin/AdminPlansPage';
+import PlanUsagePage from './pages/PlanUsagePage';
 
 export function App() {
   return (
@@ -64,6 +65,7 @@ export function App() {
             <Route element={<ProtectedRoute />}>
               <Route path="/dashboard" element={<Dashboard />} />
               <Route path="/profile" element={<ProfilePage />} />
+              <Route path="/plan" element={<PlanUsagePage />} />
             </Route>
 
             {/* Admin — users, blogs, roles (service role on server) */}

--- a/frontend/src/api/plan-api.ts
+++ b/frontend/src/api/plan-api.ts
@@ -1,0 +1,24 @@
+import type { PlanSummary } from './subscription-api.js';
+
+async function parseJson<T>(res: Response): Promise<T> {
+  const text = await res.text();
+  let body: unknown = null;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    throw new Error(res.ok ? 'Invalid JSON from server' : text || res.statusText);
+  }
+  if (!res.ok) {
+    const msg =
+      body && typeof body === 'object' && body !== null && 'error' in body
+        ? String((body as { error?: { message?: string } }).error?.message ?? 'Request failed')
+        : 'Request failed';
+    throw new Error(msg);
+  }
+  return body as T;
+}
+
+export async function getPublicPlans(): Promise<{ plans: PlanSummary[] }> {
+  const res = await fetch('/api/plans');
+  return parseJson<{ plans: PlanSummary[] }>(res);
+}

--- a/frontend/src/api/subscription-api.ts
+++ b/frontend/src/api/subscription-api.ts
@@ -1,0 +1,109 @@
+import { authedFetch } from '../lib/authed-fetch.js';
+
+const BASE = '/api/subscription';
+
+export type QuotaMetric = 'blogs' | 'ai_checks' | 'author_profiles' | 'reference_extractions';
+
+export interface PlanLimits {
+  blogQuota: number | null;
+  aiCheckQuota: number | null;
+  authorProfileLimit: number | null;
+  referenceExtractionQuota: number | null;
+}
+
+export interface PlanSummary {
+  id: string;
+  slug: string;
+  name: string;
+  description: string;
+  priceCents: number;
+  currency: string;
+  billingPeriod: string;
+  limits: PlanLimits;
+  isPublic?: boolean;
+  sortOrder?: number;
+}
+
+export interface UsageRow {
+  metric: QuotaMetric;
+  used: number;
+  limit: number | null;
+  exceeded: boolean;
+}
+
+export interface SubscriptionView {
+  subscription: {
+    id: string;
+    planId: string;
+    status: string;
+    currentPeriodStart: string;
+    currentPeriodEnd: string;
+    changedBy: string | null;
+  };
+  plan: PlanSummary;
+  usage: UsageRow[];
+  periodResetsAt: string;
+}
+
+export interface DowngradeConflict {
+  metric: QuotaMetric;
+  used: number;
+  limit: number;
+}
+
+export class SubscriptionApiError extends Error {
+  readonly code: string;
+  readonly conflicts: DowngradeConflict[];
+
+  constructor(message: string, code: string, conflicts: DowngradeConflict[] = []) {
+    super(message);
+    this.name = 'SubscriptionApiError';
+    this.code = code;
+    this.conflicts = conflicts;
+  }
+}
+
+function extractApiError(body: unknown): { message: string; code?: string; conflicts?: DowngradeConflict[] } {
+  if (!body || typeof body !== 'object') return { message: 'Request failed' };
+  const o = body as Record<string, unknown>;
+  const err = o.error;
+  if (err && typeof err === 'object' && err !== null) {
+    const e = err as { message?: unknown; code?: unknown; conflicts?: unknown };
+    const message = typeof e.message === 'string' ? e.message : 'Request failed';
+    const code = typeof e.code === 'string' ? e.code : undefined;
+    const conflicts = Array.isArray(e.conflicts) ? (e.conflicts as DowngradeConflict[]) : undefined;
+    return { message, code, conflicts };
+  }
+  return { message: 'Request failed' };
+}
+
+async function parseJson<T>(res: Response): Promise<T> {
+  const text = await res.text();
+  let body: unknown = null;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    throw new Error(res.ok ? 'Invalid JSON from server' : text || res.statusText);
+  }
+  if (!res.ok) {
+    const { message, code, conflicts } = extractApiError(body);
+    if (code === 'DOWNGRADE_BLOCKED') {
+      throw new SubscriptionApiError(message, code, conflicts ?? []);
+    }
+    throw new Error(message);
+  }
+  return body as T;
+}
+
+export async function getMySubscription(): Promise<SubscriptionView> {
+  const res = await authedFetch(BASE);
+  return parseJson<SubscriptionView>(res);
+}
+
+export async function changeMyPlan(planId: string): Promise<SubscriptionView> {
+  const res = await authedFetch(BASE, {
+    method: 'PUT',
+    body: JSON.stringify({ planId }),
+  });
+  return parseJson<SubscriptionView>(res);
+}

--- a/frontend/src/components/PlanPicker.tsx
+++ b/frontend/src/components/PlanPicker.tsx
@@ -1,0 +1,124 @@
+import { useState } from 'react';
+import type { DowngradeConflict, PlanSummary } from '../api/subscription-api.js';
+import { SubscriptionApiError, changeMyPlan } from '../api/subscription-api.js';
+import { Button } from './ui/button';
+import { Toast } from './ui/toast';
+
+const METRIC_LABELS: Record<DowngradeConflict['metric'], string> = {
+  blogs: 'Blogs this month',
+  ai_checks: 'AI checks this month',
+  author_profiles: 'Author profiles',
+  reference_extractions: 'Reference extractions this month',
+};
+
+function formatPrice(cents: number, currency: string): string {
+  return new Intl.NumberFormat(undefined, { style: 'currency', currency }).format(cents / 100);
+}
+
+function formatLimit(n: number | null): string {
+  return n === null ? 'Unlimited' : String(n);
+}
+
+interface PlanPickerProps {
+  currentPlanId: string;
+  plans: PlanSummary[];
+  onChanged: (fromSlug: string, toSlug: string, toName: string) => void;
+  onReload: () => Promise<void>;
+}
+
+export function PlanPicker({ currentPlanId, plans, onChanged, onReload }: PlanPickerProps) {
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [blockMessage, setBlockMessage] = useState<string | null>(null);
+
+  const alternatives = plans.filter((p) => p.id !== currentPlanId);
+
+  async function handleSwitch(plan: PlanSummary) {
+    const from = plans.find((p) => p.id === currentPlanId);
+    if (!from) return;
+
+    const preview =
+      plan.priceCents >= from.priceCents
+        ? `Switch to ${plan.name}? Your new limits apply immediately. Billing is not enabled yet — this preview is free.`
+        : `Switch to ${plan.name}? Your usage counts carry over. Billing is not enabled yet — this preview is free.`;
+
+    if (!window.confirm(preview)) return;
+
+    setBusyId(plan.id);
+    setError(null);
+    setBlockMessage(null);
+    try {
+      await changeMyPlan(plan.id);
+      onChanged(from.slug, plan.slug, plan.name);
+      await onReload();
+    } catch (e) {
+      if (e instanceof SubscriptionApiError && e.code === 'DOWNGRADE_BLOCKED') {
+        const lines = e.conflicts.map(
+          (c) =>
+            `${METRIC_LABELS[c.metric]}: you have ${c.used}, but ${plan.name} allows ${c.limit}. ` +
+            'Reduce usage or wait for your monthly counters to reset, then try again.',
+        );
+        setBlockMessage(lines.join(' '));
+      } else {
+        setError((e as Error).message);
+      }
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  if (alternatives.length === 0) {
+    return <p className="text-sm text-slate-600">No other public plans are available to switch to.</p>;
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-slate-600">
+        Billing is not enabled yet — plan changes are instant and free during this preview.
+      </p>
+      {blockMessage && (
+        <Toast variant="error">
+          {blockMessage}
+        </Toast>
+      )}
+      {error && (
+        <Toast variant="error">
+          {error}
+        </Toast>
+      )}
+      <ul className="grid gap-4 sm:grid-cols-2">
+        {alternatives.map((plan) => {
+          const busy = busyId === plan.id;
+          return (
+            <li
+              key={plan.id}
+              className="flex flex-col rounded-xl border border-slate-200 bg-white p-4 shadow-sm"
+            >
+              <h3 className="text-lg font-semibold text-slate-900">{plan.name}</h3>
+              <p className="mt-1 text-2xl font-bold text-slate-900">
+                {formatPrice(plan.priceCents, plan.currency)}
+                <span className="text-sm font-normal text-slate-500"> / month</span>
+              </p>
+              <p className="mt-2 flex-1 text-sm text-slate-600">{plan.description}</p>
+              <ul className="mt-3 space-y-1 text-xs text-slate-600">
+                <li>Blogs / month: {formatLimit(plan.limits.blogQuota)}</li>
+                <li>AI checks / month: {formatLimit(plan.limits.aiCheckQuota)}</li>
+                <li>Author profiles: {formatLimit(plan.limits.authorProfileLimit)}</li>
+                <li>Reference extractions / month: {formatLimit(plan.limits.referenceExtractionQuota)}</li>
+              </ul>
+              <Button
+                type="button"
+                className="mt-4 w-full"
+                size="sm"
+                disabled={busy}
+                onClick={() => void handleSwitch(plan)}
+              >
+                {busy ? 'Switching…' : `Switch to ${plan.name}`}
+              </Button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/components/UsageMeter.tsx
+++ b/frontend/src/components/UsageMeter.tsx
@@ -1,0 +1,56 @@
+import type { UsageRow } from '../api/subscription-api.js';
+
+const METRIC_LABELS: Record<UsageRow['metric'], string> = {
+  blogs: 'Blogs created',
+  ai_checks: 'AI authenticity checks',
+  author_profiles: 'Author profiles',
+  reference_extractions: 'Reference extractions',
+};
+
+function formatLimit(limit: number | null): string {
+  return limit === null ? 'Unlimited' : String(limit);
+}
+
+interface UsageMeterProps {
+  row: UsageRow;
+  periodLabel?: string;
+}
+
+export function UsageMeter({ row, periodLabel }: UsageMeterProps) {
+  const label = METRIC_LABELS[row.metric];
+  const limitText = formatLimit(row.limit);
+  const isMonthly = row.metric !== 'author_profiles';
+  const usageText =
+    row.limit === null
+      ? `${row.used} used${isMonthly && periodLabel ? ` ${periodLabel}` : ''} — Unlimited`
+      : `${row.used} of ${limitText}${isMonthly && periodLabel ? ` ${periodLabel}` : ''}`;
+
+  const pct =
+    row.limit === null || row.limit === 0 ? 0 : Math.min(100, Math.round((row.used / row.limit) * 100));
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-baseline justify-between gap-2 text-sm">
+        <span className="font-medium text-slate-800">{label}</span>
+        <span className={row.exceeded ? 'font-medium text-red-700' : 'text-slate-600'} aria-live="polite">
+          {usageText}
+        </span>
+      </div>
+      {row.limit !== null && (
+        <div
+          className="h-2 overflow-hidden rounded-full bg-slate-100"
+          role="progressbar"
+          aria-valuenow={row.used}
+          aria-valuemin={0}
+          aria-valuemax={row.limit}
+          aria-label={`${label}: ${usageText}`}
+        >
+          <div
+            className={`h-full rounded-full transition-all ${row.exceeded ? 'bg-red-500' : 'bg-indigo-500'}`}
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/WorkspaceSidebar.tsx
+++ b/frontend/src/components/WorkspaceSidebar.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom';
-import { BookOpen, PenLine, Settings, UserCircle, Users } from 'lucide-react';
+import { BookOpen, CreditCard, PenLine, Settings, UserCircle, Users } from 'lucide-react';
 
-export type WorkspaceNavKey = 'write' | 'my-blogs' | 'author-profiles' | 'account' | 'admin';
+export type WorkspaceNavKey = 'write' | 'my-blogs' | 'author-profiles' | 'account' | 'plan' | 'admin';
 
 export function workspaceNavClass(active: boolean) {
   return [
@@ -33,6 +33,7 @@ export function WorkspaceSidebar(props: WorkspaceSidebarProps) {
   const blogsActive = props.active === 'my-blogs';
   const profilesActive = props.active === 'author-profiles';
   const accountActive = props.active === 'account';
+  const planActive = props.active === 'plan';
   const adminActive = props.active === 'admin';
 
   return (
@@ -79,6 +80,10 @@ export function WorkspaceSidebar(props: WorkspaceSidebarProps) {
         <Link to="/profile" className={`${workspaceNavClass(accountActive)} no-underline`}>
           <UserCircle className="h-4 w-4 shrink-0 opacity-80" aria-hidden />
           Account
+        </Link>
+        <Link to="/plan" className={`${workspaceNavClass(planActive)} no-underline`}>
+          <CreditCard className="h-4 w-4 shrink-0 opacity-80" aria-hidden />
+          Plan &amp; usage
         </Link>
         {showAdmin && (
           <Link to="/admin" className={`${workspaceNavClass(adminActive)} no-underline`}>

--- a/frontend/src/lib/plan-analytics.ts
+++ b/frontend/src/lib/plan-analytics.ts
@@ -1,0 +1,20 @@
+/** Subscription plan analytics — wire to product SDK when available. */
+
+export type PlanChangedPayload = {
+  from_plan_slug: string;
+  to_plan_slug: string;
+};
+
+export function recordPlanViewed(): void {
+  if (import.meta.env.DEV) {
+    // eslint-disable-next-line no-console -- dev-only funnel debugging
+    console.debug('[plan analytics] plan_viewed');
+  }
+}
+
+export function recordPlanChanged(payload: PlanChangedPayload): void {
+  if (import.meta.env.DEV) {
+    // eslint-disable-next-line no-console -- dev-only funnel debugging
+    console.debug('[plan analytics] plan_changed', payload);
+  }
+}

--- a/frontend/src/pages/PlanUsagePage.tsx
+++ b/frontend/src/pages/PlanUsagePage.tsx
@@ -1,0 +1,131 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Navigate } from 'react-router-dom';
+import { getPublicPlans } from '../api/plan-api';
+import {
+  getMySubscription,
+  type PlanSummary,
+  type SubscriptionView,
+} from '../api/subscription-api';
+import { PlanPicker } from '../components/PlanPicker';
+import { UsageMeter } from '../components/UsageMeter';
+import { Toast } from '../components/ui/toast';
+import { WorkspaceLayout } from '../components/WorkspaceLayout';
+import { WorkspaceSidebar } from '../components/WorkspaceSidebar';
+import { recordPlanChanged, recordPlanViewed } from '../lib/plan-analytics';
+import { useAuth } from '../context/AuthContext';
+
+function formatPrice(cents: number, currency: string): string {
+  return new Intl.NumberFormat(undefined, { style: 'currency', currency }).format(cents / 100);
+}
+
+function formatResetDate(iso: string): string {
+  try {
+    return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(
+      new Date(iso),
+    );
+  } catch {
+    return iso;
+  }
+}
+
+export default function PlanUsagePage() {
+  const { user, role } = useAuth();
+  const viewedRef = useRef(false);
+  const [view, setView] = useState<SubscriptionView | null>(null);
+  const [publicPlans, setPublicPlans] = useState<PlanSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setError(null);
+    try {
+      const [sub, { plans }] = await Promise.all([getMySubscription(), getPublicPlans()]);
+      setView(sub);
+      setPublicPlans(plans);
+      if (!viewedRef.current) {
+        viewedRef.current = true;
+        recordPlanViewed();
+      }
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  if (!user) return <Navigate to="/login" replace />;
+
+  const showAdmin = role === 'admin';
+
+  return (
+    <WorkspaceLayout
+      sidebar={<WorkspaceSidebar mode="router" active="plan" showAdmin={showAdmin} />}
+    >
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight text-slate-900">Plan &amp; usage</h1>
+        <p className="mt-1 text-sm text-slate-600">
+          View your subscription tier, monthly usage, and switch plans. Billing is display-only during this preview.
+        </p>
+
+        {error && (
+          <div className="mt-4">
+            <Toast variant="error">{error}</Toast>
+          </div>
+        )}
+        {success && (
+          <div className="mt-4">
+            <Toast variant="info">{success}</Toast>
+          </div>
+        )}
+
+        {loading && !view ? (
+          <p className="mt-8 text-center text-slate-500">Loading your plan…</p>
+        ) : view ? (
+          <div className="mt-8 space-y-8">
+            <section className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+              <h2 className="text-lg font-semibold text-slate-900">Current plan</h2>
+              <p className="mt-2 text-3xl font-bold text-slate-900">{view.plan.name}</p>
+              <p className="mt-1 text-slate-600">
+                {formatPrice(view.plan.priceCents, view.plan.currency)} / month (display only — not charged)
+              </p>
+              {view.plan.description && <p className="mt-3 text-sm text-slate-600">{view.plan.description}</p>}
+              <p className="mt-4 text-sm text-slate-600">
+                Monthly counters reset on{' '}
+                <time dateTime={view.periodResetsAt}>{formatResetDate(view.periodResetsAt)}</time>
+              </p>
+            </section>
+
+            <section className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+              <h2 className="text-lg font-semibold text-slate-900">Usage this period</h2>
+              <div className="mt-4 space-y-4">
+                {view.usage.map((row) => (
+                  <UsageMeter key={row.metric} row={row} periodLabel="this month" />
+                ))}
+              </div>
+            </section>
+
+            <section className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+              <h2 className="text-lg font-semibold text-slate-900">Change plan</h2>
+              <div className="mt-4">
+                <PlanPicker
+                  currentPlanId={view.plan.id}
+                  plans={publicPlans}
+                  onChanged={(fromSlug, toSlug, toName) => {
+                    recordPlanChanged({ from_plan_slug: fromSlug, to_plan_slug: toSlug });
+                    setSuccess(`You are now on the ${toName} plan.`);
+                  }}
+                  onReload={load}
+                />
+              </div>
+            </section>
+          </div>
+        ) : null}
+      </div>
+    </WorkspaceLayout>
+  );
+}

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Navigate } from 'react-router-dom';
+import { Link, Navigate } from 'react-router-dom';
 import { z } from 'zod';
 import { useAuth } from '../context/AuthContext';
 import { supabase } from '../lib/supabase';
@@ -139,6 +139,12 @@ export default function ProfilePage() {
         <div>
           <h2 className="text-lg font-semibold text-slate-900">Account</h2>
           <p className="mt-1 text-sm text-slate-500">Update your name, email, or password.</p>
+          <p className="mt-2 text-sm">
+            <Link to="/plan" className="font-medium text-indigo-600 hover:text-indigo-500">
+              Plan &amp; usage
+            </Link>
+            {' — view your subscription tier and monthly limits.'}
+          </p>
         </div>
 
         <div className="grid gap-4">


### PR DESCRIPTION
## Summary

Implements US-SUB-05/06/07 — the user-facing **Plan & Usage** experience:

- `GET /api/subscription` — current plan, period usage vs limits, reset date
- `PUT /api/subscription` — self-serve plan change with `DOWNGRADE_BLOCKED` (409) when usage exceeds target limits
- `GET /api/plans` — public plan catalogue for the picker (shared with landing work in #151)
- `/plan` page with usage meters, plan picker, preview billing disclaimer
- Workspace nav + Account page link; `plan_viewed` / `plan_changed` analytics hooks

## Test plan

- [x] `npm run test --workspace=backend -- --run` (164 tests)
- [x] `npm run typecheck --workspace=backend`
- [x] `npm run typecheck --workspace=frontend`
- [ ] Manual: sign in → Plan & usage → view meters → upgrade to Pro → attempt downgrade with over-limit usage → see 409 message

## Glossary

- **Usage snapshot**: Per-metric `used` vs `limit` for the active subscription period.
- **Downgrade block**: Refusal to switch when current usage exceeds any capped limit on the target plan (`DOWNGRADE_BLOCKED`).
- **Grandfathering**: Lowering a plan’s limits in admin does not reset usage; enforcement is US-SUB-08.

Closes #152

Made with [Cursor](https://cursor.com)