### PR TITLE
feat(#151): landing page renders live plans

### DIFF
--- a/backend/src/handlers/__tests__/plan-handler.test.ts
+++ b/backend/src/handlers/__tests__/plan-handler.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Request, Response, NextFunction } from 'express';
+import type { Plan } from '../../domain/subscription-types.js';
+import { listPublicPlansHandler } from '../plan-handler.js';
+import * as repo from '../../repositories/plan-repository.js';
+
+vi.mock('../../repositories/plan-repository.js');
+
+const PUBLIC_PLAN: Plan = {
+  id: 'plan-free',
+  slug: 'free',
+  name: 'Free',
+  description: 'Get started',
+  priceCents: 0,
+  currency: 'USD',
+  billingPeriod: 'monthly',
+  limits: { blogQuota: 3, aiCheckQuota: 5, authorProfileLimit: 1, referenceExtractionQuota: 10 },
+  isPublic: true,
+  isDefault: true,
+  archivedAt: null,
+  sortOrder: 1,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+function makeRes(): { res: Response; json: ReturnType<typeof vi.fn> } {
+  const json = vi.fn();
+  const res = { json, status: vi.fn().mockReturnThis() } as unknown as Response;
+  return { res, json };
+}
+
+const next: NextFunction = vi.fn();
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('listPublicPlansHandler', () => {
+  it('returns only public plans from the repository', async () => {
+    vi.mocked(repo.listPublicPlans).mockResolvedValue([PUBLIC_PLAN]);
+
+    const { res, json } = makeRes();
+    await listPublicPlansHandler({} as Request, res, next);
+
+    expect(repo.listPublicPlans).toHaveBeenCalled();
+    expect(json).toHaveBeenCalledWith({
+      plans: [
+        expect.objectContaining({
+          slug: 'free',
+          name: 'Free',
+          priceCents: 0,
+        }),
+      ],
+    });
+    const payload = json.mock.calls[0][0] as { plans: { slug: string }[] };
+    expect(payload.plans[0]).not.toHaveProperty('isDefault');
+    expect(payload.plans[0]).not.toHaveProperty('archivedAt');
+  });
+});

--- a/frontend/src/components/PlanCard.tsx
+++ b/frontend/src/components/PlanCard.tsx
@@ -1,0 +1,84 @@
+import type { PlanSummary } from '../api/subscription-api.js';
+import { SmartNavLink } from '../landing/SmartNavLink';
+
+function formatPrice(cents: number, currency: string): string {
+  if (cents === 0) return '$0';
+  return new Intl.NumberFormat(undefined, { style: 'currency', currency, maximumFractionDigits: 0 }).format(
+    cents / 100,
+  );
+}
+
+function formatLimit(value: number | null, singular: string, plural: string): string {
+  if (value === null) return `Unlimited ${plural}`;
+  return `${value} ${value === 1 ? singular : plural}`;
+}
+
+export function planLimitsToBullets(limits: PlanSummary['limits']): string[] {
+  return [
+    `${formatLimit(limits.blogQuota, 'blog draft', 'blog drafts')} / month`,
+    limits.aiCheckQuota === null
+      ? 'Unlimited AI authenticity checks'
+      : `${formatLimit(limits.aiCheckQuota, 'AI check', 'AI checks')} / month`,
+    `${formatLimit(limits.authorProfileLimit, 'author profile', 'author profiles')}`,
+    `${formatLimit(limits.referenceExtractionQuota, 'reference extraction', 'reference extractions')} / month`,
+  ];
+}
+
+export interface PlanCardProps {
+  plan: PlanSummary;
+  /** Team tier keeps waitlist UX until billing ships. */
+  comingSoon?: boolean;
+  onCtaClick?: () => void;
+}
+
+export function PlanCard({ plan, comingSoon = false, onCtaClick }: PlanCardProps) {
+  const isTeam = comingSoon || plan.slug === 'team';
+  const ctaClass = isTeam
+    ? 'inline-flex min-h-11 w-full items-center justify-center rounded-lg border border-dashed border-slate-300 bg-slate-50 px-5 py-3 text-sm font-semibold text-slate-700 shadow-none hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2'
+    : 'inline-flex min-h-11 w-full items-center justify-center rounded-lg bg-indigo-600 px-5 py-3 text-sm font-semibold text-white shadow-sm hover:bg-indigo-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2';
+
+  const ctaLabel = isTeam ? 'Notify me' : plan.slug === 'free' ? 'Start free' : `Start ${plan.name}`;
+  const ctaHref = isTeam
+    ? '/register?plan=team_waitlist&source=landing_pricing'
+    : `/register?plan=${encodeURIComponent(plan.slug)}&source=landing_pricing`;
+  const ctaAssistiveHint = isTeam
+    ? 'Team tier is not yet purchasable. Continue to join the waitlist.'
+    : undefined;
+
+  const bullets = planLimitsToBullets(plan.limits);
+  const priceLabel =
+    plan.priceCents === 0
+      ? '$0'
+      : `${formatPrice(plan.priceCents, plan.currency)} / month`;
+
+  return (
+    <article className="flex flex-col rounded-2xl border border-slate-200 bg-white p-8 shadow-sm ring-slate-900/5">
+      <div className="flex items-start justify-between gap-3">
+        <h3 className="text-xl font-semibold text-slate-900">{plan.name}</h3>
+        {isTeam && (
+          <span className="rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wide text-amber-900">
+            Coming soon
+          </span>
+        )}
+      </div>
+      <p className="mt-2 text-3xl font-bold tracking-tight text-slate-900">{priceLabel}</p>
+      <p className="mt-2 text-sm text-slate-600">{plan.description}</p>
+      <ul className="mt-6 flex flex-1 flex-col gap-2 text-sm text-slate-700">
+        {bullets.map((b) => (
+          <li key={b} className="flex gap-2">
+            <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-indigo-500" aria-hidden />
+            <span>{b}</span>
+          </li>
+        ))}
+      </ul>
+      <SmartNavLink
+        href={ctaHref}
+        className={ctaClass}
+        aria-label={ctaAssistiveHint ? `${ctaLabel}. ${ctaAssistiveHint}` : undefined}
+        onClick={onCtaClick}
+      >
+        {ctaLabel}
+      </SmartNavLink>
+    </article>
+  );
+}

--- a/frontend/src/landing/Pricing.tsx
+++ b/frontend/src/landing/Pricing.tsx
@@ -1,18 +1,39 @@
+import { useEffect, useState } from 'react';
+import { getPublicPlans } from '../api/plan-api';
+import type { PlanSummary } from '../api/subscription-api';
+import { PlanCard } from '../components/PlanCard';
 import { landingContent } from './content';
-import { SmartNavLink } from './SmartNavLink';
 import { recordLandingCtaClick, recordLandingPricingCtaClick } from './analytics';
 
-function planToAnalyticsPlan(
-  tierId: string,
-): 'free' | 'pro' | 'team_waitlist' | null {
-  if (tierId === 'free') return 'free';
-  if (tierId === 'pro') return 'pro';
-  if (tierId === 'team') return 'team_waitlist';
+function planToAnalyticsPlan(slug: string): 'free' | 'pro' | 'team_waitlist' | null {
+  if (slug === 'free') return 'free';
+  if (slug === 'pro') return 'pro';
+  if (slug === 'team') return 'team_waitlist';
   return null;
 }
 
 export function Pricing() {
   const { pricing } = landingContent;
+  const [plans, setPlans] = useState<PlanSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void getPublicPlans()
+      .then(({ plans: rows }) => {
+        if (!cancelled) setPlans(rows);
+      })
+      .catch((e) => {
+        if (!cancelled) setError((e as Error).message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   return (
     <section
@@ -31,58 +52,41 @@ export function Pricing() {
           <p className="mt-4 text-lg text-slate-600">{pricing.sectionSubtitle}</p>
         </div>
 
-        <div className="mt-14 grid gap-8 lg:grid-cols-3">
-          {pricing.tiers.map((tier) => {
-            const plan = planToAnalyticsPlan(tier.id);
-            const isTeam = tier.comingSoon === true;
-            const ctaClass = isTeam
-              ? 'inline-flex min-h-11 w-full items-center justify-center rounded-lg border border-dashed border-slate-300 bg-slate-50 px-5 py-3 text-sm font-semibold text-slate-700 shadow-none hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2'
-              : 'inline-flex min-h-11 w-full items-center justify-center rounded-lg bg-indigo-600 px-5 py-3 text-sm font-semibold text-white shadow-sm hover:bg-indigo-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2';
+        {error && (
+          <p className="mt-10 text-center text-sm text-red-700" role="alert">
+            Could not load plans: {error}
+          </p>
+        )}
 
-            return (
-              <article
-                key={tier.id}
-                className="flex flex-col rounded-2xl border border-slate-200 bg-white p-8 shadow-sm ring-slate-900/5"
-              >
-                <div className="flex items-start justify-between gap-3">
-                  <h3 className="text-xl font-semibold text-slate-900">{tier.name}</h3>
-                  {isTeam && (
-                    <span className="rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wide text-amber-900">
-                      Coming soon
-                    </span>
-                  )}
-                </div>
-                <p className="mt-2 text-3xl font-bold tracking-tight text-slate-900">{tier.priceLabel}</p>
-                <p className="mt-2 text-sm text-slate-600">{tier.summary}</p>
-                <ul className="mt-6 flex flex-1 flex-col gap-2 text-sm text-slate-700">
-                  {tier.bullets.map((b) => (
-                    <li key={b} className="flex gap-2">
-                      <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-indigo-500" aria-hidden />
-                      <span>{b}</span>
-                    </li>
-                  ))}
-                </ul>
-                <SmartNavLink
-                  href={tier.cta.href}
-                  className={ctaClass}
-                  aria-label={tier.ctaAssistiveHint ? `${tier.cta.label}. ${tier.ctaAssistiveHint}` : undefined}
-                  onClick={() => {
-                    if (plan) {
-                      recordLandingPricingCtaClick({ plan });
+        {loading && plans.length === 0 ? (
+          <p className="mt-14 text-center text-slate-500">Loading plans…</p>
+        ) : (
+          <div className="mt-14 grid gap-8 lg:grid-cols-3">
+            {plans.map((plan) => {
+              const analyticsPlan = planToAnalyticsPlan(plan.slug);
+              return (
+                <PlanCard
+                  key={plan.id}
+                  plan={plan}
+                  comingSoon={plan.slug === 'team'}
+                  onCtaClick={() => {
+                    if (analyticsPlan) {
+                      recordLandingPricingCtaClick({ plan: analyticsPlan });
                     }
                     recordLandingCtaClick({
-                      cta_id: `pricing_${tier.id}`,
-                      destination_url: tier.cta.href,
+                      cta_id: `pricing_${plan.slug}`,
+                      destination_url:
+                        plan.slug === 'team'
+                          ? '/register?plan=team_waitlist&source=landing_pricing'
+                          : `/register?plan=${plan.slug}&source=landing_pricing`,
                       current_section_id: 'pricing',
                     });
                   }}
-                >
-                  {tier.cta.label}
-                </SmartNavLink>
-              </article>
-            );
-          })}
-        </div>
+                />
+              );
+            })}
+          </div>
+        )}
 
         <p className="mx-auto mt-10 max-w-3xl text-center text-sm text-slate-500">
           {pricing.disclaimer}

--- a/frontend/src/landing/Pricing.tsx
+++ b/frontend/src/landing/Pricing.tsx
@@ -60,6 +60,8 @@ export function Pricing() {
 
         {loading && plans.length === 0 ? (
           <p className="mt-14 text-center text-slate-500">Loading plans…</p>
+        ) : !loading && plans.length === 0 ? (
+          <p className="mt-14 text-center text-slate-500">Plans are not available right now. Please try again later.</p>
         ) : (
           <div className="mt-14 grid gap-8 lg:grid-cols-3">
             {plans.map((plan) => {

--- a/frontend/src/landing/content.ts
+++ b/frontend/src/landing/content.ts
@@ -43,18 +43,6 @@ export interface SocialStat {
   value: string;
 }
 
-export interface PricingTier {
-  id: string;
-  name: string;
-  priceLabel: string;
-  summary: string;
-  bullets: string[];
-  cta: CtaLink;
-  /** When true, CTA is styled as secondary / waitlist but remains focusable (PRD US-4 Team). */
-  comingSoon?: boolean;
-  ctaAssistiveHint?: string;
-}
-
 export interface LandingContent {
   hero: {
     h1: string;
@@ -81,7 +69,6 @@ export interface LandingContent {
     sectionTitle: string;
     sectionSubtitle: string;
     disclaimer: string;
-    tiers: PricingTier[];
   };
 }
 
@@ -189,50 +176,5 @@ export const landingContent: LandingContent = {
     sectionSubtitle: 'Pick a lane — billing arrives after we finish the preview.',
     disclaimer:
       'Pricing is illustrative for v1 — billing not yet enabled. All paid features are free during this preview.',
-    tiers: [
-      {
-        id: 'free',
-        name: 'Free',
-        priceLabel: '$0',
-        summary: 'Try the product.',
-        bullets: ['3 blog drafts / month', 'AI generation + outlines', 'SEO panel + readability'],
-        cta: {
-          label: 'Start free',
-          href: '/register?plan=free&source=landing_pricing',
-        },
-      },
-      {
-        id: 'pro',
-        name: 'Pro',
-        priceLabel: '$19 / month',
-        summary: 'For creators publishing weekly.',
-        bullets: [
-          '50 blog drafts / month',
-          'Full AI authenticity check',
-          'SEO export + meta controls',
-        ],
-        cta: {
-          label: 'Start Pro trial',
-          href: '/register?plan=pro&source=landing_pricing',
-        },
-      },
-      {
-        id: 'team',
-        name: 'Team',
-        priceLabel: '$49 / user / month',
-        summary: 'Collaboration when you are ready.',
-        bullets: [
-          'Everything in Pro',
-          'Team workspaces',
-          'Admin controls (roadmap)',
-        ],
-        cta: {
-          label: 'Notify me',
-          href: '/register?plan=team_waitlist&source=landing_pricing',
-        },
-        comingSoon: true,
-        ctaAssistiveHint: 'Team tier is not yet purchasable. Continue to join the waitlist.',
-      },
-    ],
   },
 };


### PR DESCRIPTION
## Summary

US-SUB-09 — landing pricing section loads **public, non-archived** plans from `GET /api/plans` at runtime (no stale prerender data).

- `PlanCard.tsx` — shared card with limits derived from live plan data
- `Pricing.tsx` — client fetch on mount; removed hardcoded `pricing.tiers`
- `content.ts` — keeps section title, subtitle, and preview disclaimer only
- `plan-handler.test.ts` — public catalogue handler coverage

## Test plan

- [x] `npm run test --workspace=backend -- --run plan-handler`
- [x] `npm run typecheck --workspace=frontend`
- [ ] Manual: open `/` → pricing shows Free/Pro/Team from API; edit a public plan in admin → refresh landing

## Glossary

- **Public plan**: `is_public = true` and not archived — the only plans exposed on the landing page.
- **Runtime fetch**: Plans load after hydration so static prerender never freezes tier data.

Closes #151

Made with [Cursor](https://cursor.com)