### PR TITLE
feat(#153): admin per-user subscription management

### DIFF
--- a/backend/src/handlers/__tests__/subscription-admin-handler.test.ts
+++ b/backend/src/handlers/__tests__/subscription-admin-handler.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Request, Response, NextFunction } from 'express';
+import type { Plan, Subscription, SubscriptionView } from '../../domain/subscription-types.js';
+import { changeUserSubscription, getUserSubscription } from '../subscription-handler.js';
+import * as subscriptionService from '../../services/subscription-service.js';
+import { getSupabase } from '../../db/supabase.js';
+
+vi.mock('../../services/subscription-service.js');
+vi.mock('../../db/supabase.js', () => ({
+  getSupabase: vi.fn(),
+}));
+
+const VIEW: SubscriptionView = {
+  subscription: {
+    id: 'sub-1',
+    userId: 'user-1',
+    planId: 'plan-pro',
+    status: 'active',
+    currentPeriodStart: new Date('2026-05-01T00:00:00Z'),
+    currentPeriodEnd: new Date('2026-06-01T00:00:00Z'),
+    stripeSubscriptionId: null,
+    changedBy: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+  plan: {
+    id: 'plan-pro',
+    slug: 'pro',
+    name: 'Pro',
+    description: '',
+    priceCents: 1900,
+    currency: 'USD',
+    billingPeriod: 'monthly',
+    limits: { blogQuota: 50, aiCheckQuota: 200, authorProfileLimit: 10, referenceExtractionQuota: 300 },
+    isPublic: true,
+    isDefault: false,
+    archivedAt: null,
+    sortOrder: 2,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as Plan,
+  usage: [],
+  periodResetsAt: new Date('2026-06-01T00:00:00Z'),
+};
+
+function makeReq(body: unknown = {}, params: Record<string, string> = {}, userId = 'admin-1'): Request {
+  return { body, params, userId } as unknown as Request;
+}
+
+function makeRes(): { res: Response; json: ReturnType<typeof vi.fn> } {
+  const json = vi.fn();
+  const res = { json, status: vi.fn().mockReturnThis() } as unknown as Response;
+  return { res, json };
+}
+
+const next: NextFunction = vi.fn();
+
+function mockActiveUser() {
+  vi.mocked(getSupabase).mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: { deactivated_at: null }, error: null }),
+        }),
+      }),
+    }),
+  } as unknown as ReturnType<typeof getSupabase>);
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('getUserSubscription', () => {
+  it('returns subscription view JSON', async () => {
+    vi.mocked(subscriptionService.getSubscriptionView).mockResolvedValue(VIEW);
+    const { res, json } = makeRes();
+    await getUserSubscription(makeReq({}, { id: 'user-1' }), res, next);
+    expect(json).toHaveBeenCalledWith(expect.objectContaining({ plan: expect.objectContaining({ slug: 'pro' }) }));
+  });
+});
+
+describe('changeUserSubscription', () => {
+  it('records admin actor and respects downgrade block without override', async () => {
+    mockActiveUser();
+    const { AppError } = await import('../../middleware/error-handler.js');
+    vi.mocked(subscriptionService.changePlan).mockRejectedValue(
+      new AppError(409, 'DOWNGRADE_BLOCKED', 'blocked', {
+        conflicts: [{ metric: 'blogs', used: 5, limit: 3 }],
+      }),
+    );
+
+    await changeUserSubscription(
+      makeReq({ planId: 'plan-free', override: false }, { id: 'user-1' }, 'admin-9'),
+      makeRes().res,
+      next,
+    );
+    expect(subscriptionService.changePlan).toHaveBeenCalledWith('user-1', 'plan-free', {
+      actor: 'admin-9',
+      override: false,
+    });
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ code: 'DOWNGRADE_BLOCKED' }));
+  });
+
+  it('allows override and returns updated view', async () => {
+    mockActiveUser();
+    vi.mocked(subscriptionService.changePlan).mockResolvedValue({
+      ...VIEW,
+      subscription: { ...VIEW.subscription, planId: 'plan-free', changedBy: 'admin-9' },
+    });
+
+    const { res, json } = makeRes();
+    await changeUserSubscription(
+      makeReq({ planId: 'plan-free', override: true }, { id: 'user-1' }, 'admin-9'),
+      res,
+      next,
+    );
+
+    expect(subscriptionService.changePlan).toHaveBeenCalledWith('user-1', 'plan-free', {
+      actor: 'admin-9',
+      override: true,
+    });
+    expect(json).toHaveBeenCalled();
+  });
+
+  it('rejects plan change for deactivated users', async () => {
+    vi.mocked(getSupabase).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: { deactivated_at: '2026-05-01T00:00:00Z' },
+              error: null,
+            }),
+          }),
+        }),
+      }),
+    } as unknown as ReturnType<typeof getSupabase>);
+
+    await changeUserSubscription(
+      makeReq({ planId: 'plan-free' }, { id: 'user-1' }),
+      makeRes().res,
+      next,
+    );
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ code: 'USER_DEACTIVATED' }));
+    expect(subscriptionService.changePlan).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/handlers/subscription-handler.ts
+++ b/backend/src/handlers/subscription-handler.ts
@@ -1,8 +1,30 @@
 import type { Request, Response, NextFunction } from 'express';
 import type { Plan, Subscription, SubscriptionView, UsageSnapshot } from '../domain/subscription-types.js';
+import { getSupabase } from '../db/supabase.js';
 import { AppError } from '../middleware/error-handler.js';
 import { getUserId } from '../middleware/auth.js';
 import { changePlan, getSubscriptionView } from '../services/subscription-service.js';
+
+function routeParam(value: string | string[] | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  return Array.isArray(value) ? value[0] : value;
+}
+
+async function assertUserAllowsPlanChange(userId: string): Promise<void> {
+  const { data, error } = await getSupabase()
+    .from('users')
+    .select('deactivated_at')
+    .eq('id', userId)
+    .single<{ deactivated_at: string | null }>();
+
+  if (error?.code === 'PGRST116') {
+    throw new AppError(404, 'NOT_FOUND', 'User not found');
+  }
+  if (error) throw new Error(error.message);
+  if (data.deactivated_at) {
+    throw new AppError(400, 'USER_DEACTIVATED', 'Cannot change plan for a deactivated user');
+  }
+}
 
 function planToJson(plan: Plan) {
   return {
@@ -68,6 +90,40 @@ export async function changeMyPlan(req: Request, res: Response, next: NextFuncti
     }
 
     const view = await changePlan(userId, planId.trim(), { actor: null, override: false });
+    res.json(viewToJson(view));
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function getUserSubscription(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const userId = routeParam(req.params.id);
+    if (!userId) throw new AppError(400, 'VALIDATION', 'Missing user id');
+
+    const view = await getSubscriptionView(userId);
+    res.json(viewToJson(view));
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function changeUserSubscription(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const adminId = getUserId(req);
+    const userId = routeParam(req.params.id);
+    if (!userId) throw new AppError(400, 'VALIDATION', 'Missing user id');
+
+    await assertUserAllowsPlanChange(userId);
+
+    const body = req.body as Record<string, unknown>;
+    const planId = typeof body.planId === 'string' ? body.planId : typeof body.plan_id === 'string' ? body.plan_id : '';
+    if (!planId.trim()) {
+      throw new AppError(400, 'VALIDATION', 'planId is required');
+    }
+    const override = Boolean(body.override);
+
+    const view = await changePlan(userId, planId.trim(), { actor: adminId, override });
     res.json(viewToJson(view));
   } catch (err) {
     next(err);

--- a/backend/src/routes/admin-routes.ts
+++ b/backend/src/routes/admin-routes.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { requireAuth, requireAdmin } from '../middleware/auth.js';
 import * as adminHandler from '../handlers/admin-handler.js';
 import * as planAdminHandler from '../handlers/plan-admin-handler.js';
+import * as subscriptionHandler from '../handlers/subscription-handler.js';
 
 const router = Router();
 
@@ -10,6 +11,8 @@ router.use(requireAuth, requireAdmin);
 
 router.get('/users', adminHandler.listUsers);
 router.get('/users/:id/usage', adminHandler.getUserUsage);
+router.get('/users/:id/subscription', subscriptionHandler.getUserSubscription);
+router.put('/users/:id/subscription', subscriptionHandler.changeUserSubscription);
 router.get('/users/:id/profiles', adminHandler.listUserProfiles);
 router.put('/users/:userId/profiles/:profileId', adminHandler.adminUpdateUserProfile);
 router.post('/users/:id/deactivate', adminHandler.deactivateUser);

--- a/frontend/src/api/subscription-api.ts
+++ b/frontend/src/api/subscription-api.ts
@@ -107,3 +107,22 @@ export async function changeMyPlan(planId: string): Promise<SubscriptionView> {
   });
   return parseJson<SubscriptionView>(res);
 }
+
+const ADMIN = '/api/admin';
+
+export async function getAdminUserSubscription(userId: string): Promise<SubscriptionView> {
+  const res = await authedFetch(`${ADMIN}/users/${encodeURIComponent(userId)}/subscription`);
+  return parseJson<SubscriptionView>(res);
+}
+
+export async function changeAdminUserSubscription(
+  userId: string,
+  planId: string,
+  override = false,
+): Promise<SubscriptionView> {
+  const res = await authedFetch(`${ADMIN}/users/${encodeURIComponent(userId)}/subscription`, {
+    method: 'PUT',
+    body: JSON.stringify({ planId, override }),
+  });
+  return parseJson<SubscriptionView>(res);
+}

--- a/frontend/src/components/AdminUserSubscriptionPanel.tsx
+++ b/frontend/src/components/AdminUserSubscriptionPanel.tsx
@@ -1,0 +1,171 @@
+import { useCallback, useEffect, useState } from 'react';
+import { listAdminPlans, type AdminPlanRow } from '../api/admin-api';
+import {
+  SubscriptionApiError,
+  changeAdminUserSubscription,
+  getAdminUserSubscription,
+  type DowngradeConflict,
+  type SubscriptionView,
+} from '../api/subscription-api';
+import { UsageMeter } from './UsageMeter';
+import { Button } from './ui/button';
+import { Toast } from './ui/toast';
+
+const METRIC_LABELS: Record<DowngradeConflict['metric'], string> = {
+  blogs: 'Blogs per month',
+  ai_checks: 'AI checks per month',
+  author_profiles: 'Author profiles',
+  reference_extractions: 'Reference extractions per month',
+};
+
+function formatPrice(cents: number, currency: string): string {
+  return new Intl.NumberFormat(undefined, { style: 'currency', currency }).format(cents / 100);
+}
+
+function formatResetDate(iso: string): string {
+  try {
+    return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(
+      new Date(iso),
+    );
+  } catch {
+    return iso;
+  }
+}
+
+interface AdminUserSubscriptionPanelProps {
+  userId: string;
+  disabled: boolean;
+  onUpdated?: () => void;
+}
+
+export function AdminUserSubscriptionPanel({ userId, disabled, onUpdated }: AdminUserSubscriptionPanelProps) {
+  const [view, setView] = useState<SubscriptionView | null>(null);
+  const [plans, setPlans] = useState<AdminPlanRow[]>([]);
+  const [selectedPlanId, setSelectedPlanId] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setError(null);
+    setLoading(true);
+    try {
+      const [sub, { plans: catalogue }] = await Promise.all([
+        getAdminUserSubscription(userId),
+        listAdminPlans(),
+      ]);
+      setView(sub);
+      setPlans(catalogue.filter((p) => !p.archivedAt));
+      setSelectedPlanId(sub.plan.id);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function handleChange(override = false) {
+    if (!selectedPlanId || selectedPlanId === view?.plan.id) return;
+    setBusy(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      const updated = await changeAdminUserSubscription(userId, selectedPlanId, override);
+      setView(updated);
+      setSelectedPlanId(updated.plan.id);
+      setSuccess(`Subscription updated to ${updated.plan.name}.`);
+      onUpdated?.();
+    } catch (e) {
+      if (e instanceof SubscriptionApiError && e.code === 'DOWNGRADE_BLOCKED') {
+        const lines = e.conflicts.map(
+          (c) => `${METRIC_LABELS[c.metric]}: ${c.used} used, target plan allows ${c.limit}`,
+        );
+        const ok = window.confirm(
+          `Usage exceeds the target plan on: ${lines.join('; ')}. Override and move this user anyway? They keep grandfathered limits until the period resets.`,
+        );
+        if (ok) {
+          await handleChange(true);
+          return;
+        }
+        setError('Plan change cancelled. Reduce usage or choose override to proceed.');
+      } else {
+        setError((e as Error).message);
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (loading && !view) {
+    return <p className="text-sm text-slate-500">Loading subscription…</p>;
+  }
+
+  if (!view) {
+    return error ? <Toast variant="error">{error}</Toast> : null;
+  }
+
+  const activePlans = plans.filter((p) => p.id !== view.plan.id);
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-600">Subscription</h2>
+        <p className="mt-1 text-sm text-slate-600">
+          Current plan: <span className="font-medium text-slate-900">{view.plan.name}</span> (
+          {formatPrice(view.plan.priceCents, view.plan.currency)} / month, display only)
+        </p>
+        <p className="mt-1 text-xs text-slate-500">
+          Period resets{' '}
+          <time dateTime={view.periodResetsAt}>{formatResetDate(view.periodResetsAt)}</time>
+        </p>
+      </div>
+
+      <div className="space-y-3 rounded-lg border border-slate-100 bg-slate-50/80 p-4">
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Usage this period</p>
+        {view.usage.map((row) => (
+          <UsageMeter key={row.metric} row={row} periodLabel="this month" />
+        ))}
+      </div>
+
+      {error && <Toast variant="error">{error}</Toast>}
+      {success && <Toast variant="info">{success}</Toast>}
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+        <label className="min-w-0 flex-1 text-sm">
+          <span className="mb-1 block font-medium text-slate-700">Move to plan</span>
+          <select
+            className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/30 disabled:bg-slate-100"
+            value={selectedPlanId}
+            disabled={disabled || busy}
+            onChange={(e) => setSelectedPlanId(e.target.value)}
+          >
+            <option value={view.plan.id}>{view.plan.name} (current)</option>
+            {activePlans.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.name}
+                {p.isPublic ? '' : ' (private)'}
+              </option>
+            ))}
+          </select>
+        </label>
+        <Button
+          type="button"
+          size="sm"
+          disabled={disabled || busy || selectedPlanId === view.plan.id}
+          onClick={() => void handleChange(false)}
+        >
+          {busy ? 'Updating…' : 'Update plan'}
+        </Button>
+      </div>
+
+      {disabled && (
+        <p className="text-xs text-amber-800">Plan changes are disabled while this account is deactivated.</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/AdminUserDetailPage.tsx
+++ b/frontend/src/pages/admin/AdminUserDetailPage.tsx
@@ -2,6 +2,7 @@ import { Link, Navigate, useNavigate, useParams } from 'react-router-dom';
 import { useAdminDashboard } from './admin-context';
 import { AdminUserPanel } from '../../components/AdminUserPanel';
 import { AdminUserActions } from '../../components/AdminUserActions';
+import { AdminUserSubscriptionPanel } from '../../components/AdminUserSubscriptionPanel';
 
 function fmtDate(iso: string | null | undefined): string {
   if (!iso) return '—';
@@ -124,6 +125,14 @@ export default function AdminUserDetailPage() {
             </div>
           ) : null}
         </dl>
+
+        <div className="mt-8 border-t border-slate-100 pt-6">
+          <AdminUserSubscriptionPanel
+            userId={u.id}
+            disabled={isDeactivated}
+            onUpdated={() => void load({ keepNotice: true })}
+          />
+        </div>
 
         <div className="mt-8 border-t border-slate-100 pt-6">
           <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-600">Actions</h2>


### PR DESCRIPTION
## Summary

US-SUB-04 — admin can view a user's plan + period usage and move them to another plan, with override when usage exceeds target limits.

- `GET/PUT /api/admin/users/:id/subscription` — admin-only; sets `changed_by` on admin moves
- `AdminUserSubscriptionPanel` on user detail — usage meters, plan selector, override confirm on downgrade block
- Deactivated users: subscription shown, plan controls disabled

## Test plan

- [x] `npm run test --workspace=backend -- --run subscription` (18 tests)
- [x] `npm run typecheck --workspace=frontend`
- [ ] Manual: admin user detail → view usage → move user to another plan → override when over limit

## Glossary

- **Override**: Admin bypass of `DOWNGRADE_BLOCKED`; user is grandfathered for the current period.
- **changed_by**: Admin user id recorded on subscription row for admin-initiated plan changes.

Closes #153

Made with [Cursor](https://cursor.com)