### PR TITLE
feat(#154): quota enforcement on gated actions

### DIFF
--- a/backend/src/handlers/__tests__/blog-handler.test.ts
+++ b/backend/src/handlers/__tests__/blog-handler.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockListBlogsByUser, mockCreateBlog, mockGetUserId } = vi.hoisted(() => ({
+const { mockListBlogsByUser, mockCreateBlog, mockGetUserId, mockAssertWithinQuota } = vi.hoisted(() => ({
   mockListBlogsByUser: vi.fn(),
   mockCreateBlog: vi.fn(),
   mockGetUserId: vi.fn(() => 'user-1'),
+  mockAssertWithinQuota: vi.fn(),
 }));
 
 vi.mock('../../repositories/blog-repository.js', () => ({
@@ -17,7 +18,12 @@ vi.mock('../../middleware/auth.js', () => ({
   getUserId: mockGetUserId,
 }));
 
-import { handleListBlogs } from '../blog-handler.js';
+vi.mock('../../services/quota-enforcement.js', () => ({
+  assertWithinQuota: mockAssertWithinQuota,
+}));
+
+import { handleCreateBlog, handleListBlogs } from '../blog-handler.js';
+import { AppError } from '../../middleware/error-handler.js';
 import type { Request, Response, NextFunction } from 'express';
 
 function makeReqRes() {
@@ -56,5 +62,32 @@ describe('handleListBlogs', () => {
     await handleListBlogs(req, res, next);
 
     expect(next).toHaveBeenCalledWith(expect.any(Error));
+  });
+});
+
+describe('handleCreateBlog', () => {
+  it('checks blog quota before creating', async () => {
+    mockAssertWithinQuota.mockResolvedValue(undefined);
+    mockCreateBlog.mockResolvedValue({ id: 'b-new', currentStep: 1 });
+
+    const { req, res, json, next } = makeReqRes();
+    await handleCreateBlog(req, res, next);
+
+    expect(mockAssertWithinQuota).toHaveBeenCalledWith('user-1', 'blogs');
+    expect(mockCreateBlog).toHaveBeenCalledWith('user-1');
+    expect(json).toHaveBeenCalledWith({ blogId: 'b-new', currentStep: 1 });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('does not create a blog when quota is exceeded', async () => {
+    mockAssertWithinQuota.mockRejectedValue(
+      new AppError(402, 'QUOTA_EXCEEDED', 'limit', { metric: 'blogs', limit: 3, usage: 3 }),
+    );
+
+    const { req, res, next } = makeReqRes();
+    await handleCreateBlog(req, res, next);
+
+    expect(mockCreateBlog).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 402, code: 'QUOTA_EXCEEDED' }));
   });
 });

--- a/backend/src/handlers/__tests__/blog-references-handler.test.ts
+++ b/backend/src/handlers/__tests__/blog-references-handler.test.ts
@@ -11,6 +11,7 @@ const {
   mockScrapeInBackground,
   mockExtractInBackground,
   mockGetUserId,
+  mockAssertWithinQuota,
 } = vi.hoisted(() => ({
   mockGetBlogByIdAndUser: vi.fn(),
   mockCountRefs: vi.fn(),
@@ -22,6 +23,7 @@ const {
   mockScrapeInBackground: vi.fn(),
   mockExtractInBackground: vi.fn(),
   mockGetUserId: vi.fn(() => 'user-1'),
+  mockAssertWithinQuota: vi.fn(),
 }));
 
 vi.mock('../../repositories/blog-repository.js', () => ({
@@ -49,6 +51,10 @@ vi.mock('../../services/reference-extraction-runner.js', () => ({
 
 vi.mock('../../middleware/auth.js', () => ({
   getUserId: mockGetUserId,
+}));
+
+vi.mock('../../services/quota-enforcement.js', () => ({
+  assertWithinQuota: mockAssertWithinQuota,
 }));
 
 import {
@@ -87,6 +93,7 @@ function makeReqRes(blogId: string, body: Record<string, unknown> = {}, params: 
 beforeEach(() => {
   vi.clearAllMocks();
   mockGetUserId.mockReturnValue('user-1');
+  mockAssertWithinQuota.mockResolvedValue(undefined);
 });
 
 describe('handleAddReference', () => {
@@ -98,6 +105,7 @@ describe('handleAddReference', () => {
     const { req, res, json, next } = makeReqRes('blog-1', { url: 'https://example.com/article' });
     await handleAddReference(req, res, next);
 
+    expect(mockAssertWithinQuota).toHaveBeenCalledWith('user-1', 'reference_extractions');
     expect(mockInsertRef).toHaveBeenCalledWith('blog-1', 'https://example.com/article', 1);
     expect(mockScrapeInBackground).toHaveBeenCalledWith('ref-1', 'https://example.com/article');
     expect(json).toHaveBeenCalledWith({ reference: fakeRef });

--- a/backend/src/handlers/__tests__/profile-handler.test.ts
+++ b/backend/src/handlers/__tests__/profile-handler.test.ts
@@ -12,6 +12,11 @@ import { AppError } from '../../middleware/error-handler.js';
 
 vi.mock('../../repositories/profile-repository.js');
 
+const mockAssertWithinQuota = vi.fn();
+vi.mock('../../services/quota-enforcement.js', () => ({
+  assertWithinQuota: (...args: unknown[]) => mockAssertWithinQuota(...args),
+}));
+
 const SAMPLE_PROFILE = {
   id: 'p-1',
   userId: '00000000-0000-0000-0000-000000000001',
@@ -45,7 +50,10 @@ function makeRes(): { res: Response; json: ReturnType<typeof vi.fn>; status: Ret
 
 const next: NextFunction = vi.fn();
 
-beforeEach(() => vi.clearAllMocks());
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAssertWithinQuota.mockResolvedValue(undefined);
+});
 
 describe('handleListProfiles', () => {
   it('returns profiles from repository', async () => {
@@ -91,6 +99,16 @@ describe('handleCreateProfile — validation', () => {
     expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 400 }));
   });
 
+  it('checks author profile quota before create', async () => {
+    vi.mocked(repo.createProfile).mockResolvedValue(SAMPLE_PROFILE);
+    const { res } = makeRes();
+    await handleCreateProfile(makeReq({
+      name: 'Test Profile', authorRole: 'CTO', audiencePersona: 'Engineers',
+      intent: 'thought_leadership', toneOfVoice: 'Direct',
+    }), res, next);
+    expect(mockAssertWithinQuota).toHaveBeenCalledWith('00000000-0000-0000-0000-000000000001', 'author_profiles');
+  });
+
   it('creates profile from valid payload', async () => {
     vi.mocked(repo.createProfile).mockResolvedValue(SAMPLE_PROFILE);
     const { res, status } = makeRes();
@@ -114,6 +132,7 @@ describe('handleCreateProfile — validation', () => {
     vi.mocked(repo.cloneProfileFromPredefined).mockResolvedValue(SAMPLE_PROFILE);
     const { res, status } = makeRes();
     await handleCreateProfile(makeReq({ cloneFromPredefinedId: 'pred-1' }), res, next);
+    expect(mockAssertWithinQuota).toHaveBeenCalledWith('00000000-0000-0000-0000-000000000001', 'author_profiles');
     expect(repo.cloneProfileFromPredefined).toHaveBeenCalledWith('00000000-0000-0000-0000-000000000001', 'pred-1');
     expect(status).toHaveBeenCalledWith(201);
   });

--- a/backend/src/handlers/blog-ai-check-handler.ts
+++ b/backend/src/handlers/blog-ai-check-handler.ts
@@ -23,6 +23,7 @@ import {
   runAiDetectorLlm,
   truncateToWordBudget,
 } from '../services/ai-detector-service.js';
+import { assertWithinQuota } from '../services/quota-enforcement.js';
 
 function buildHaystack(cleanedBody: string, seoTitle: string, meta: string): string {
   return `${cleanedBody}\n\n${seoTitle}\n\n${meta}`;
@@ -89,6 +90,8 @@ export async function handleRunAiCheck(
     if (!allowAiCheckForBlog(blogId)) {
       throw new AppError(429, 'RATE_LIMITED', 'Too many AI checks for this draft — try again in an hour.');
     }
+
+    await assertWithinQuota(userId, 'ai_checks');
 
     const { cleanedForScoring, excluded } = stripExcludedSegments(bodyRaw);
     const wc = wordCount(cleanedForScoring);

--- a/backend/src/handlers/blog-handler.ts
+++ b/backend/src/handlers/blog-handler.ts
@@ -2,6 +2,7 @@ import type { Request, Response, NextFunction } from 'express';
 import { createBlog, getBlogByIdAndUser, listBlogsByUser, advanceBlogStep } from '../repositories/blog-repository.js';
 import { AppError } from '../middleware/error-handler.js';
 import { getUserId } from '../middleware/auth.js';
+import { assertWithinQuota } from '../services/quota-enforcement.js';
 
 export async function handleListBlogs(
   req: Request,
@@ -24,6 +25,7 @@ export async function handleCreateBlog(
 ): Promise<void> {
   try {
     const userId = getUserId(req as Request & { userId?: string });
+    await assertWithinQuota(userId, 'blogs');
     const blog = await createBlog(userId);
     res.status(201).json({ blogId: blog.id, currentStep: blog.currentStep });
   } catch (err) {

--- a/backend/src/handlers/blog-references-handler.ts
+++ b/backend/src/handlers/blog-references-handler.ts
@@ -13,6 +13,7 @@ import { extractReferenceInBackground } from '../services/reference-extraction-r
 import { ReferenceUrl } from '../domain/value-objects.js';
 import { AppError } from '../middleware/error-handler.js';
 import { getUserId } from '../middleware/auth.js';
+import { assertWithinQuota } from '../services/quota-enforcement.js';
 
 const MAX_REFERENCES = 5;
 
@@ -60,6 +61,8 @@ export async function handleAddReference(
     if (count >= MAX_REFERENCES) {
       throw new AppError(400, 'VALIDATION_ERROR', `Maximum of ${MAX_REFERENCES} reference URLs allowed`);
     }
+
+    await assertWithinQuota(userId, 'reference_extractions');
 
     const reference = await insertReference(blogId, validUrl, count + 1);
     scrapeReferenceInBackground(reference.id, validUrl);

--- a/backend/src/handlers/profile-handler.ts
+++ b/backend/src/handlers/profile-handler.ts
@@ -11,6 +11,7 @@ import {
 import { AppError } from '../middleware/error-handler.js';
 import type { BlogIntent } from '../domain/types.js';
 import { getUserId } from '../middleware/auth.js';
+import { assertWithinQuota } from '../services/quota-enforcement.js';
 
 const VALID_INTENTS = new Set<BlogIntent>([
   'thought_leadership',
@@ -221,6 +222,7 @@ export async function handleCreateProfile(
     if (cloneErrors.length === 0) {
       const b = body as Record<string, unknown>;
       const cloneFromId = b.cloneFromPredefinedId as string;
+      await assertWithinQuota(userId, 'author_profiles');
       const profile = await cloneProfileFromPredefined(userId, cloneFromId);
       res.status(201).json({ profile });
       return;
@@ -233,6 +235,7 @@ export async function handleCreateProfile(
     }
 
     const b = body as Record<string, unknown>;
+    await assertWithinQuota(userId, 'author_profiles');
     const profile = await createProfile(
       userId,
       b.name as string,

--- a/backend/src/services/__tests__/quota-service.test.ts
+++ b/backend/src/services/__tests__/quota-service.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Plan, UsageSnapshot } from '../../domain/subscription-types.js';
+import { AppError } from '../../middleware/error-handler.js';
+import * as planRepo from '../../repositories/plan-repository.js';
+import * as subRepo from '../../repositories/subscription-repository.js';
+import * as quotaService from '../quota-service.js';
+import { assertWithinQuota } from '../quota-enforcement.js';
+
+vi.mock('../../repositories/plan-repository.js');
+vi.mock('../../repositories/subscription-repository.js');
+vi.mock('../quota-service.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../quota-service.js')>();
+  return {
+    ...actual,
+    computeUsage: vi.fn(),
+  };
+});
+
+const PLAN: Plan = {
+  id: 'plan-free',
+  slug: 'free',
+  name: 'Free',
+  description: '',
+  priceCents: 0,
+  currency: 'USD',
+  billingPeriod: 'monthly',
+  limits: { blogQuota: 3, aiCheckQuota: 5, authorProfileLimit: 1, referenceExtractionQuota: 10 },
+  isPublic: true,
+  isDefault: true,
+  archivedAt: null,
+  sortOrder: 1,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const SUBSCRIPTION = {
+  id: 'sub-1',
+  userId: 'user-1',
+  planId: 'plan-free',
+  status: 'active' as const,
+  currentPeriodStart: new Date('2026-05-01T00:00:00Z'),
+  currentPeriodEnd: new Date('2026-06-01T00:00:00Z'),
+  stripeSubscriptionId: null,
+  changedBy: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+function usageFor(metric: UsageSnapshot['metric'], used: number, limit: number | null): UsageSnapshot[] {
+  return [
+    { metric: 'blogs', used: 0, limit: 3, exceeded: false },
+    { metric: 'ai_checks', used: 0, limit: 5, exceeded: false },
+    { metric: 'author_profiles', used: 0, limit: 1, exceeded: false },
+    { metric: 'reference_extractions', used: 0, limit: 10, exceeded: false },
+  ].map((row) =>
+    row.metric === metric
+      ? { ...row, used, limit, exceeded: limit !== null && used >= limit }
+      : row,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(subRepo.getActiveSubscriptionByUserId).mockResolvedValue(SUBSCRIPTION);
+  vi.mocked(planRepo.getPlanById).mockResolvedValue(PLAN);
+});
+
+describe('assertWithinQuota', () => {
+  it('blocks when used equals the limit (inclusive max)', async () => {
+    vi.mocked(quotaService.computeUsage).mockResolvedValue(usageFor('blogs', 3, 3));
+
+    await expect(assertWithinQuota('user-1', 'blogs')).rejects.toMatchObject({
+      status: 402,
+      code: 'QUOTA_EXCEEDED',
+      details: { metric: 'blogs', limit: 3, usage: 3 },
+    });
+  });
+
+  it('allows when used is below the limit', async () => {
+    vi.mocked(quotaService.computeUsage).mockResolvedValue(usageFor('blogs', 2, 3));
+
+    await expect(assertWithinQuota('user-1', 'blogs')).resolves.toBeUndefined();
+  });
+
+  it('never blocks when the plan limit is unlimited', async () => {
+    const unlimitedPlan: Plan = {
+      ...PLAN,
+      limits: { blogQuota: null, aiCheckQuota: null, authorProfileLimit: null, referenceExtractionQuota: null },
+    };
+    vi.mocked(planRepo.getPlanById).mockResolvedValue(unlimitedPlan);
+    vi.mocked(quotaService.computeUsage).mockResolvedValue(usageFor('blogs', 999, null));
+
+    await expect(assertWithinQuota('user-1', 'blogs')).resolves.toBeUndefined();
+  });
+
+  it('throws 402 for ai_checks, author_profiles, and reference_extractions at limit', async () => {
+    for (const metric of ['ai_checks', 'author_profiles', 'reference_extractions'] as const) {
+      vi.mocked(quotaService.computeUsage).mockResolvedValue(usageFor(metric, 10, 10));
+      await expect(assertWithinQuota('user-1', metric)).rejects.toBeInstanceOf(AppError);
+    }
+  });
+});

--- a/backend/src/services/quota-enforcement.ts
+++ b/backend/src/services/quota-enforcement.ts
@@ -1,0 +1,43 @@
+import type { QuotaMetric } from '../domain/subscription-types.js';
+import { AppError } from '../middleware/error-handler.js';
+import { getPlanById } from '../repositories/plan-repository.js';
+import { getActiveSubscriptionByUserId } from '../repositories/subscription-repository.js';
+import { computeUsage, QUOTA_METRIC_LABELS } from './quota-service.js';
+
+/**
+ * Throws when the user is at or over the plan limit for `metric`.
+ * No-ops when under the limit or the plan grants unlimited usage for that metric.
+ */
+export async function assertWithinQuota(userId: string, metric: QuotaMetric): Promise<void> {
+  const subscription = await getActiveSubscriptionByUserId(userId);
+  if (!subscription) {
+    throw new AppError(404, 'NO_SUBSCRIPTION', 'No active subscription found for this account');
+  }
+
+  const plan = await getPlanById(subscription.planId);
+  if (!plan) {
+    throw new AppError(500, 'PLAN_MISSING', 'Subscription references a plan that no longer exists');
+  }
+
+  const usage = await computeUsage(
+    userId,
+    subscription.currentPeriodStart,
+    subscription.currentPeriodEnd,
+    plan.limits,
+  );
+
+  const row = usage.find((u) => u.metric === metric);
+  if (!row) {
+    throw new Error(`Unknown quota metric: ${metric}`);
+  }
+
+  if (!row.exceeded) return;
+
+  const label = QUOTA_METRIC_LABELS[metric];
+  throw new AppError(
+    402,
+    'QUOTA_EXCEEDED',
+    `You have reached your ${label}. Upgrade your plan to continue.`,
+    { metric, limit: row.limit, usage: row.used },
+  );
+}

--- a/backend/src/services/quota-service.ts
+++ b/backend/src/services/quota-service.ts
@@ -1,5 +1,12 @@
-import { getSupabase } from '../db/supabase.js';
 import type { PlanLimits, QuotaMetric, UsageSnapshot } from '../domain/subscription-types.js';
+import { getSupabase } from '../db/supabase.js';
+
+export const QUOTA_METRIC_LABELS: Record<QuotaMetric, string> = {
+  blogs: 'blog quota',
+  ai_checks: 'AI check quota',
+  author_profiles: 'author profile limit',
+  reference_extractions: 'reference extraction quota',
+};
 
 function snapshot(metric: QuotaMetric, used: number, limit: number | null): UsageSnapshot {
   const exceeded = limit !== null && used >= limit;

--- a/frontend/src/api/api-errors.ts
+++ b/frontend/src/api/api-errors.ts
@@ -1,0 +1,76 @@
+import type { QuotaMetric } from './subscription-api.js';
+
+export interface QuotaExceededDetails {
+  metric: QuotaMetric;
+  limit: number;
+  usage: number;
+}
+
+export class QuotaApiError extends Error {
+  readonly code = 'QUOTA_EXCEEDED';
+  readonly metric: QuotaMetric;
+  readonly limit: number;
+  readonly usage: number;
+
+  constructor(message: string, details: QuotaExceededDetails) {
+    super(message);
+    this.name = 'QuotaApiError';
+    this.metric = details.metric;
+    this.limit = details.limit;
+    this.usage = details.usage;
+  }
+}
+
+export interface ParsedApiError {
+  message: string;
+  code?: string;
+  quota?: QuotaExceededDetails;
+}
+
+function isQuotaMetric(value: unknown): value is QuotaMetric {
+  return (
+    value === 'blogs' ||
+    value === 'ai_checks' ||
+    value === 'author_profiles' ||
+    value === 'reference_extractions'
+  );
+}
+
+function parseQuotaDetails(details: unknown): QuotaExceededDetails | undefined {
+  if (!details || typeof details !== 'object') return undefined;
+  const d = details as Record<string, unknown>;
+  if (!isQuotaMetric(d.metric)) return undefined;
+  if (typeof d.limit !== 'number' || typeof d.usage !== 'number') return undefined;
+  return { metric: d.metric, limit: d.limit, usage: d.usage };
+}
+
+export function parseApiError(body: unknown, status: number): ParsedApiError {
+  if (!body || typeof body !== 'object') {
+    return { message: 'Request failed' };
+  }
+
+  const err = (body as { error?: unknown }).error;
+  if (!err || typeof err !== 'object' || err === null) {
+    return { message: 'Request failed' };
+  }
+
+  const e = err as {
+    message?: unknown;
+    code?: unknown;
+    details?: unknown;
+  };
+
+  const message = typeof e.message === 'string' ? e.message : 'Request failed';
+  const code = typeof e.code === 'string' ? e.code : undefined;
+  const quota =
+    status === 402 && code === 'QUOTA_EXCEEDED' ? parseQuotaDetails(e.details) : undefined;
+
+  return { message, code, quota };
+}
+
+export function throwForApiResponse(_status: number, parsed: ParsedApiError): never {
+  if (parsed.quota) {
+    throw new QuotaApiError(parsed.message, parsed.quota);
+  }
+  throw new Error(parsed.message);
+}

--- a/frontend/src/api/blog-api.ts
+++ b/frontend/src/api/blog-api.ts
@@ -1,4 +1,5 @@
 import { authedFetch } from '../lib/authed-fetch.js';
+import { parseApiError, throwForApiResponse } from './api-errors.js';
 
 const BASE = '/api/blogs';
 
@@ -44,10 +45,9 @@ async function request<T>(url: string, options?: RequestInit): Promise<T> {
     headers: { 'Content-Type': 'application/json' },
     ...options,
   });
-  const body = await res.json() as unknown;
+  const body = (await res.json()) as unknown;
   if (!res.ok) {
-    const err = body as { error?: { message?: string } };
-    throw new Error(err.error?.message ?? 'Request failed');
+    throwForApiResponse(res.status, parseApiError(body, res.status));
   }
   return body as T;
 }

--- a/frontend/src/api/profile-api.ts
+++ b/frontend/src/api/profile-api.ts
@@ -1,4 +1,5 @@
 import { authedFetch } from '../lib/authed-fetch.js';
+import { parseApiError, throwForApiResponse } from './api-errors.js';
 
 const BASE = '/api/profiles';
 
@@ -38,8 +39,7 @@ async function request<T>(url: string, options?: RequestInit): Promise<T> {
   });
   const body = (await res.json()) as unknown;
   if (!res.ok) {
-    const err = body as { error?: { message?: string } };
-    throw new Error(err.error?.message ?? 'Request failed');
+    throwForApiResponse(res.status, parseApiError(body, res.status));
   }
   return body as T;
 }

--- a/frontend/src/components/AuthenticityPanel.tsx
+++ b/frontend/src/components/AuthenticityPanel.tsx
@@ -6,6 +6,9 @@ import {
   recordBlogAnalyticsEvent,
   type AiCheckResponse,
 } from '../api/blog-api.js';
+import { QuotaApiError } from '../api/api-errors.js';
+import { recordQuotaBlocked } from '../lib/plan-analytics.js';
+import { QuotaBlockPrompt } from './QuotaBlockPrompt.js';
 import { Button } from './ui/button.js';
 
 function scoreBadgeClass(score: number | null): string {
@@ -87,12 +90,14 @@ export function AuthenticityPanel({
 }: Props) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [quotaBlock, setQuotaBlock] = useState<QuotaApiError | null>(null);
   const [result, setResult] = useState<AiCheckResponse | null>(null);
   const [rulesOpen, setRulesOpen] = useState(false);
   const [sectionsOpen, setSectionsOpen] = useState(false);
 
   const run = useCallback(async () => {
     setError(null);
+    setQuotaBlock(null);
     setLoading(true);
     try {
       const res = await runAiCheck(blogId);
@@ -101,7 +106,12 @@ export function AuthenticityPanel({
         type: res.cached ? 'ai_check_cache_hit' : 'ai_check_run',
       });
     } catch (e) {
-      setError((e as Error).message);
+      if (e instanceof QuotaApiError) {
+        recordQuotaBlocked(e.metric);
+        setQuotaBlock(e);
+      } else {
+        setError((e as Error).message);
+      }
     } finally {
       setLoading(false);
     }
@@ -142,6 +152,17 @@ export function AuthenticityPanel({
           </Link>
         </div>
       </div>
+
+      {quotaBlock && (
+        <div className="mt-3">
+          <QuotaBlockPrompt
+            metric={quotaBlock.metric}
+            limit={quotaBlock.limit}
+            usage={quotaBlock.usage}
+            message={quotaBlock.message}
+          />
+        </div>
+      )}
 
       {error && (
         <p className="mt-3 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-800" role="alert">

--- a/frontend/src/components/ProfileSettings.tsx
+++ b/frontend/src/components/ProfileSettings.tsx
@@ -1,7 +1,10 @@
 import { useState, useEffect } from 'react';
 import type { AuthorProfile, CreateProfilePayload } from '../api/profile-api.js';
 import { listProfiles, createProfile, updateProfile, deleteProfile } from '../api/profile-api.js';
+import { QuotaApiError } from '../api/api-errors.js';
+import { recordQuotaBlocked } from '../lib/plan-analytics.js';
 import { ProfileForm } from './ProfileForm.js';
+import { QuotaBlockPrompt } from './QuotaBlockPrompt.js';
 import { Button } from './ui/button.js';
 import { Toast } from './ui/toast.js';
 
@@ -18,6 +21,7 @@ export function ProfileSettings({ activeProfileId, onActiveProfileChange, onBack
   const [view, setView] = useState<View>('list');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [quotaBlock, setQuotaBlock] = useState<QuotaApiError | null>(null);
   const [successMsg, setSuccessMsg] = useState<string | null>(null);
 
   useEffect(() => {
@@ -36,13 +40,19 @@ export function ProfileSettings({ activeProfileId, onActiveProfileChange, onBack
   async function handleCreate(values: CreateProfilePayload) {
     setIsLoading(true);
     setError(null);
+    setQuotaBlock(null);
     try {
       const { profile } = await createProfile(values);
       setProfiles((prev) => [...prev, profile]);
       setView('list');
       setSuccessMsg(`Profile "${profile.name}" created.`);
     } catch (e) {
-      setError((e as Error).message);
+      if (e instanceof QuotaApiError) {
+        recordQuotaBlocked(e.metric);
+        setQuotaBlock(e);
+      } else {
+        setError((e as Error).message);
+      }
     } finally {
       setIsLoading(false);
     }
@@ -90,6 +100,14 @@ export function ProfileSettings({ activeProfileId, onActiveProfileChange, onBack
           </button>
           <h2 className="text-lg font-semibold text-slate-800">Create New Profile</h2>
         </div>
+        {quotaBlock && (
+          <QuotaBlockPrompt
+            metric={quotaBlock.metric}
+            limit={quotaBlock.limit}
+            usage={quotaBlock.usage}
+            message={quotaBlock.message}
+          />
+        )}
         {error && <Toast variant="error">{error}</Toast>}
         <ProfileForm
           onSubmit={handleCreate}

--- a/frontend/src/components/ProfileWizard.tsx
+++ b/frontend/src/components/ProfileWizard.tsx
@@ -1,7 +1,10 @@
 import { useState, useEffect } from 'react';
 import type { AuthorProfile, CreateProfilePayload } from '../api/profile-api.js';
 import { getPredefinedProfiles, cloneProfile, createProfile, updateProfile } from '../api/profile-api.js';
+import { QuotaApiError } from '../api/api-errors.js';
+import { recordQuotaBlocked } from '../lib/plan-analytics.js';
 import { ProfileForm } from './ProfileForm.js';
+import { QuotaBlockPrompt } from './QuotaBlockPrompt.js';
 import { Button } from './ui/button.js';
 import { Toast } from './ui/toast.js';
 
@@ -17,6 +20,7 @@ export function ProfileWizard({ onProfileSelected }: Props) {
   const [selectedProfile, setSelectedProfile] = useState<AuthorProfile | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [quotaBlock, setQuotaBlock] = useState<QuotaApiError | null>(null);
 
   useEffect(() => {
     async function loadProfiles() {
@@ -33,12 +37,18 @@ export function ProfileWizard({ onProfileSelected }: Props) {
   async function handlePickPredefined(profile: AuthorProfile) {
     setIsLoading(true);
     setError(null);
+    setQuotaBlock(null);
     try {
       const { profile: cloned } = await cloneProfile({ cloneFromPredefinedId: profile.id });
       setSelectedProfile(cloned);
       setStep('customize');
     } catch (e) {
-      setError((e as Error).message);
+      if (e instanceof QuotaApiError) {
+        recordQuotaBlocked(e.metric);
+        setQuotaBlock(e);
+      } else {
+        setError((e as Error).message);
+      }
     } finally {
       setIsLoading(false);
     }
@@ -47,11 +57,17 @@ export function ProfileWizard({ onProfileSelected }: Props) {
   async function handleCreateFromScratch(values: CreateProfilePayload) {
     setIsLoading(true);
     setError(null);
+    setQuotaBlock(null);
     try {
       const { profile: created } = await createProfile(values);
       onProfileSelected(created);
     } catch (e) {
-      setError((e as Error).message);
+      if (e instanceof QuotaApiError) {
+        recordQuotaBlocked(e.metric);
+        setQuotaBlock(e);
+      } else {
+        setError((e as Error).message);
+      }
     } finally {
       setIsLoading(false);
     }
@@ -81,6 +97,14 @@ export function ProfileWizard({ onProfileSelected }: Props) {
           </p>
         </div>
 
+        {quotaBlock && (
+          <QuotaBlockPrompt
+            metric={quotaBlock.metric}
+            limit={quotaBlock.limit}
+            usage={quotaBlock.usage}
+            message={quotaBlock.message}
+          />
+        )}
         {error && <Toast variant="error">{error}</Toast>}
 
         <div className="grid gap-4 sm:grid-cols-2">
@@ -123,6 +147,14 @@ export function ProfileWizard({ onProfileSelected }: Props) {
           </p>
         </div>
 
+        {quotaBlock && (
+          <QuotaBlockPrompt
+            metric={quotaBlock.metric}
+            limit={quotaBlock.limit}
+            usage={quotaBlock.usage}
+            message={quotaBlock.message}
+          />
+        )}
         {error && <Toast variant="error">{error}</Toast>}
 
         <div className="rounded-lg border border-slate-200 bg-slate-50 p-6">

--- a/frontend/src/components/QuotaBlockPrompt.tsx
+++ b/frontend/src/components/QuotaBlockPrompt.tsx
@@ -1,0 +1,41 @@
+import { Link } from 'react-router-dom';
+import type { QuotaMetric } from '../api/subscription-api.js';
+import { Button } from './ui/button.js';
+
+const METRIC_LABELS: Record<QuotaMetric, string> = {
+  blogs: 'blogs this month',
+  ai_checks: 'AI checks this month',
+  author_profiles: 'author profiles',
+  reference_extractions: 'reference extractions this month',
+};
+
+interface QuotaBlockPromptProps {
+  metric: QuotaMetric;
+  limit: number;
+  usage: number;
+  message?: string;
+}
+
+export function QuotaBlockPrompt({ metric, limit, usage, message }: QuotaBlockPromptProps) {
+  const label = METRIC_LABELS[metric];
+  const body =
+    message ??
+    `You have used ${usage} of ${limit} ${label} on your current plan. Upgrade to continue.`;
+
+  return (
+    <div
+      role="alert"
+      className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950"
+    >
+      <p className="font-medium">Plan limit reached</p>
+      <p className="mt-1">{body}</p>
+      <div className="mt-3">
+        <Link to="/plan">
+          <Button type="button" size="sm">
+            View plan &amp; usage
+          </Button>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ReferenceUrlList.tsx
+++ b/frontend/src/components/ReferenceUrlList.tsx
@@ -1,5 +1,8 @@
 import { useState, useCallback } from 'react';
 import { addReference, type BlogReference, type ReferenceScrapeStatus, type ReferenceExtractionStatus } from '../api/blog-api.js';
+import { QuotaApiError } from '../api/api-errors.js';
+import { recordQuotaBlocked } from '../lib/plan-analytics.js';
+import { QuotaBlockPrompt } from './QuotaBlockPrompt.js';
 import { ReferenceUrlCard } from './ReferenceUrlCard.js';
 import { Input } from './ui/input.js';
 import { Button } from './ui/button.js';
@@ -16,6 +19,7 @@ export function ReferenceUrlList({ blogId, initialReferences = [] }: Props) {
   const [references, setReferences] = useState<BlogReference[]>(initialReferences);
   const [inputValue, setInputValue] = useState('');
   const [inputError, setInputError] = useState<string | null>(null);
+  const [quotaBlock, setQuotaBlock] = useState<QuotaApiError | null>(null);
   const [adding, setAdding] = useState(false);
 
   async function handleAdd() {
@@ -33,13 +37,19 @@ export function ReferenceUrlList({ blogId, initialReferences = [] }: Props) {
     }
 
     setInputError(null);
+    setQuotaBlock(null);
     setAdding(true);
     try {
       const { reference } = await addReference(blogId, url);
       setReferences((prev) => [...prev, reference]);
       setInputValue('');
     } catch (e) {
-      setInputError((e as Error).message);
+      if (e instanceof QuotaApiError) {
+        recordQuotaBlocked(e.metric);
+        setQuotaBlock(e);
+      } else {
+        setInputError((e as Error).message);
+      }
     } finally {
       setAdding(false);
     }
@@ -89,6 +99,15 @@ export function ReferenceUrlList({ blogId, initialReferences = [] }: Props) {
           onReferenceUpdate={handleReferenceUpdate}
         />
       ))}
+
+      {quotaBlock && (
+        <QuotaBlockPrompt
+          metric={quotaBlock.metric}
+          limit={quotaBlock.limit}
+          usage={quotaBlock.usage}
+          message={quotaBlock.message}
+        />
+      )}
 
       {references.length < MAX_REFERENCES && (
         <div className="flex flex-col gap-1">

--- a/frontend/src/lib/plan-analytics.ts
+++ b/frontend/src/lib/plan-analytics.ts
@@ -1,5 +1,7 @@
 /** Subscription plan analytics — wire to product SDK when available. */
 
+import type { QuotaMetric } from '../api/subscription-api.js';
+
 export type PlanChangedPayload = {
   from_plan_slug: string;
   to_plan_slug: string;
@@ -16,5 +18,12 @@ export function recordPlanChanged(payload: PlanChangedPayload): void {
   if (import.meta.env.DEV) {
     // eslint-disable-next-line no-console -- dev-only funnel debugging
     console.debug('[plan analytics] plan_changed', payload);
+  }
+}
+
+export function recordQuotaBlocked(metric: QuotaMetric): void {
+  if (import.meta.env.DEV) {
+    // eslint-disable-next-line no-console -- dev-only funnel debugging
+    console.debug('[plan analytics] quota_blocked', { metric });
   }
 }

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -16,7 +16,10 @@ import { Toast } from '../components/ui/toast.js';
 import { WorkspaceLayout } from '../components/WorkspaceLayout';
 import { WorkspaceSidebar } from '../components/WorkspaceSidebar';
 import { createBlog } from '../api/blog-api.js';
+import { QuotaApiError } from '../api/api-errors.js';
 import { listProfiles } from '../api/profile-api.js';
+import { QuotaBlockPrompt } from '../components/QuotaBlockPrompt.js';
+import { recordQuotaBlocked } from '../lib/plan-analytics.js';
 import { useAuth } from '../context/AuthContext';
 
 type AppState =
@@ -58,6 +61,7 @@ export default function Dashboard() {
   const location = useLocation();
   const [state, setState] = useState<AppState>({ step: 'idle' });
   const [error, setError] = useState<string | null>(null);
+  const [quotaBlock, setQuotaBlock] = useState<QuotaApiError | null>(null);
   const [activeProfileId, setActiveProfileId] = useState<string | null>(() => {
     return localStorage.getItem(ACTIVE_PROFILE_KEY);
   });
@@ -96,12 +100,18 @@ export default function Dashboard() {
 
   async function startNewBlog() {
     setError(null);
+    setQuotaBlock(null);
     setState({ step: 'creating' });
     try {
       const { blogId } = await createBlog();
       setState({ step: 'brief', blogId });
     } catch (e) {
-      setError((e as Error).message);
+      if (e instanceof QuotaApiError) {
+        recordQuotaBlocked(e.metric);
+        setQuotaBlock(e);
+      } else {
+        setError((e as Error).message);
+      }
       setState({ step: 'idle' });
     }
   }
@@ -205,6 +215,14 @@ export default function Dashboard() {
                   Walk through our step-by-step wizard and let AI handle the heavy lifting.
                 </p>
               </div>
+              {quotaBlock && (
+                <QuotaBlockPrompt
+                  metric={quotaBlock.metric}
+                  limit={quotaBlock.limit}
+                  usage={quotaBlock.usage}
+                  message={quotaBlock.message}
+                />
+              )}
               {error && <Toast variant="error">{error}</Toast>}
               <div className="flex gap-3">
                 <Button onClick={() => void startNewBlog()} size="md">


### PR DESCRIPTION
## Summary

- Add `assertWithinQuota` in `quota-enforcement.ts` — throws `402 QUOTA_EXCEEDED` with `{ metric, limit, usage }` when `used >= limit`; unlimited plans never block.
- Wire enforcement into blog create, AI check (after cache/rate-limit, not on cache hits), author profile create/clone, and reference URL add.
- Frontend: shared `QuotaApiError` parsing, `QuotaBlockPrompt` with link to `/plan`, and `quota_blocked` dev analytics on all four surfaces.

## Test plan

- [x] Backend unit tests (176 passing) — quota service + handler wiring
- [x] Frontend `tsc` + Vite build
- [ ] Manual: user at blog limit cannot start a new post; sees upgrade prompt → `/plan`
- [ ] Manual: AI check blocked at limit; cache hits still free
- [ ] Manual: profile create/clone blocked at limit
- [ ] Manual: reference add blocked at monthly extraction limit

## Glossary

| Term | Meaning |
|------|---------|
| **Quota metric** | One of `blogs`, `ai_checks`, `author_profiles`, `reference_extractions` |
| **assertWithinQuota** | Server helper that loads subscription usage and throws 402 when at/over limit |
| **QUOTA_EXCEEDED** | Typed API error code returned with HTTP 402 |
| **QuotaBlockPrompt** | UI component shown when a gated action hits the plan limit |

Closes #154

Made with [Cursor](https://cursor.com)